### PR TITLE
fix: add CGO_CFLAGS for GCC 15+ compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "packageManager": "pnpm@10.23.0",
   "scripts": {
     "wacli": "bash -lc 'pnpm -s build >/dev/null && exec ./dist/wacli \"$@\"' _",
-    "build": "mkdir -p dist && go build -tags sqlite_fts5 -o dist/wacli ./cmd/wacli",
+    "build": "mkdir -p dist && CGO_CFLAGS='-Wno-error=missing-braces' go build -tags sqlite_fts5 -o dist/wacli ./cmd/wacli",
     "start": "pnpm -s build && ./dist/wacli",
     "test": "pnpm -s test:go && pnpm -s test:fts",
     "test:go": "go test ./...",


### PR DESCRIPTION
## Summary

- Add `CGO_CFLAGS='-Wno-error=missing-braces'` to the build script in `package.json`

## Problem

GCC 15+ with glibc 2.42+ treats pthread initializer patterns in Go's `runtime/cgo` as errors due to stricter `-Werror` + brace checking. This causes build failures on modern Linux distros like CachyOS, Fedora 42+, and Arch Linux.

Build error:
```
# runtime/cgo
gcc_libinit.c:23:1: error: braces around scalar initializer [-Werror]
   23 | static pthread_cond_t runtime_init_cond = PTHREAD_COND_INITIALIZER;
      | ^~~~~~
cc1: all warnings being treated as errors
```

## Solution

Add `-Wno-error=missing-braces` to `CGO_CFLAGS` to allow builds on modern toolchains while preserving other warning-as-error checks.

## Testing

Verified build succeeds on CachyOS with GCC 15.2.1 and glibc 2.42.

🤖 *This PR was generated with AI assistance using Claude Opus 4.5 (GitHub Copilot).*