### PR TITLE
feat: add support for sending stickers

### DIFF
--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -19,6 +19,7 @@ func newSendCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.AddCommand(newSendTextCmd(flags))
 	cmd.AddCommand(newSendFileCmd(flags))
+	cmd.AddCommand(newSendStickerCmd(flags))
 	return cmd
 }
 

--- a/cmd/wacli/send_sticker.go
+++ b/cmd/wacli/send_sticker.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/steipete/wacli/internal/app"
+	"github.com/steipete/wacli/internal/store"
+	"github.com/steipete/wacli/internal/wa"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
+)
+
+func sendSticker(ctx context.Context, a interface {
+	WA() app.WAClient
+	DB() *store.DB
+}, to types.JID, filePath string) (string, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	// Validate file extension - stickers must be WebP
+	ext := strings.ToLower(filepath.Ext(filePath))
+	if ext != ".webp" {
+		return "", fmt.Errorf("stickers must be WebP files (got %s)", ext)
+	}
+
+	uploadType, _ := wa.MediaTypeFromString("sticker")
+	up, err := a.WA().Upload(ctx, data, uploadType)
+	if err != nil {
+		return "", err
+	}
+
+	msg := &waProto.Message{
+		StickerMessage: &waProto.StickerMessage{
+			URL:           proto.String(up.URL),
+			DirectPath:    proto.String(up.DirectPath),
+			MediaKey:      up.MediaKey,
+			FileEncSHA256: up.FileEncSHA256,
+			FileSHA256:    up.FileSHA256,
+			FileLength:    proto.Uint64(up.FileLength),
+			Mimetype:      proto.String("image/webp"),
+		},
+	}
+
+	id, err := a.WA().SendProtoMessage(ctx, to, msg)
+	if err != nil {
+		return "", err
+	}
+
+	now := time.Now().UTC()
+	chatName := a.WA().ResolveChatName(ctx, to, "")
+	kind := chatKindFromJID(to)
+	_ = a.DB().UpsertChat(to.String(), kind, chatName, now)
+	_ = a.DB().UpsertMessage(store.UpsertMessageParams{
+		ChatJID:       to.String(),
+		ChatName:      chatName,
+		MsgID:         id,
+		SenderJID:     "",
+		SenderName:    "me",
+		Timestamp:     now,
+		FromMe:        true,
+		Text:          "",
+		MediaType:     "sticker",
+		MimeType:      "image/webp",
+		DirectPath:    up.DirectPath,
+		MediaKey:      up.MediaKey,
+		FileSHA256:    up.FileSHA256,
+		FileEncSHA256: up.FileEncSHA256,
+		FileLength:    up.FileLength,
+	})
+
+	return id, nil
+}

--- a/cmd/wacli/send_sticker_cmd.go
+++ b/cmd/wacli/send_sticker_cmd.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/steipete/wacli/internal/out"
+	"github.com/steipete/wacli/internal/wa"
+)
+
+func newSendStickerCmd(flags *rootFlags) *cobra.Command {
+	var to string
+	var filePath string
+
+	cmd := &cobra.Command{
+		Use:   "sticker",
+		Short: "Send a sticker (WebP image)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if to == "" || filePath == "" {
+				return fmt.Errorf("--to and --file are required")
+			}
+
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+
+			toJID, err := wa.ParseUserOrJID(to)
+			if err != nil {
+				return err
+			}
+
+			msgID, err := sendSticker(ctx, a, toJID, filePath)
+			if err != nil {
+				return err
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"sent": true,
+					"to":   toJID.String(),
+					"id":   msgID,
+					"type": "sticker",
+				})
+			}
+			fmt.Fprintf(os.Stdout, "Sent sticker to %s (id %s)\n", toJID.String(), msgID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&to, "to", "", "recipient phone number or JID")
+	cmd.Flags().StringVar(&filePath, "file", "", "path to WebP sticker file")
+	return cmd
+}


### PR DESCRIPTION
Add `wacli send sticker` command that allows sending WebP stickers.
Usage: wacli send sticker --to <JID> --file <path-to-webp>