### PR TITLE
feat: show full message IDs when piped or with --full flag

### DIFF
--- a/cmd/wacli/helpers.go
+++ b/cmd/wacli/helpers.go
@@ -27,9 +27,12 @@ func parseTime(s string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("unsupported time format %q (use RFC3339 or YYYY-MM-DD)", s)
 }
 
+func sanitize(s string) string {
+	return strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))
+}
+
 func truncate(s string, max int) string {
-	s = strings.ReplaceAll(s, "\n", " ")
-	s = strings.TrimSpace(s)
+	s = sanitize(s)
 	if max <= 0 || len(s) <= max {
 		return s
 	}
@@ -37,4 +40,13 @@ func truncate(s string, max int) string {
 		return s[:max]
 	}
 	return s[:max-1] + "…"
+}
+
+// truncateForDisplay truncates strings for tabular output.
+// When forceFull is true or stdout is not a TTY (piped), returns the full string.
+func truncateForDisplay(s string, max int, forceFull bool) string {
+	if forceFull || !isTTY() {
+		return sanitize(s)
+	}
+	return truncate(s, max)
 }

--- a/cmd/wacli/helpers_test.go
+++ b/cmd/wacli/helpers_test.go
@@ -1,0 +1,74 @@
+package main
+
+import "testing"
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		input string
+		max   int
+		want  string
+	}{
+		{"hello", 10, "hello"},
+		{"hello world", 5, "hell…"},
+		{"hello", 5, "hello"},
+		{"hello", 0, "hello"},
+		{"hello", -1, "hello"},
+		{"ab", 1, "a"},
+		{"hello\nworld", 20, "hello world"},
+		{"  hello  ", 20, "hello"},
+	}
+	for _, tc := range tests {
+		got := truncate(tc.input, tc.max)
+		if got != tc.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", tc.input, tc.max, got, tc.want)
+		}
+	}
+}
+
+func TestTruncateForDisplayForceFull(t *testing.T) {
+	long := "3EB0B0E8A1B2C3D4E5F6A7B8C9D0"
+
+	// with forceFull=true, should always return full string (after cleanup)
+	got := truncateForDisplay(long, 14, true)
+	if got != long {
+		t.Errorf("truncateForDisplay(%q, 14, true) = %q, want %q", long, got, long)
+	}
+
+	// newlines should still be replaced
+	got = truncateForDisplay("hello\nworld", 5, true)
+	if got != "hello world" {
+		t.Errorf("truncateForDisplay with newline: got %q, want %q", got, "hello world")
+	}
+}
+
+func TestParseTime(t *testing.T) {
+	// RFC3339
+	ts, err := parseTime("2025-01-27T10:30:00Z")
+	if err != nil {
+		t.Fatalf("parseTime RFC3339: %v", err)
+	}
+	if ts.Year() != 2025 || ts.Month() != 1 || ts.Day() != 27 {
+		t.Fatalf("unexpected parsed time: %v", ts)
+	}
+
+	// YYYY-MM-DD
+	ts, err = parseTime("2025-01-27")
+	if err != nil {
+		t.Fatalf("parseTime YYYY-MM-DD: %v", err)
+	}
+	if ts.Year() != 2025 || ts.Month() != 1 || ts.Day() != 27 {
+		t.Fatalf("unexpected parsed time: %v", ts)
+	}
+
+	// invalid
+	_, err = parseTime("not-a-date")
+	if err == nil {
+		t.Fatalf("expected error for invalid date")
+	}
+
+	// empty
+	_, err = parseTime("")
+	if err == nil {
+		t.Fatalf("expected error for empty date")
+	}
+}

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -100,7 +100,7 @@ func newMessagesListCmd(flags *rootFlags) *cobra.Command {
 					m.Timestamp.Local().Format("2006-01-02 15:04:05"),
 					truncate(chatLabel, 24),
 					truncate(from, 18),
-					truncate(m.MsgID, 14),
+					truncateForDisplay(m.MsgID, 14, flags.fullOutput),
 					truncate(text, 80),
 				)
 			}
@@ -197,7 +197,7 @@ func newMessagesSearchCmd(flags *rootFlags) *cobra.Command {
 					m.Timestamp.Local().Format("2006-01-02 15:04:05"),
 					truncate(chatLabel, 24),
 					truncate(fromLabel, 18),
-					truncate(m.MsgID, 14),
+					truncateForDisplay(m.MsgID, 14, flags.fullOutput),
 					truncate(match, 90),
 				)
 			}
@@ -318,7 +318,7 @@ func newMessagesContextCmd(flags *rootFlags) *cobra.Command {
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
 					m.Timestamp.Local().Format("2006-01-02 15:04:05"),
 					truncate(from, 18),
-					truncate(m.MsgID, 14),
+					truncateForDisplay(m.MsgID, 14, flags.fullOutput),
 					truncate(line, 100),
 				)
 			}

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -18,9 +18,10 @@ import (
 var version = "dev"
 
 type rootFlags struct {
-	storeDir string
-	asJSON   bool
-	timeout  time.Duration
+	storeDir   string
+	asJSON     bool
+	fullOutput bool
+	timeout    time.Duration
 }
 
 func execute(args []string) error {
@@ -36,6 +37,7 @@ func execute(args []string) error {
 
 	rootCmd.PersistentFlags().StringVar(&flags.storeDir, "store", "", "store directory (default: ~/.wacli)")
 	rootCmd.PersistentFlags().BoolVar(&flags.asJSON, "json", false, "output JSON instead of human-readable text")
+	rootCmd.PersistentFlags().BoolVar(&flags.fullOutput, "full", false, "disable truncation in table output")
 	rootCmd.PersistentFlags().DurationVar(&flags.timeout, "timeout", 5*time.Minute, "command timeout (non-sync commands)")
 
 	rootCmd.AddCommand(newVersionCmd())


### PR DESCRIPTION
Message IDs in tabular output (list/search/context) were truncated to 14 chars, making them unusable with `messages show --id` or `media download --id` without resorting to `--json | jq`.

Changes:
- Add `--full` flag to disable truncation in table output
- Auto-detect piped output and show full IDs (uses existing `isTTY()` helper)
- Add tests for helper functions

 - Closes the workflow gap where users couldn't copy IDs from list output.