### PR TITLE
fix: normalize JIDs to non-AD form before storage

### DIFF
--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -224,7 +224,7 @@ func chatKind(chat types.JID) string {
 }
 
 func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error {
-	chatJID := pm.Chat.String()
+	chatJID := pm.Chat.ToNonAD().String()
 	chatName := a.wa.ResolveChatName(ctx, pm.Chat, pm.PushName)
 	if err := a.db.UpsertChat(chatJID, chatKind(pm.Chat), chatName, pm.Timestamp); err != nil {
 		return err
@@ -232,10 +232,11 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 
 	// Best-effort: store contact info for DMs.
 	if pm.Chat.Server == types.DefaultUserServer {
-		if info, err := a.wa.GetContact(ctx, pm.Chat.ToNonAD()); err == nil {
+		normalizedChat := pm.Chat.ToNonAD()
+		if info, err := a.wa.GetContact(ctx, normalizedChat); err == nil {
 			_ = a.db.UpsertContact(
-				pm.Chat.String(),
-				pm.Chat.User,
+				normalizedChat.String(),
+				normalizedChat.User,
 				info.PushName,
 				info.FullName,
 				info.FirstName,
@@ -245,6 +246,7 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 	}
 
 	senderName := ""
+	senderJID := ""
 	if pm.FromMe {
 		senderName = "me"
 	} else if s := strings.TrimSpace(pm.PushName); s != "" && s != "-" {
@@ -252,13 +254,15 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 	}
 	if pm.SenderJID != "" {
 		if jid, err := types.ParseJID(pm.SenderJID); err == nil {
-			if info, err := a.wa.GetContact(ctx, jid.ToNonAD()); err == nil {
+			normalizedJID := jid.ToNonAD()
+			senderJID = normalizedJID.String()
+			if info, err := a.wa.GetContact(ctx, normalizedJID); err == nil {
 				if name := wa.BestContactName(info); name != "" {
 					senderName = name
 				}
 				_ = a.db.UpsertContact(
-					jid.String(),
-					jid.User,
+					normalizedJID.String(),
+					normalizedJID.User,
 					info.PushName,
 					info.FullName,
 					info.FirstName,
@@ -271,7 +275,8 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 	// Best-effort: store group metadata (and participants) when available.
 	if pm.Chat.Server == types.GroupServer {
 		if gi, err := a.wa.GetGroupInfo(ctx, pm.Chat); err == nil && gi != nil {
-			_ = a.db.UpsertGroup(gi.JID.String(), gi.GroupName.Name, gi.OwnerJID.String(), gi.GroupCreated)
+			normalizedChat := pm.Chat.ToNonAD()
+			_ = a.db.UpsertGroup(normalizedChat.String(), gi.GroupName.Name, gi.OwnerJID.String(), gi.GroupCreated)
 			var ps []store.GroupParticipant
 			for _, p := range gi.Participants {
 				role := "member"
@@ -281,12 +286,12 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 					role = "admin"
 				}
 				ps = append(ps, store.GroupParticipant{
-					GroupJID: pm.Chat.String(),
-					UserJID:  p.JID.String(),
+					GroupJID: normalizedChat.String(),
+					UserJID:  p.JID.ToNonAD().String(),
 					Role:     role,
 				})
 			}
-			_ = a.db.ReplaceGroupParticipants(pm.Chat.String(), ps)
+			_ = a.db.ReplaceGroupParticipants(normalizedChat.String(), ps)
 		}
 	}
 
@@ -311,7 +316,7 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 		ChatJID:       chatJID,
 		ChatName:      chatName,
 		MsgID:         pm.ID,
-		SenderJID:     pm.SenderJID,
+		SenderJID:     senderJID,
 		SenderName:    senderName,
 		Timestamp:     pm.Timestamp,
 		FromMe:        pm.FromMe,


### PR DESCRIPTION
Fixes #31

## Problem
Messages for the same contact were being stored under different JIDs:
- @lid or AD JIDs (with agent/device fields) for linked devices
- @s.whatsapp.net for regular users

This caused message history to be split across multiple JID entries for the same contact.

## Solution
Normalize all JIDs to their non-AD form before storage using the ToNonAD() method.

### Changes
- Normalize chat JID before storing messages
- Normalize sender JID before storing messages  
- Normalize chat JID when storing contacts
- Normalize group JID and participant JIDs

### Implementation
All JIDs are now converted using jid.ToNonAD() before being stored in the database. This ensures:
1. Messages from linked devices and primary device are stored under the same JID
2. Contact info is consistently stored
3. Group participants are correctly tracked

The ToNonAD() method from whatsmeow removes the agent and device components from AD-JIDs, converting them to regular user@server format.

## Testing
- All existing tests pass
- Binary builds successfully
