### PR TITLE
feat: store WhatsApp Community hierarchy in groups table

### DIFF
--- a/cmd/wacli/groups.go
+++ b/cmd/wacli/groups.go
@@ -157,12 +157,14 @@ func newGroupsInfoCmd(flags *rootFlags) *cobra.Command {
 				return out.WriteJSON(os.Stdout, info)
 			}
 
-			fmt.Fprintf(os.Stdout, "JID: %s\nName: %s\nOwner: %s\nCreated: %s\nParticipants: %d\n",
+			fmt.Fprintf(os.Stdout, "JID: %s\nName: %s\nOwner: %s\nCreated: %s\nParticipants: %d\nCommunity: %v\nParent: %s\n",
 				info.JID.String(),
 				info.GroupName.Name,
 				info.OwnerJID.String(),
 				info.GroupCreated.Local().Format(time.RFC3339),
 				len(info.Participants),
+				info.IsParent,
+				info.LinkedParentJID.String(),
 			)
 			return nil
 		},
@@ -483,7 +485,7 @@ func persistGroupInfo(db *store.DB, info *types.GroupInfo) error {
 	if info == nil {
 		return nil
 	}
-	if err := db.UpsertGroup(info.JID.String(), info.GroupName.Name, info.OwnerJID.String(), info.GroupCreated); err != nil {
+	if err := db.UpsertGroup(info.JID.String(), info.GroupName.Name, info.OwnerJID.String(), info.GroupCreated, info.IsParent, info.LinkedParentJID.String()); err != nil {
 		return err
 	}
 	var ps []store.GroupParticipant

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -39,7 +39,7 @@ func (a *App) refreshGroups(ctx context.Context) error {
 		if g == nil {
 			continue
 		}
-		_ = a.db.UpsertGroup(g.JID.String(), g.GroupName.Name, g.OwnerJID.String(), g.GroupCreated)
+		_ = a.db.UpsertGroup(g.JID.String(), g.GroupName.Name, g.OwnerJID.String(), g.GroupCreated, g.IsParent, g.LinkedParentJID.String())
 		_ = a.db.UpsertChat(g.JID.String(), "group", g.GroupName.Name, now)
 	}
 	return nil

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -271,7 +271,7 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 	// Best-effort: store group metadata (and participants) when available.
 	if pm.Chat.Server == types.GroupServer {
 		if gi, err := a.wa.GetGroupInfo(ctx, pm.Chat); err == nil && gi != nil {
-			_ = a.db.UpsertGroup(gi.JID.String(), gi.GroupName.Name, gi.OwnerJID.String(), gi.GroupCreated)
+			_ = a.db.UpsertGroup(gi.JID.String(), gi.GroupName.Name, gi.OwnerJID.String(), gi.GroupCreated, gi.IsParent, gi.LinkedParentJID.String())
 			var ps []store.GroupParticipant
 			for _, p := range gi.Participants {
 				role := "member"

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -295,7 +295,7 @@ func TestGroupsUpsertListAndParticipantsReplace(t *testing.T) {
 
 	gid := "123@g.us"
 	created := time.Date(2023, 12, 1, 0, 0, 0, 0, time.UTC)
-	if err := db.UpsertGroup(gid, "Group", "owner@s.whatsapp.net", created); err != nil {
+	if err := db.UpsertGroup(gid, "Group", "owner@s.whatsapp.net", created, false, ""); err != nil {
 		t.Fatalf("UpsertGroup: %v", err)
 	}
 	if err := db.ReplaceGroupParticipants(gid, []GroupParticipant{


### PR DESCRIPTION
## Summary

- Adds `is_parent` (BOOLEAN) and `linked_parent_jid` (TEXT) columns to the `groups` table
- Persists WhatsApp Community relationships that whatsmeow already exposes via `GroupInfo.IsParent` and `GroupInfo.LinkedParentJID`
- Includes auto-migration for existing databases (`ensureGroupColumns()`)
- Communities have `is_parent=true`; their subgroups reference the parent via `linked_parent_jid`

## Motivation

WhatsApp Communities group related chats (e.g. a "CPO Network" community with subgroups like "General Chat", "Events", "AI Discussion"). whatsmeow provides this hierarchy data, but wacli currently discards it. Storing it enables community-aware UIs and queries like:

```sql
-- Find all subgroups of a community
SELECT * FROM groups WHERE linked_parent_jid = '120363285405063202@g.us';

-- List all communities
SELECT * FROM groups WHERE is_parent = 1;
```

## Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Schema, migration, `UpsertGroup()` signature, `Group` struct, `ListGroups()` query |
| `internal/app/bootstrap.go` | Pass `IsParent`/`LinkedParentJID` to `UpsertGroup()` |
| `internal/app/sync.go` | Pass `IsParent`/`LinkedParentJID` to `UpsertGroup()` |
| `cmd/wacli/groups.go` | Update `persistGroupInfo()` + `groups info` output |
| `internal/store/store_test.go` | Updated test to match new signature |

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./internal/store/` passes
- [ ] `wacli groups refresh` populates `is_parent` and `linked_parent_jid`
- [ ] `wacli groups info --jid <community-jid>` shows `Community: true`
- [ ] `wacli groups list --json` includes new fields
- [ ] Existing databases migrate cleanly (columns added on first run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)