### PR TITLE
Allow to set linked platform & device label

### DIFF
--- a/cmd/wacli/main.go
+++ b/cmd/wacli/main.go
@@ -2,10 +2,40 @@ package main
 
 import (
 	"os"
+	"strings"
+
+	"go.mau.fi/whatsmeow/proto/waCompanionReg"
+	"go.mau.fi/whatsmeow/store"
+	"google.golang.org/protobuf/proto"
 )
 
 func main() {
+	applyDeviceLabel()
 	if err := execute(os.Args[1:]); err != nil {
 		os.Exit(1)
 	}
+}
+
+func applyDeviceLabel() {
+	label := strings.TrimSpace(os.Getenv("WACLI_DEVICE_LABEL"))
+	platform := parsePlatformType(os.Getenv("WACLI_DEVICE_PLATFORM"))
+	store.DeviceProps.PlatformType = platform.Enum()
+	if label == "" {
+		return
+	}
+	store.SetOSInfo(label, [3]uint32{0, 1, 0})
+	store.BaseClientPayload.UserAgent.Device = proto.String(label)
+	store.BaseClientPayload.UserAgent.Manufacturer = proto.String(label)
+}
+
+func parsePlatformType(raw string) waCompanionReg.DeviceProps_PlatformType {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return waCompanionReg.DeviceProps_CHROME
+	}
+	value = strings.ToUpper(value)
+	if enumValue, ok := waCompanionReg.DeviceProps_PlatformType_value[value]; ok {
+		return waCompanionReg.DeviceProps_PlatformType(enumValue)
+	}
+	return waCompanionReg.DeviceProps_CHROME
 }


### PR DESCRIPTION
Couldn't find an existing way to set the label on the WA linked device (although clawdbot does it somehow?)

<img width="200" alt="image" src="https://github.com/user-attachments/assets/9afcbf8d-35df-4773-b129-2ef3ec0da17b" />

in case it is actually missing, here it is

## Summary
- set WhatsApp companion device label from `WACLI_DEVICE_LABEL` (defaults to "lenses")
- apply label to OS info and user agent fields

- allow overriding device platform via  (validated, defaults to CHROME)
- allow overriding device platform via `WACLI_DEVICE_PLATFORM` (validated, defaults to CHROME)
## Testing
- not run (not requested)
