### PR TITLE
Add display text for reactions, replies, media types

### DIFF
--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -88,9 +89,12 @@ func newMessagesListCmd(flags *rootFlags) *cobra.Command {
 				if chatLabel == "" {
 					chatLabel = m.ChatJID
 				}
-				text := m.Text
+				text := strings.TrimSpace(m.DisplayText)
+				if text == "" {
+					text = strings.TrimSpace(m.Text)
+				}
 				if m.MediaType != "" && text == "" {
-					text = "[" + m.MediaType + "]"
+					text = "Sent " + m.MediaType
 				}
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 					m.Timestamp.Local().Format("2006-01-02 15:04:05"),
@@ -183,6 +187,9 @@ func newMessagesSearchCmd(flags *rootFlags) *cobra.Command {
 					chatLabel = m.ChatJID
 				}
 				match := m.Snippet
+				if match == "" {
+					match = strings.TrimSpace(m.DisplayText)
+				}
 				if match == "" {
 					match = m.Text
 				}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -12,6 +12,7 @@ import (
 	"go.mau.fi/whatsmeow"
 	waProto "go.mau.fi/whatsmeow/binary/proto"
 	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
 )
 
 type WAClient interface {
@@ -41,6 +42,7 @@ type WAClient interface {
 	Upload(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error)
 	DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error)
 
+	DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error)
 	RequestHistorySyncOnDemand(ctx context.Context, lastKnown types.MessageInfo, count int) (types.MessageID, error)
 	Logout(ctx context.Context) error
 }

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -216,6 +216,10 @@ func (f *fakeWA) Upload(ctx context.Context, data []byte, mediaType whatsmeow.Me
 	return whatsmeow.UploadResponse{}, nil
 }
 
+func (f *fakeWA) DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error) {
+	return nil, fmt.Errorf("not supported")
+}
+
 func (f *fakeWA) DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error) {
 	if err := os.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
 		return 0, err

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -85,6 +85,156 @@ func TestSyncStoresLiveAndHistoryMessages(t *testing.T) {
 	}
 }
 
+func TestSyncStoresDisplayText(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "123", Server: types.DefaultUserServer}
+	f.contacts[chat.ToNonAD()] = types.ContactInfo{
+		Found:     true,
+		FullName:  "Alice",
+		FirstName: "Alice",
+		PushName:  "Alice",
+	}
+
+	base := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	textMsg := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     chat,
+				Sender:   chat,
+				IsFromMe: false,
+				IsGroup:  false,
+			},
+			ID:        "m-text",
+			Timestamp: base.Add(1 * time.Second),
+			PushName:  "Alice",
+		},
+		Message: &waProto.Message{Conversation: proto.String("hello")},
+	}
+
+	imageMsg := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     chat,
+				Sender:   chat,
+				IsFromMe: false,
+				IsGroup:  false,
+			},
+			ID:        "m-image",
+			Timestamp: base.Add(2 * time.Second),
+			PushName:  "Alice",
+		},
+		Message: &waProto.Message{
+			ImageMessage: &waProto.ImageMessage{
+				Mimetype:      proto.String("image/jpeg"),
+				DirectPath:    proto.String("/direct"),
+				MediaKey:      []byte{1},
+				FileSHA256:    []byte{2},
+				FileEncSHA256: []byte{3},
+				FileLength:    proto.Uint64(10),
+			},
+		},
+	}
+
+	replyMsg := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     chat,
+				Sender:   chat,
+				IsFromMe: false,
+				IsGroup:  false,
+			},
+			ID:        "m-reply",
+			Timestamp: base.Add(3 * time.Second),
+			PushName:  "Alice",
+		},
+		Message: &waProto.Message{
+			ExtendedTextMessage: &waProto.ExtendedTextMessage{
+				Text: proto.String("reply text"),
+				ContextInfo: &waProto.ContextInfo{
+					StanzaID: proto.String("m-text"),
+					QuotedMessage: &waProto.Message{
+						Conversation: proto.String("quoted text"),
+					},
+				},
+			},
+		},
+	}
+
+	reactionMsg := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     chat,
+				Sender:   chat,
+				IsFromMe: false,
+				IsGroup:  false,
+			},
+			ID:        "m-react",
+			Timestamp: base.Add(4 * time.Second),
+			PushName:  "Alice",
+		},
+		Message: &waProto.Message{
+			ReactionMessage: &waProto.ReactionMessage{
+				Text: proto.String("👍"),
+				Key:  &waProto.MessageKey{ID: proto.String("m-text")},
+			},
+		},
+	}
+
+	f.connectEvents = []interface{}{textMsg, imageMsg, replyMsg, reactionMsg}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	res, err := a.Sync(ctx, SyncOptions{
+		Mode:    SyncModeFollow,
+		AllowQR: false,
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.MessagesStored != 4 {
+		t.Fatalf("expected 4 MessagesStored, got %d", res.MessagesStored)
+	}
+
+	msg, err := a.db.GetMessage(chat.String(), "m-text")
+	if err != nil {
+		t.Fatalf("GetMessage text: %v", err)
+	}
+	if msg.DisplayText != "hello" {
+		t.Fatalf("expected display text 'hello', got %q", msg.DisplayText)
+	}
+
+	msg, err = a.db.GetMessage(chat.String(), "m-image")
+	if err != nil {
+		t.Fatalf("GetMessage image: %v", err)
+	}
+	if msg.DisplayText != "Sent image" {
+		t.Fatalf("expected display text 'Sent image', got %q", msg.DisplayText)
+	}
+
+	msg, err = a.db.GetMessage(chat.String(), "m-reply")
+	if err != nil {
+		t.Fatalf("GetMessage reply: %v", err)
+	}
+	if msg.DisplayText != "> quoted text\nreply text" {
+		t.Fatalf("unexpected reply display text: %q", msg.DisplayText)
+	}
+
+	msg, err = a.db.GetMessage(chat.String(), "m-react")
+	if err != nil {
+		t.Fatalf("GetMessage react: %v", err)
+	}
+	if msg.DisplayText != "Reacted 👍 to hello" {
+		t.Fatalf("unexpected reaction display text: %q", msg.DisplayText)
+	}
+}
+
 func TestSyncOnceIdleExit(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/store/schema_test.go
+++ b/internal/store/schema_test.go
@@ -25,6 +25,7 @@ func TestOpenCreatesExpectedSchema(t *testing.T) {
 	for _, want := range []string{
 		"chat_name",
 		"sender_name",
+		"display_text",
 		"local_path",
 		"downloaded_at",
 	} {

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -14,6 +14,7 @@ import (
 	waProto "go.mau.fi/whatsmeow/binary/proto"
 	"go.mau.fi/whatsmeow/store/sqlstore"
 	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
 	waLog "go.mau.fi/whatsmeow/util/log"
 )
 
@@ -204,6 +205,16 @@ func (c *Client) Upload(ctx context.Context, data []byte, mediaType whatsmeow.Me
 		return whatsmeow.UploadResponse{}, fmt.Errorf("not connected")
 	}
 	return cli.Upload(ctx, data, mediaType)
+}
+
+func (c *Client) DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return nil, fmt.Errorf("not connected")
+	}
+	return cli.DecryptReaction(ctx, reaction)
 }
 
 func (c *Client) RequestHistorySyncOnDemand(ctx context.Context, lastKnown types.MessageInfo, count int) (types.MessageID, error) {


### PR DESCRIPTION
## Summary
- Store display_text on messages and include it in FTS/triggers with migration/backfill.
- Parse reaction/reply metadata and compute display text for reactions, replies, and media.
- Add tests covering parsing and sync display-text generation.

## Display text examples
| type | example |
| :- | :- |
| Text | `hello` |
| Media | `Sent image` / `Sent gif` / `Sent video` / `Sent audio` / `Sent sticker` / `Sent document` |
|  Reply | `> quoted text` <br/> `reply text` |
| Reaction | `Reacted 👍 to hello` |

## Testing
- go test ./...
- go test -tags sqlite_fts5 ./...