### PR TITLE
feat: import system contacts with proper precedence

### DIFF
--- a/cmd/wacli/contacts.go
+++ b/cmd/wacli/contacts.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	"github.com/steipete/wacli/internal/contacts"
 	"github.com/steipete/wacli/internal/out"
 )
 
@@ -19,6 +20,7 @@ func newContactsCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newContactsSearchCmd(flags))
 	cmd.AddCommand(newContactsShowCmd(flags))
 	cmd.AddCommand(newContactsRefreshCmd(flags))
+	cmd.AddCommand(newContactsImportSystemCmd(flags))
 	cmd.AddCommand(newContactsAliasCmd(flags))
 	cmd.AddCommand(newContactsTagsCmd(flags))
 	return cmd
@@ -104,6 +106,9 @@ func newContactsShowCmd(flags *rootFlags) *cobra.Command {
 			if c.Alias != "" {
 				fmt.Fprintf(os.Stdout, "Alias: %s\n", c.Alias)
 			}
+			if c.SystemName != "" {
+				fmt.Fprintf(os.Stdout, "System Name: %s\n", c.SystemName)
+			}
 			if len(c.Tags) > 0 {
 				fmt.Fprintf(os.Stdout, "Tags: %s\n", strings.Join(c.Tags, ", "))
 			}
@@ -156,6 +161,187 @@ func newContactsRefreshCmd(flags *rootFlags) *cobra.Command {
 			return nil
 		},
 	}
+	return cmd
+}
+
+func newContactsImportSystemCmd(flags *rootFlags) *cobra.Command {
+	var dryRun bool
+	var clear bool
+	cmd := &cobra.Command{
+		Use:   "import-system",
+		Short: "Import names from macOS Contacts (matches by phone number)",
+		Long: `Imports contacts from macOS Contacts.app and sets them as system names in wacli.
+
+This command:
+1. Reads all contacts with phone numbers from macOS Contacts.app
+2. Matches them against existing wacli contacts by phone number
+3. Sets the system contact name (displayed with precedence over WhatsApp names)
+
+Display name precedence:
+  1. Manual alias (user override - highest priority)
+  2. System contact name (from this import)
+  3. WhatsApp names (push_name, full_name, etc.)
+  4. Phone number (fallback)
+
+This mirrors how the native WhatsApp app displays contacts.
+
+Run 'wacli contacts refresh' first to ensure contacts are synced from WhatsApp.
+
+Note: Only supported on macOS.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			// Open DB
+			a, lk, err := newApp(ctx, flags, false, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			// Handle --clear flag
+			if clear {
+				if dryRun {
+					count, err := a.DB().CountSystemNames()
+					if err != nil {
+						return fmt.Errorf("count system names: %w", err)
+					}
+					if flags.asJSON {
+						return out.WriteJSON(os.Stdout, map[string]any{
+							"action":  "clear",
+							"count":   count,
+							"dryRun":  true,
+						})
+					}
+					fmt.Fprintf(os.Stdout, "[DRY RUN] Would clear %d system names.\n", count)
+					return nil
+				}
+				count, err := a.DB().ClearAllSystemNames()
+				if err != nil {
+					return fmt.Errorf("clear system names: %w", err)
+				}
+				if flags.asJSON {
+					return out.WriteJSON(os.Stdout, map[string]any{
+						"action":  "clear",
+						"cleared": count,
+					})
+				}
+				fmt.Fprintf(os.Stdout, "Cleared %d system names.\n", count)
+				return nil
+			}
+
+			// Fetch system contacts
+			fmt.Fprintln(os.Stderr, "Reading macOS Contacts...")
+			systemContacts, err := contacts.GetSystemContacts()
+			if err != nil {
+				return fmt.Errorf("failed to read system contacts: %w", err)
+			}
+			fmt.Fprintf(os.Stderr, "Found %d contacts with phone numbers\n", len(systemContacts))
+
+			// Build phone-to-name map
+			phoneToName := contacts.BuildPhoneToNameMap(systemContacts)
+			fmt.Fprintf(os.Stderr, "Built lookup map with %d unique phone numbers\n", len(phoneToName))
+
+			// Get all contacts from wacli DB
+			allContacts, err := a.DB().SearchContacts("%", 100000)
+			if err != nil {
+				return fmt.Errorf("failed to list contacts: %w", err)
+			}
+			fmt.Fprintf(os.Stderr, "Checking %d wacli contacts...\n", len(allContacts))
+
+			type match struct {
+				JID            string `json:"jid"`
+				Phone          string `json:"phone"`
+				CurrentName    string `json:"currentName"`
+				NewSystemName  string `json:"newSystemName"`
+				HadSystemName  bool   `json:"hadSystemName"`
+			}
+			var matches []match
+			var skippedSameName int
+			var skippedNoMatch int
+
+			for _, c := range allContacts {
+				// Normalize the phone from wacli contact
+				normalizedPhone := contacts.NormalizePhone(c.Phone)
+				if normalizedPhone == "" {
+					skippedNoMatch++
+					continue
+				}
+
+				// Try to find a match in system contacts
+				systemName, found := phoneToName[normalizedPhone]
+				if !found {
+					skippedNoMatch++
+					continue
+				}
+
+				// Skip if system name is already the same
+				if c.SystemName == systemName {
+					skippedSameName++
+					continue
+				}
+
+				matches = append(matches, match{
+					JID:           c.JID,
+					Phone:         c.Phone,
+					CurrentName:   c.Name,
+					NewSystemName: systemName,
+					HadSystemName: c.SystemName != "",
+				})
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"matches":         matches,
+					"skippedSameName": skippedSameName,
+					"skippedNoMatch":  skippedNoMatch,
+					"dryRun":          dryRun,
+				})
+			}
+
+			fmt.Fprintf(os.Stderr, "\nResults:\n")
+			fmt.Fprintf(os.Stderr, "  Matched: %d\n", len(matches))
+			fmt.Fprintf(os.Stderr, "  Skipped (same name): %d\n", skippedSameName)
+			fmt.Fprintf(os.Stderr, "  Skipped (no phone match): %d\n", skippedNoMatch)
+
+			if len(matches) == 0 {
+				fmt.Fprintln(os.Stdout, "\nNo new matches to import.")
+				return nil
+			}
+
+			if dryRun {
+				fmt.Fprintln(os.Stdout, "\n[DRY RUN] Would set these system names:")
+				w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+				fmt.Fprintln(w, "PHONE\tCURRENT\tSYSTEM NAME")
+				for _, m := range matches {
+					fmt.Fprintf(w, "%s\t%s\t%s\n",
+						truncate(m.Phone, 16),
+						truncate(m.CurrentName, 20),
+						truncate(m.NewSystemName, 24),
+					)
+				}
+				_ = w.Flush()
+				fmt.Fprintln(os.Stdout, "\nRun without --dry-run to apply.")
+				return nil
+			}
+
+			// Apply system names
+			fmt.Fprintln(os.Stdout, "\nSetting system names...")
+			var applied int
+			for _, m := range matches {
+				if err := a.DB().SetSystemName(m.JID, m.NewSystemName); err != nil {
+					fmt.Fprintf(os.Stderr, "  Failed to set system name for %s: %v\n", m.JID, err)
+					continue
+				}
+				applied++
+			}
+			fmt.Fprintf(os.Stdout, "Applied %d system names.\n", applied)
+
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be imported without making changes")
+	cmd.Flags().BoolVar(&clear, "clear", false, "remove all imported system names")
 	return cmd
 }
 

--- a/internal/contacts/contacts_test.go
+++ b/internal/contacts/contacts_test.go
@@ -1,0 +1,70 @@
+package contacts
+
+import (
+	"testing"
+)
+
+func TestNormalizePhone(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"+14157347847", "14157347847"},
+		{"+43 664 104 2436", "436641042436"},
+		{"+1 (415) 734-7847", "14157347847"},
+		{"14157347847", "14157347847"},
+		{"00436641042436", "436641042436"}, // international format with 00
+		{"+1-415-734-7847", "14157347847"},
+		{"", ""},
+		{"+", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := NormalizePhone(tt.input)
+			if got != tt.expected {
+				t.Errorf("NormalizePhone(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSystemContactName(t *testing.T) {
+	tests := []struct {
+		contact  SystemContact
+		expected string
+	}{
+		{SystemContact{FirstName: "John", LastName: "Doe"}, "John Doe"},
+		{SystemContact{FirstName: "John", LastName: ""}, "John"},
+		{SystemContact{FirstName: "", LastName: "Doe"}, "Doe"},
+		{SystemContact{FirstName: "", LastName: "", FullName: "John Doe"}, "John Doe"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			got := tt.contact.Name()
+			if got != tt.expected {
+				t.Errorf("Name() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildPhoneToNameMap(t *testing.T) {
+	contacts := []SystemContact{
+		{FirstName: "John", LastName: "Doe", FullName: "John Doe", Phones: []string{"+1 (415) 734-7847"}},
+		{FirstName: "Jane", LastName: "Smith", FullName: "Jane Smith", Phones: []string{"+43 664 104 2436", "+43 664 999 8888"}},
+	}
+
+	m := BuildPhoneToNameMap(contacts)
+
+	if m["14157347847"] != "John Doe" {
+		t.Errorf("Expected John Doe for 14157347847, got %q", m["14157347847"])
+	}
+	if m["436641042436"] != "Jane Smith" {
+		t.Errorf("Expected Jane Smith for 436641042436, got %q", m["436641042436"])
+	}
+	if m["436649998888"] != "Jane Smith" {
+		t.Errorf("Expected Jane Smith for 436649998888, got %q", m["436649998888"])
+	}
+}

--- a/internal/contacts/darwin.go
+++ b/internal/contacts/darwin.go
@@ -1,0 +1,265 @@
+//go:build darwin
+
+package contacts
+
+import (
+	"bufio"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// SystemContact represents a contact from macOS Contacts.app
+type SystemContact struct {
+	FirstName string   `json:"firstName"`
+	LastName  string   `json:"lastName"`
+	FullName  string   `json:"fullName"`
+	Phones    []string `json:"phones"`
+}
+
+// Name returns the best display name for the contact
+func (c SystemContact) Name() string {
+	if c.FullName != "" {
+		return c.FullName
+	}
+	parts := []string{}
+	if c.FirstName != "" {
+		parts = append(parts, c.FirstName)
+	}
+	if c.LastName != "" {
+		parts = append(parts, c.LastName)
+	}
+	return strings.Join(parts, " ")
+}
+
+// GetSystemContacts fetches all contacts with phone numbers from macOS Contacts.app
+// Tries Swift helper first (proper API), falls back to direct SQLite (faster, no permissions)
+func GetSystemContacts() ([]SystemContact, error) {
+	// Try Swift helper first (uses CNContactStore - proper macOS API)
+	contacts, err := getContactsViaSwiftHelper()
+	if err == nil && len(contacts) > 0 {
+		return contacts, nil
+	}
+
+	// Fallback to direct SQLite access (works without permissions but uses private API)
+	return getContactsViaSQLite()
+}
+
+// getContactsViaSwiftHelper uses the contacts-export Swift tool
+func getContactsViaSwiftHelper() ([]SystemContact, error) {
+	// Find the helper binary (check common locations)
+	helperPaths := []string{
+		"contacts-export", // In PATH
+	}
+
+	// Check relative to executable
+	if exe, err := os.Executable(); err == nil {
+		dir := filepath.Dir(exe)
+		helperPaths = append(helperPaths,
+			filepath.Join(dir, "contacts-export"),
+			filepath.Join(dir, "..", "tools", "contacts-export", "contacts-export"),
+		)
+	}
+
+	// Check in wacli tools directory
+	if home, err := os.UserHomeDir(); err == nil {
+		helperPaths = append(helperPaths,
+			filepath.Join(home, ".wacli", "tools", "contacts-export"),
+			filepath.Join(home, "github", "wacli", "tools", "contacts-export", "contacts-export"),
+		)
+	}
+
+	var helperPath string
+	for _, p := range helperPaths {
+		if _, err := exec.LookPath(p); err == nil {
+			helperPath = p
+			break
+		}
+		if _, err := os.Stat(p); err == nil {
+			helperPath = p
+			break
+		}
+	}
+
+	if helperPath == "" {
+		return nil, fmt.Errorf("contacts-export helper not found")
+	}
+
+	cmd := exec.Command(helperPath)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("create pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start helper: %w", err)
+	}
+
+	var contacts []SystemContact
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		var c SystemContact
+		if err := json.Unmarshal(scanner.Bytes(), &c); err != nil {
+			continue
+		}
+		if c.Name() != "" && len(c.Phones) > 0 {
+			contacts = append(contacts, c)
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return nil, fmt.Errorf("helper failed: %w", err)
+	}
+
+	return contacts, nil
+}
+
+// findAddressBookDBs finds all AddressBook SQLite databases on macOS
+func findAddressBookDBs() ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	var dbs []string
+	abPath := filepath.Join(home, "Library", "Application Support", "AddressBook")
+
+	// Check main database
+	mainDB := filepath.Join(abPath, "AddressBook-v22.abcddb")
+	if _, err := os.Stat(mainDB); err == nil {
+		dbs = append(dbs, mainDB)
+	}
+
+	// Check Sources folder for synced databases (iCloud, Exchange, etc.)
+	sourcesPath := filepath.Join(abPath, "Sources")
+	entries, err := os.ReadDir(sourcesPath)
+	if err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() {
+				sourceDB := filepath.Join(sourcesPath, entry.Name(), "AddressBook-v22.abcddb")
+				if _, err := os.Stat(sourceDB); err == nil {
+					dbs = append(dbs, sourceDB)
+				}
+			}
+		}
+	}
+
+	return dbs, nil
+}
+
+// getContactsViaSQLite reads directly from AddressBook SQLite databases
+// This is a fallback - it works without permissions but uses undocumented schema
+func getContactsViaSQLite() ([]SystemContact, error) {
+	dbPaths, err := findAddressBookDBs()
+	if err != nil {
+		return nil, fmt.Errorf("find address book databases: %w", err)
+	}
+	if len(dbPaths) == 0 {
+		return nil, fmt.Errorf("no AddressBook database found")
+	}
+
+	// Aggregate contacts from all databases, keyed by first+last name to avoid duplicates
+	contactMap := make(map[string]*SystemContact)
+
+	for _, dbPath := range dbPaths {
+		// Open in read-only mode with immutable flag to avoid locking issues
+		db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?mode=ro&immutable=1", dbPath))
+		if err != nil {
+			continue // Skip databases we can't open
+		}
+
+		// Query contacts with phone numbers
+		rows, err := db.Query(`
+			SELECT 
+				COALESCE(r.ZFIRSTNAME, ''),
+				COALESCE(r.ZLASTNAME, ''),
+				p.ZFULLNUMBER
+			FROM ZABCDRECORD r
+			JOIN ZABCDPHONENUMBER p ON p.ZOWNER = r.Z_PK
+			WHERE p.ZFULLNUMBER IS NOT NULL 
+			  AND p.ZFULLNUMBER != ''
+			  AND (r.ZFIRSTNAME IS NOT NULL OR r.ZLASTNAME IS NOT NULL)
+		`)
+		if err != nil {
+			db.Close()
+			continue
+		}
+
+		for rows.Next() {
+			var firstName, lastName, phone string
+			if err := rows.Scan(&firstName, &lastName, &phone); err != nil {
+				continue
+			}
+
+			key := firstName + "|" + lastName
+			if existing, ok := contactMap[key]; ok {
+				// Add phone to existing contact
+				existing.Phones = append(existing.Phones, phone)
+			} else {
+				c := &SystemContact{
+					FirstName: firstName,
+					LastName:  lastName,
+					Phones:    []string{phone},
+				}
+				c.FullName = c.Name()
+				contactMap[key] = c
+			}
+		}
+		rows.Close()
+		db.Close()
+	}
+
+	// Convert map to slice
+	contacts := make([]SystemContact, 0, len(contactMap))
+	for _, c := range contactMap {
+		if c.Name() != "" && len(c.Phones) > 0 {
+			contacts = append(contacts, *c)
+		}
+	}
+
+	return contacts, nil
+}
+
+// NormalizePhone strips non-digit characters and normalizes phone numbers
+// Returns the normalized number suitable for WhatsApp JID matching
+func NormalizePhone(phone string) string {
+	// Remove all non-digit characters except leading +
+	re := regexp.MustCompile(`[^\d+]`)
+	normalized := re.ReplaceAllString(phone, "")
+
+	// Remove leading + if present (WhatsApp JIDs don't have it)
+	normalized = strings.TrimPrefix(normalized, "+")
+
+	// Remove leading zeros (international format)
+	normalized = strings.TrimLeft(normalized, "0")
+
+	return normalized
+}
+
+// BuildPhoneToNameMap creates a map from normalized phone numbers to contact names
+func BuildPhoneToNameMap(contacts []SystemContact) map[string]string {
+	result := make(map[string]string)
+	for _, c := range contacts {
+		name := c.Name()
+		if name == "" {
+			continue
+		}
+		for _, phone := range c.Phones {
+			normalized := NormalizePhone(phone)
+			if normalized != "" && len(normalized) >= 7 { // Skip very short numbers
+				// Don't overwrite if we already have a name for this number
+				if _, exists := result[normalized]; !exists {
+					result[normalized] = name
+				}
+			}
+		}
+	}
+	return result
+}

--- a/internal/contacts/other.go
+++ b/internal/contacts/other.go
@@ -1,0 +1,33 @@
+//go:build !darwin
+
+package contacts
+
+import "fmt"
+
+// SystemContact represents a contact from the system address book
+type SystemContact struct {
+	FirstName string   `json:"firstName"`
+	LastName  string   `json:"lastName"`
+	FullName  string   `json:"fullName"`
+	Phones    []string `json:"phones"`
+}
+
+// Name returns the best display name for the contact
+func (c SystemContact) Name() string {
+	return c.FullName
+}
+
+// GetSystemContacts is not implemented on non-Darwin platforms
+func GetSystemContacts() ([]SystemContact, error) {
+	return nil, fmt.Errorf("system contacts import is only supported on macOS")
+}
+
+// NormalizePhone strips non-digit characters and normalizes phone numbers
+func NormalizePhone(phone string) string {
+	return ""
+}
+
+// BuildPhoneToNameMap creates a map from normalized phone numbers to contact names
+func BuildPhoneToNameMap(contacts []SystemContact) map[string]string {
+	return nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -145,10 +145,28 @@ func (d *DB) ensureSchema() error {
 		return err
 	}
 
+	if err := d.ensureContactColumns(); err != nil {
+		return err
+	}
+
 	if err := d.ensureMessagesFTS(); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+func (d *DB) ensureContactColumns() error {
+	ok, err := d.tableHasColumn("contacts", "system_name")
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+	if _, err := d.sql.Exec(`ALTER TABLE contacts ADD COLUMN system_name TEXT`); err != nil {
+		return fmt.Errorf("add system_name column: %w", err)
+	}
 	return nil
 }
 
@@ -347,12 +365,13 @@ type MessageInfo struct {
 }
 
 type Contact struct {
-	JID       string
-	Phone     string
-	Name      string
-	Alias     string
-	Tags      []string
-	UpdatedAt time.Time
+	JID        string
+	Phone      string
+	Name       string    // Display name (computed from precedence: alias > system_name > whatsapp names)
+	Alias      string    // Manual user override
+	SystemName string    // From system contacts (macOS/iOS address book)
+	Tags       []string
+	UpdatedAt  time.Time
 }
 
 func unix(t time.Time) int64 {
@@ -841,19 +860,26 @@ func (d *DB) SearchContacts(query string, limit int) ([]Contact, error) {
 	if limit <= 0 {
 		limit = 50
 	}
+	// Display name precedence: alias > system_name > full_name > push_name > business_name > first_name
 	q := `
 		SELECT c.jid,
 		       COALESCE(c.phone,''),
 		       COALESCE(NULLIF(a.alias,''), ''),
-		       COALESCE(NULLIF(c.full_name,''), NULLIF(c.push_name,''), NULLIF(c.business_name,''), NULLIF(c.first_name,''), ''),
+		       COALESCE(NULLIF(c.system_name,''), ''),
+		       COALESCE(NULLIF(a.alias,''), NULLIF(c.system_name,''), NULLIF(c.full_name,''), NULLIF(c.push_name,''), NULLIF(c.business_name,''), NULLIF(c.first_name,''), ''),
 		       c.updated_at
 		FROM contacts c
 		LEFT JOIN contact_aliases a ON a.jid = c.jid
-		WHERE LOWER(COALESCE(a.alias,'')) LIKE LOWER(?) OR LOWER(COALESCE(c.full_name,'')) LIKE LOWER(?) OR LOWER(COALESCE(c.push_name,'')) LIKE LOWER(?) OR LOWER(COALESCE(c.phone,'')) LIKE LOWER(?) OR LOWER(c.jid) LIKE LOWER(?)
-		ORDER BY COALESCE(NULLIF(a.alias,''), NULLIF(c.full_name,''), NULLIF(c.push_name,''), c.jid)
+		WHERE LOWER(COALESCE(a.alias,'')) LIKE LOWER(?) 
+		   OR LOWER(COALESCE(c.system_name,'')) LIKE LOWER(?)
+		   OR LOWER(COALESCE(c.full_name,'')) LIKE LOWER(?) 
+		   OR LOWER(COALESCE(c.push_name,'')) LIKE LOWER(?) 
+		   OR LOWER(COALESCE(c.phone,'')) LIKE LOWER(?) 
+		   OR LOWER(c.jid) LIKE LOWER(?)
+		ORDER BY COALESCE(NULLIF(a.alias,''), NULLIF(c.system_name,''), NULLIF(c.full_name,''), NULLIF(c.push_name,''), c.jid)
 		LIMIT ?`
 	needle := "%" + query + "%"
-	rows, err := d.sql.Query(q, needle, needle, needle, needle, needle, limit)
+	rows, err := d.sql.Query(q, needle, needle, needle, needle, needle, needle, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -862,7 +888,7 @@ func (d *DB) SearchContacts(query string, limit int) ([]Contact, error) {
 	for rows.Next() {
 		var c Contact
 		var updated int64
-		if err := rows.Scan(&c.JID, &c.Phone, &c.Alias, &c.Name, &updated); err != nil {
+		if err := rows.Scan(&c.JID, &c.Phone, &c.Alias, &c.SystemName, &c.Name, &updated); err != nil {
 			return nil, err
 		}
 		c.UpdatedAt = fromUnix(updated)
@@ -872,11 +898,13 @@ func (d *DB) SearchContacts(query string, limit int) ([]Contact, error) {
 }
 
 func (d *DB) GetContact(jid string) (Contact, error) {
+	// Display name precedence: alias > system_name > full_name > push_name > business_name > first_name
 	row := d.sql.QueryRow(`
 		SELECT c.jid,
 		       COALESCE(c.phone,''),
 		       COALESCE(NULLIF(a.alias,''), ''),
-		       COALESCE(NULLIF(c.full_name,''), NULLIF(c.push_name,''), NULLIF(c.business_name,''), NULLIF(c.first_name,''), ''),
+		       COALESCE(NULLIF(c.system_name,''), ''),
+		       COALESCE(NULLIF(a.alias,''), NULLIF(c.system_name,''), NULLIF(c.full_name,''), NULLIF(c.push_name,''), NULLIF(c.business_name,''), NULLIF(c.first_name,''), ''),
 		       c.updated_at
 		FROM contacts c
 		LEFT JOIN contact_aliases a ON a.jid = c.jid
@@ -884,7 +912,7 @@ func (d *DB) GetContact(jid string) (Contact, error) {
 	`, jid)
 	var c Contact
 	var updated int64
-	if err := row.Scan(&c.JID, &c.Phone, &c.Alias, &c.Name, &updated); err != nil {
+	if err := row.Scan(&c.JID, &c.Phone, &c.Alias, &c.SystemName, &c.Name, &updated); err != nil {
 		return Contact{}, err
 	}
 	c.UpdatedAt = fromUnix(updated)
@@ -1021,6 +1049,50 @@ func (d *DB) SetAlias(jid, alias string) error {
 func (d *DB) RemoveAlias(jid string) error {
 	_, err := d.sql.Exec(`DELETE FROM contact_aliases WHERE jid = ?`, jid)
 	return err
+}
+
+// SetSystemName sets the system contact name for a contact (from macOS/iOS address book)
+func (d *DB) SetSystemName(jid, systemName string) error {
+	systemName = strings.TrimSpace(systemName)
+	if systemName == "" {
+		return fmt.Errorf("system_name is required")
+	}
+	now := time.Now().UTC().Unix()
+	_, err := d.sql.Exec(`
+		UPDATE contacts SET system_name = ?, updated_at = ? WHERE jid = ?
+	`, systemName, now, jid)
+	return err
+}
+
+// ClearSystemName removes the system contact name for a contact
+func (d *DB) ClearSystemName(jid string) error {
+	now := time.Now().UTC().Unix()
+	_, err := d.sql.Exec(`
+		UPDATE contacts SET system_name = NULL, updated_at = ? WHERE jid = ?
+	`, now, jid)
+	return err
+}
+
+// ClearAllSystemNames removes all system contact names
+func (d *DB) ClearAllSystemNames() (int64, error) {
+	now := time.Now().UTC().Unix()
+	result, err := d.sql.Exec(`
+		UPDATE contacts SET system_name = NULL, updated_at = ? WHERE system_name IS NOT NULL
+	`, now)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+// CountSystemNames returns the number of contacts with system names set
+func (d *DB) CountSystemNames() (int64, error) {
+	row := d.sql.QueryRow(`SELECT COUNT(1) FROM contacts WHERE system_name IS NOT NULL AND system_name != ''`)
+	var n int64
+	if err := row.Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
 }
 
 func (d *DB) AddTag(jid, tag string) error {

--- a/tools/contacts-export/Info.plist
+++ b/tools/contacts-export/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.wacli.contacts-export</string>
+    <key>CFBundleName</key>
+    <string>contacts-export</string>
+    <key>NSContactsUsageDescription</key>
+    <string>wacli needs access to your contacts to import names for WhatsApp contacts.</string>
+</dict>
+</plist>

--- a/tools/contacts-export/main.swift
+++ b/tools/contacts-export/main.swift
@@ -1,0 +1,144 @@
+#!/usr/bin/env swift
+//
+// contacts-export - Export macOS contacts as JSON
+//
+// Usage: contacts-export [--help]
+//
+// Outputs newline-delimited JSON to stdout:
+// {"firstName":"John","lastName":"Doe","phones":["14157347847","14157348888"]}
+//
+// Phone numbers are normalized to digits only (E.164-ish without +).
+// Only contacts with at least one phone number are exported.
+//
+
+import Contacts
+import Foundation
+
+struct Contact: Codable {
+    let firstName: String
+    let lastName: String
+    let fullName: String
+    let phones: [String]
+}
+
+/// Normalize phone number to digits only, strip leading + and 00
+func normalizePhone(_ phone: String) -> String {
+    let digits = phone.unicodeScalars.filter { CharacterSet.decimalDigits.contains($0) }
+    var result = String(digits)
+    
+    // Strip leading zeros (international 00 prefix)
+    while result.hasPrefix("0") {
+        result = String(result.dropFirst())
+    }
+    
+    return result
+}
+
+func exportContacts() {
+    let store = CNContactStore()
+    
+    // Check authorization status first
+    let status = CNContactStore.authorizationStatus(for: .contacts)
+    
+    switch status {
+    case .authorized, .limited:
+        break // Good to go
+    case .notDetermined:
+        // Request access synchronously
+        let semaphore = DispatchSemaphore(value: 0)
+        var accessGranted = false
+        
+        store.requestAccess(for: .contacts) { granted, error in
+            accessGranted = granted
+            if let error = error {
+                fputs("Error requesting access: \(error.localizedDescription)\n", stderr)
+            }
+            semaphore.signal()
+        }
+        _ = semaphore.wait(timeout: .now() + 30)
+        
+        guard accessGranted else {
+            fputs("Error: Contacts access denied. Grant access in System Settings > Privacy & Security > Contacts.\n", stderr)
+            exit(1)
+        }
+    case .denied, .restricted:
+        fputs("Error: Contacts access denied. Grant access in System Settings > Privacy & Security > Contacts.\n", stderr)
+        exit(1)
+    @unknown default:
+        fputs("Error: Unknown authorization status.\n", stderr)
+        exit(1)
+    }
+    
+    // Fetch all contacts with phone numbers
+    let keysToFetch: [CNKeyDescriptor] = [
+        CNContactGivenNameKey as CNKeyDescriptor,
+        CNContactFamilyNameKey as CNKeyDescriptor,
+        CNContactPhoneNumbersKey as CNKeyDescriptor,
+    ]
+    
+    let request = CNContactFetchRequest(keysToFetch: keysToFetch)
+    let encoder = JSONEncoder()
+    
+    do {
+        try store.enumerateContacts(with: request) { contact, _ in
+            // Skip contacts without phone numbers
+            guard !contact.phoneNumbers.isEmpty else { return }
+            
+            // Normalize phone numbers
+            let phones = contact.phoneNumbers.compactMap { phone -> String? in
+                let normalized = normalizePhone(phone.value.stringValue)
+                // Skip very short numbers (likely invalid)
+                guard normalized.count >= 7 else { return nil }
+                return normalized
+            }
+            
+            // Skip if no valid phones after normalization
+            guard !phones.isEmpty else { return }
+            
+            // Build full name
+            var fullName = ""
+            if !contact.givenName.isEmpty {
+                fullName = contact.givenName
+            }
+            if !contact.familyName.isEmpty {
+                if !fullName.isEmpty { fullName += " " }
+                fullName += contact.familyName
+            }
+            
+            let c = Contact(
+                firstName: contact.givenName,
+                lastName: contact.familyName,
+                fullName: fullName,
+                phones: phones
+            )
+            
+            if let jsonData = try? encoder.encode(c),
+               let jsonString = String(data: jsonData, encoding: .utf8) {
+                print(jsonString)
+            }
+        }
+    } catch {
+        fputs("Error fetching contacts: \(error.localizedDescription)\n", stderr)
+        exit(1)
+    }
+}
+
+// Main
+if CommandLine.arguments.contains("--help") || CommandLine.arguments.contains("-h") {
+    print("""
+        contacts-export - Export macOS contacts as JSON
+        
+        Usage: contacts-export [--help]
+        
+        Outputs newline-delimited JSON to stdout. Each line is a contact:
+        {"firstName":"John","lastName":"Doe","fullName":"John Doe","phones":["14157347847"]}
+        
+        Only contacts with phone numbers are exported.
+        Phone numbers are normalized to digits only.
+        
+        Requires Contacts access permission (will prompt on first run).
+        """)
+    exit(0)
+}
+
+exportContacts()


### PR DESCRIPTION
⁠ Adds support for importing contact names from macOS Contacts.app, mirroring native WhatsApp behavior.

## Changes
- Add system_name column to contacts table
- Display precedence: alias > system_name > WhatsApp names
- New command: wacli contacts import-system
- Swift helper for macOS Contacts.app (CNContactStore)
- Fallback to direct SQLite for compatibility

## Usage
 ⁠bash
wacli contacts import-system           # Import all matches
wacli contacts import-system --dry-run # Preview changes
wacli contacts import-system --clear   # Remove imported names


## Architecture
- `internal/contacts/` - System contacts abstraction (macOS-specific + stub)
- `internal/store/` - Schema migration + new methods
- `tools/contacts-export/` - Swift helper for CNContactStore access

Co-authored-by: Octavio Froid <froid@bohm.com>