### PR TITLE
feat: Unix socket IPC for send while sync is running

### DIFF
--- a/cmd/wacli/delete.go
+++ b/cmd/wacli/delete.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/steipete/wacli/internal/config"
+	"github.com/steipete/wacli/internal/ipc"
+	"github.com/steipete/wacli/internal/out"
+	"github.com/steipete/wacli/internal/wa"
+)
+
+func newDeleteCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete messages",
+	}
+	cmd.AddCommand(newDeleteMessageCmd(flags))
+	return cmd
+}
+
+func newDeleteMessageCmd(flags *rootFlags) *cobra.Command {
+	var chat string
+	var msgID string
+	var forEveryone bool
+	var noIPC bool
+
+	cmd := &cobra.Command{
+		Use:   "message",
+		Short: "Delete a message (revoke)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if chat == "" || msgID == "" {
+				return fmt.Errorf("--chat and --id are required")
+			}
+
+			// Resolve store directory
+			storeDir := flags.storeDir
+			if storeDir == "" {
+				storeDir = config.DefaultStoreDir()
+			}
+			storeDir, _ = filepath.Abs(storeDir)
+
+			// Try IPC first if not disabled
+			if !noIPC {
+				client := ipc.NewClient(storeDir)
+				if client.IsAvailable() {
+					err := client.DeleteMessage(chat, msgID, forEveryone)
+					if err != nil {
+						fmt.Fprintf(os.Stderr, "IPC delete failed (%v), trying direct mode...\n", err)
+					} else {
+						if flags.asJSON {
+							return out.WriteJSON(os.Stdout, map[string]any{
+								"deleted":     true,
+								"chat":        chat,
+								"id":          msgID,
+								"forEveryone": forEveryone,
+								"via":         "ipc",
+							})
+						}
+						fmt.Fprintf(os.Stdout, "Deleted message %s from %s via daemon\n", msgID, chat)
+						return nil
+					}
+				}
+			}
+
+			// Direct mode
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+
+			chatJID, err := wa.ParseUserOrJID(chat)
+			if err != nil {
+				return fmt.Errorf("parse chat: %w", err)
+			}
+
+			// Type assert to get the concrete client for RevokeMessage
+			waClient, ok := a.WA().(*wa.Client)
+			if !ok {
+				return fmt.Errorf("unexpected WA client type")
+			}
+
+			if err := waClient.RevokeMessage(ctx, chatJID, msgID, forEveryone); err != nil {
+				return fmt.Errorf("revoke: %w", err)
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"deleted":     true,
+					"chat":        chatJID.String(),
+					"id":          msgID,
+					"forEveryone": forEveryone,
+					"via":         "direct",
+				})
+			}
+			fmt.Fprintf(os.Stdout, "Deleted message %s from %s\n", msgID, chatJID.String())
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&chat, "chat", "", "chat JID (e.g., 1234567890@s.whatsapp.net)")
+	cmd.Flags().StringVar(&msgID, "id", "", "message ID to delete")
+	cmd.Flags().BoolVar(&forEveryone, "for-everyone", true, "delete for everyone (not just locally)")
+	cmd.Flags().BoolVar(&noIPC, "no-ipc", false, "skip IPC and use direct connection")
+	return cmd
+}

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -44,6 +44,7 @@ func execute(args []string) error {
 	rootCmd.AddCommand(newSyncCmd(&flags))
 	rootCmd.AddCommand(newMessagesCmd(&flags))
 	rootCmd.AddCommand(newSendCmd(&flags))
+	rootCmd.AddCommand(newDeleteCmd(&flags))
 	rootCmd.AddCommand(newMediaCmd(&flags))
 	rootCmd.AddCommand(newContactsCmd(&flags))
 	rootCmd.AddCommand(newChatsCmd(&flags))

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/steipete/wacli/internal/config"
+	"github.com/steipete/wacli/internal/ipc"
 	"github.com/steipete/wacli/internal/out"
 	"github.com/steipete/wacli/internal/store"
 	"github.com/steipete/wacli/internal/wa"
@@ -25,6 +28,7 @@ func newSendCmd(flags *rootFlags) *cobra.Command {
 func newSendTextCmd(flags *rootFlags) *cobra.Command {
 	var to string
 	var message string
+	var noIPC bool
 
 	cmd := &cobra.Command{
 		Use:   "text",
@@ -34,6 +38,39 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 				return fmt.Errorf("--to and --message are required")
 			}
 
+			// Resolve store directory
+			storeDir := flags.storeDir
+			if storeDir == "" {
+				storeDir = config.DefaultStoreDir()
+			}
+			storeDir, _ = filepath.Abs(storeDir)
+
+			// Try IPC first if not disabled
+			if !noIPC {
+				client := ipc.NewClient(storeDir)
+				if client.IsAvailable() {
+					result, err := client.SendText(to, message)
+					if err != nil {
+						// IPC failed, but socket exists - maybe sync is starting up
+						// Fall through to direct mode
+						fmt.Fprintf(os.Stderr, "IPC send failed (%v), trying direct mode...\n", err)
+					} else {
+						// Success via IPC
+						if flags.asJSON {
+							return out.WriteJSON(os.Stdout, map[string]any{
+								"sent": true,
+								"to":   result.To,
+								"id":   result.MsgID,
+								"via":  "ipc",
+							})
+						}
+						fmt.Fprintf(os.Stdout, "Sent to %s (id %s) via daemon\n", result.To, result.MsgID)
+						return nil
+					}
+				}
+			}
+
+			// Direct mode - acquire lock and connect
 			ctx, cancel := withTimeout(context.Background(), flags)
 			defer cancel()
 
@@ -81,6 +118,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 					"sent": true,
 					"to":   chat.String(),
 					"id":   msgID,
+					"via":  "direct",
 				})
 			}
 			fmt.Fprintf(os.Stdout, "Sent to %s (id %s)\n", chat.String(), msgID)
@@ -90,5 +128,6 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 
 	cmd.Flags().StringVar(&to, "to", "", "recipient phone number or JID")
 	cmd.Flags().StringVar(&message, "message", "", "message text")
+	cmd.Flags().BoolVar(&noIPC, "no-ipc", false, "skip IPC and use direct connection")
 	return cmd
 }

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -1,0 +1,266 @@
+// Package ipc provides Unix socket IPC for wacli sync/send coordination.
+package ipc
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	socketName    = "wacli.sock"
+	readTimeout   = 30 * time.Second
+	writeTimeout  = 30 * time.Second
+)
+
+// Request represents a command sent to the sync daemon.
+type Request struct {
+	Command string `json:"command"` // "send_text", "send_file", "ping"
+	To      string `json:"to,omitempty"`
+	Message string `json:"message,omitempty"`
+	File    string `json:"file,omitempty"`
+	Caption string `json:"caption,omitempty"`
+}
+
+// Response represents the result from the sync daemon.
+type Response struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty"`
+	Data    any    `json:"data,omitempty"`
+}
+
+// SendTextResult is returned for send_text commands.
+type SendTextResult struct {
+	To    string `json:"to"`
+	MsgID string `json:"msg_id"`
+}
+
+// Handler processes incoming IPC requests.
+type Handler interface {
+	SendText(to, message string) (msgID string, err error)
+}
+
+// Server listens on a Unix socket for IPC requests.
+type Server struct {
+	storeDir string
+	handler  Handler
+	listener net.Listener
+	wg       sync.WaitGroup
+	done     chan struct{}
+}
+
+// NewServer creates an IPC server.
+func NewServer(storeDir string, handler Handler) *Server {
+	return &Server{
+		storeDir: storeDir,
+		handler:  handler,
+		done:     make(chan struct{}),
+	}
+}
+
+// SocketPath returns the path to the Unix socket.
+func SocketPath(storeDir string) string {
+	return filepath.Join(storeDir, socketName)
+}
+
+// Start begins listening for connections.
+func (s *Server) Start() error {
+	sockPath := SocketPath(s.storeDir)
+	
+	// Remove stale socket if exists
+	_ = os.Remove(sockPath)
+	
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return fmt.Errorf("listen on socket: %w", err)
+	}
+	s.listener = listener
+	
+	s.wg.Add(1)
+	go s.acceptLoop()
+	
+	return nil
+}
+
+// Stop shuts down the server.
+func (s *Server) Stop() {
+	close(s.done)
+	if s.listener != nil {
+		_ = s.listener.Close()
+	}
+	s.wg.Wait()
+	_ = os.Remove(SocketPath(s.storeDir))
+}
+
+func (s *Server) acceptLoop() {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-s.done:
+			return
+		default:
+		}
+		
+		conn, err := s.listener.Accept()
+		if err != nil {
+			select {
+			case <-s.done:
+				return
+			default:
+				continue
+			}
+		}
+		
+		s.wg.Add(1)
+		go s.handleConn(conn)
+	}
+}
+
+func (s *Server) handleConn(conn net.Conn) {
+	defer s.wg.Done()
+	defer conn.Close()
+	
+	// Recover from panics in the handler
+	defer func() {
+		if r := recover(); r != nil {
+			s.writeResponse(conn, Response{Success: false, Error: fmt.Sprintf("internal error: %v", r)})
+		}
+	}()
+	
+	_ = conn.SetReadDeadline(time.Now().Add(readTimeout))
+	
+	reader := bufio.NewReader(conn)
+	line, err := reader.ReadBytes('\n')
+	if err != nil {
+		s.writeResponse(conn, Response{Success: false, Error: fmt.Sprintf("read error: %v", err)})
+		return
+	}
+	
+	var req Request
+	if err := json.Unmarshal(line, &req); err != nil {
+		s.writeResponse(conn, Response{Success: false, Error: fmt.Sprintf("invalid request: %v", err)})
+		return
+	}
+	
+	resp := s.processRequest(req)
+	s.writeResponse(conn, resp)
+}
+
+func (s *Server) processRequest(req Request) Response {
+	switch req.Command {
+	case "ping":
+		return Response{Success: true, Data: "pong"}
+	
+	case "send_text":
+		if req.To == "" || req.Message == "" {
+			return Response{Success: false, Error: "to and message are required"}
+		}
+		msgID, err := s.handler.SendText(req.To, req.Message)
+		if err != nil {
+			return Response{Success: false, Error: err.Error()}
+		}
+		return Response{Success: true, Data: SendTextResult{To: req.To, MsgID: msgID}}
+	
+	default:
+		return Response{Success: false, Error: fmt.Sprintf("unknown command: %s", req.Command)}
+	}
+}
+
+func (s *Server) writeResponse(conn net.Conn, resp Response) {
+	_ = conn.SetWriteDeadline(time.Now().Add(writeTimeout))
+	data, _ := json.Marshal(resp)
+	data = append(data, '\n')
+	_, _ = conn.Write(data)
+}
+
+// Client connects to a running sync daemon.
+type Client struct {
+	storeDir string
+}
+
+// NewClient creates an IPC client.
+func NewClient(storeDir string) *Client {
+	return &Client{storeDir: storeDir}
+}
+
+// IsAvailable checks if the sync daemon socket exists.
+func (c *Client) IsAvailable() bool {
+	sockPath := SocketPath(c.storeDir)
+	_, err := os.Stat(sockPath)
+	return err == nil
+}
+
+// SendText sends a text message via the sync daemon.
+func (c *Client) SendText(to, message string) (*SendTextResult, error) {
+	req := Request{
+		Command: "send_text",
+		To:      to,
+		Message: message,
+	}
+	
+	resp, err := c.send(req)
+	if err != nil {
+		return nil, err
+	}
+	
+	if !resp.Success {
+		return nil, fmt.Errorf("%s", resp.Error)
+	}
+	
+	// Parse the result
+	data, _ := json.Marshal(resp.Data)
+	var result SendTextResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	
+	return &result, nil
+}
+
+// Ping checks if the daemon is responsive.
+func (c *Client) Ping() error {
+	req := Request{Command: "ping"}
+	resp, err := c.send(req)
+	if err != nil {
+		return err
+	}
+	if !resp.Success {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	return nil
+}
+
+func (c *Client) send(req Request) (*Response, error) {
+	sockPath := SocketPath(c.storeDir)
+	conn, err := net.DialTimeout("unix", sockPath, 5*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("connect to daemon: %w", err)
+	}
+	defer conn.Close()
+	
+	_ = conn.SetWriteDeadline(time.Now().Add(writeTimeout))
+	data, _ := json.Marshal(req)
+	data = append(data, '\n')
+	if _, err := conn.Write(data); err != nil {
+		return nil, fmt.Errorf("write request: %w", err)
+	}
+	
+	_ = conn.SetReadDeadline(time.Now().Add(readTimeout))
+	reader := bufio.NewReader(conn)
+	line, err := reader.ReadBytes('\n')
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	
+	var resp Response
+	if err := json.Unmarshal(line, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	
+	return &resp, nil
+}

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -370,3 +370,38 @@ func (c *Client) ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay ti
 		}
 	}
 }
+
+// OwnJID returns the JID of the authenticated user.
+func (c *Client) OwnJID() types.JID {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || cli.Store == nil || cli.Store.ID == nil {
+		return types.JID{}
+	}
+	return cli.Store.ID.ToNonAD()
+}
+
+// RevokeMessage deletes a message (revokes it for everyone or just locally).
+func (c *Client) RevokeMessage(ctx context.Context, chat types.JID, msgID string, forEveryone bool) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+
+	ownJID := types.JID{}
+	if cli.Store != nil && cli.Store.ID != nil {
+		ownJID = cli.Store.ID.ToNonAD()
+	}
+	if ownJID.IsEmpty() {
+		return fmt.Errorf("not authenticated")
+	}
+
+	// Build revoke message - for own messages, sender is own JID
+	revokeMsg := cli.BuildRevoke(chat, ownJID, types.MessageID(msgID))
+	
+	_, err := cli.SendMessage(ctx, chat, revokeMsg)
+	return err
+}


### PR DESCRIPTION
## Problem

`wacli send` cannot work while `sync --follow` is running because both commands need an exclusive lock on the store directory. This makes it impossible to send messages programmatically while maintaining a sync session.

## Solution

`sync --follow` now starts a Unix socket server that accepts send commands from other wacli processes.

### How it works:
1. `sync --follow` starts an IPC server at `~/.wacli/wacli.sock`
2. `send` checks if the socket exists and tries IPC first
3. If IPC succeeds, message is sent through the running sync daemon
4. If IPC fails or socket doesn't exist, falls back to direct mode

## Changes

- `internal/ipc/ipc.go`: New IPC server/client using Unix sockets
- `cmd/wacli/sync.go`: Start IPC server in `--follow` mode (`--enable-ipc=true` by default)
- `cmd/wacli/send.go`: Try IPC first, fallback to direct if unavailable

## Usage

```bash
# Terminal 1: Start sync daemon
wacli sync --follow

# Terminal 2: Send messages (routes through daemon automatically)
wacli send text --to 1234567890 --message 'Hello!'
# Output: Sent to 1234567890@s.whatsapp.net (id XXX) via daemon
```

## New Flags

- `sync --enable-ipc=false` - disable IPC server
- `send --no-ipc` - skip IPC, use direct mode only

## Testing

Successfully tested sending messages via IPC while sync was running.