### PR TITLE
feat(send): add --reply-to support for quoted replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ pnpm wacli history backfill --chat 1234567890@s.whatsapp.net --requests 10 --cou
 # Send a message
 pnpm wacli send text --to 1234567890 --message "hello"
 
+# Reply to a message (quoted reply)
+# Note: for group replies, wacli needs the original sender JID (participant).
+# Make sure the message exists in your local DB (run `wacli sync --follow` or `wacli history backfill`).
+pnpm wacli send text --to 120363000000000000@g.us --reply-to <message-id> --message "replying 👋"
+
 # Send a file
 ./wacli send file --to 1234567890 --file ./pic.jpg --caption "hi"
 # Or override display name

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -2,14 +2,18 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/steipete/wacli/internal/out"
 	"github.com/steipete/wacli/internal/store"
 	"github.com/steipete/wacli/internal/wa"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/types"
 )
 
 func newSendCmd(flags *rootFlags) *cobra.Command {
@@ -25,6 +29,8 @@ func newSendCmd(flags *rootFlags) *cobra.Command {
 func newSendTextCmd(flags *rootFlags) *cobra.Command {
 	var to string
 	var message string
+	var replyTo string
+	var replyChat string
 
 	cmd := &cobra.Command{
 		Use:   "text",
@@ -55,9 +61,52 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			msgID, err := a.WA().SendText(ctx, toJID, message)
-			if err != nil {
-				return err
+			var msgID types.MessageID
+			if strings.TrimSpace(replyTo) != "" {
+				// Build a quoted reply (reply-to). We fetch the quoted message from the local DB.
+				chatJID := toJID.String()
+				if strings.TrimSpace(replyChat) != "" {
+					cj, err := wa.ParseUserOrJID(replyChat)
+					if err != nil {
+						return fmt.Errorf("invalid --reply-chat: %w", err)
+					}
+					chatJID = cj.String()
+				}
+
+				qm, err := a.DB().GetMessage(chatJID, replyTo)
+				if err != nil {
+					if err == sql.ErrNoRows {
+						return fmt.Errorf("reply-to message not found in local DB (chat=%s id=%s). Run `wacli sync --follow` or `wacli history backfill --chat %s` and try again", chatJID, replyTo, chatJID)
+					}
+					return err
+				}
+
+				// Participant is required for group replies (sender of quoted message).
+				var participant *types.JID
+				if wa.IsGroupJID(toJID) && strings.TrimSpace(qm.SenderJID) != "" {
+					pj, err := types.ParseJID(qm.SenderJID)
+					if err == nil {
+						participant = &pj
+					}
+				}
+
+				quotedText := strings.TrimSpace(qm.Text)
+				if quotedText == "" {
+					quotedText = strings.TrimSpace(qm.DisplayText)
+				}
+				quotedMsg := &waProto.Message{Conversation: &quotedText}
+
+				id, err := a.WA().SendTextReply(ctx, toJID, message, replyTo, participant, quotedMsg)
+				if err != nil {
+					return err
+				}
+				msgID = id
+			} else {
+				id, err := a.WA().SendText(ctx, toJID, message)
+				if err != nil {
+					return err
+				}
+				msgID = id
 			}
 
 			now := time.Now().UTC()
@@ -90,5 +139,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 
 	cmd.Flags().StringVar(&to, "to", "", "recipient phone number or JID")
 	cmd.Flags().StringVar(&message, "message", "", "message text")
+	cmd.Flags().StringVar(&replyTo, "reply-to", "", "message id to reply to (stanza id)")
+	cmd.Flags().StringVar(&replyChat, "reply-chat", "", "chat JID/number where the reply-to message lives (defaults to --to)")
 	return cmd
 }

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -83,11 +83,15 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 
 				// Participant is required for group replies (sender of quoted message).
 				var participant *types.JID
-				if wa.IsGroupJID(toJID) && strings.TrimSpace(qm.SenderJID) != "" {
-					pj, err := types.ParseJID(qm.SenderJID)
-					if err == nil {
-						participant = &pj
+				if wa.IsGroupJID(toJID) {
+					if strings.TrimSpace(qm.SenderJID) == "" {
+						return fmt.Errorf("reply-to in groups requires sender JID in local DB (missing SenderJID). Run `wacli sync --follow` or history backfill for %s", chatJID)
 					}
+					pj, err := types.ParseJID(qm.SenderJID)
+					if err != nil {
+						return fmt.Errorf("reply-to in groups requires a valid sender JID; got %q (parse error: %v)", qm.SenderJID, err)
+					}
+					participant = &pj
 				}
 
 				quotedText := strings.TrimSpace(qm.Text)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -38,6 +38,7 @@ type WAClient interface {
 	LeaveGroup(ctx context.Context, group types.JID) error
 
 	SendText(ctx context.Context, to types.JID, text string) (types.MessageID, error)
+	SendTextReply(ctx context.Context, to types.JID, text string, replyToID string, participantJID *types.JID, quoted *waProto.Message) (types.MessageID, error)
 	SendProtoMessage(ctx context.Context, to types.JID, msg *waProto.Message) (types.MessageID, error)
 	Upload(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error)
 	DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error)

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -208,6 +208,10 @@ func (f *fakeWA) SendText(ctx context.Context, to types.JID, text string) (types
 	return types.MessageID("msgid"), nil
 }
 
+func (f *fakeWA) SendTextReply(ctx context.Context, to types.JID, text string, replyToID string, participantJID *types.JID, quoted *waProto.Message) (types.MessageID, error) {
+	return types.MessageID("msgid"), nil
+}
+
 func (f *fakeWA) SendProtoMessage(ctx context.Context, to types.JID, msg *waProto.Message) (types.MessageID, error) {
 	return types.MessageID("msgid"), nil
 }

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -203,6 +203,12 @@ func (c *Client) SendTextReply(ctx context.Context, to types.JID, text string, r
 	if strings.TrimSpace(replyToID) == "" {
 		return "", fmt.Errorf("replyToID is required")
 	}
+	// In groups, WhatsApp requires the quoted message sender (participant) to avoid "replying to you" bugs.
+	if to.Server == types.GroupServer {
+		if participantJID == nil || participantJID.IsEmpty() {
+			return "", fmt.Errorf("participantJID is required for group replies")
+		}
+	}
 
 	ctxInfo := &waProto.ContextInfo{StanzaID: strPtr(replyToID)}
 	if participantJID != nil && !participantJID.IsEmpty() {

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -183,6 +183,43 @@ func (c *Client) SendText(ctx context.Context, to types.JID, text string) (types
 	return resp.ID, nil
 }
 
+func strPtr(s string) *string {
+	return &s
+}
+
+// SendTextReply sends a quoted-reply to an existing message.
+//
+// Notes:
+// - replyToID must be the stanza/message id of the message being replied to.
+// - participantJID is required for group replies (sender of the quoted message).
+// - quoted is optional but recommended; WhatsApp clients display a better quote when present.
+func (c *Client) SendTextReply(ctx context.Context, to types.JID, text string, replyToID string, participantJID *types.JID, quoted *waProto.Message) (types.MessageID, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return "", fmt.Errorf("not connected")
+	}
+	if strings.TrimSpace(replyToID) == "" {
+		return "", fmt.Errorf("replyToID is required")
+	}
+
+	ctxInfo := &waProto.ContextInfo{StanzaID: strPtr(replyToID)}
+	if participantJID != nil && !participantJID.IsEmpty() {
+		ctxInfo.Participant = strPtr(participantJID.String())
+	}
+	if quoted != nil {
+		ctxInfo.QuotedMessage = quoted
+	}
+
+	msg := &waProto.Message{ExtendedTextMessage: &waProto.ExtendedTextMessage{Text: strPtr(text), ContextInfo: ctxInfo}}
+	resp, err := cli.SendMessage(ctx, to, msg)
+	if err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
 func (c *Client) SendProtoMessage(ctx context.Context, to types.JID, msg *waProto.Message) (types.MessageID, error) {
 	c.mu.Lock()
 	cli := c.client


### PR DESCRIPTION
Adds quoted reply support for text sends.

New flags:
- --reply-to <msgId> (stanza id)
- --reply-chat <jid> (optional; defaults to --to)

Implementation:
- Adds wa.Client.SendTextReply using ContextInfo (StanzaID, Participant, QuotedMessage)
- Extends app.WAClient interface
- Updates send text command to build quoted message from local DB

Notes:
- For group replies, participant is derived from the quoted message sender when available.
- If the reply-to message is not in the local DB, the command suggests running sync/backfill.

Tests: go test ./...