### PR TITLE
feat: add WACLI_STORE_DIR environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Defaults to `~/.wacli` (override with `--store DIR`).
 
 ## Environment overrides
 
+- `WACLI_STORE_DIR`: override the store directory (default: `~/.wacli`). Equivalent to `--store`.
 - `WACLI_DEVICE_LABEL`: set the linked device label (shown in WhatsApp).
 - `WACLI_DEVICE_PLATFORM`: override the linked device platform (defaults to `CHROME` if unset or invalid).
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,9 @@ import (
 )
 
 func DefaultStoreDir() string {
+	if dir := os.Getenv("WACLI_STORE_DIR"); dir != "" {
+		return dir
+	}
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		return ".wacli"


### PR DESCRIPTION
Add support for configuring the store directory via `WACLI_STORE_DIR` environment variable, as suggested in #36.

## Changes

- `internal/config/config.go`: Check `WACLI_STORE_DIR` env before falling back to `~/.wacli`
- `README.md`: Document the new env var in the Environment overrides section

## Priority

`--store` flag > `WACLI_STORE_DIR` env > `~/.wacli` default

This follows the existing pattern of `WACLI_DEVICE_LABEL` and `WACLI_DEVICE_PLATFORM` env vars.

Closes #36