### PR TITLE
feat: add voice note (PTT) sending support

### DIFF
--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -19,6 +19,7 @@ func newSendCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.AddCommand(newSendTextCmd(flags))
 	cmd.AddCommand(newSendFileCmd(flags))
+	cmd.AddCommand(newSendVoiceCmd(flags))
 	return cmd
 }
 

--- a/cmd/wacli/send_file.go
+++ b/cmd/wacli/send_file.go
@@ -2,10 +2,15 @@ package main
 
 import (
 	"context"
+	"encoding/binary"
+	"fmt"
+	"math"
 	"mime"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,7 +25,7 @@ import (
 func sendFile(ctx context.Context, a interface {
 	WA() app.WAClient
 	DB() *store.DB
-}, to types.JID, filePath, filename, caption, mimeOverride string) (string, map[string]string, error) {
+}, to types.JID, filePath, filename, caption, mimeOverride string, ptt bool) (string, map[string]string, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return "", nil, err
@@ -41,6 +46,18 @@ func sendFile(ctx context.Context, a interface {
 			sniff = sniff[:512]
 		}
 		mimeType = http.DetectContentType(sniff)
+	}
+
+	// WhatsApp requires "audio/ogg; codecs=opus" for OGG audio to be
+	// delivered correctly. Go's mime detection returns "audio/ogg" which
+	// causes silent delivery failure. Fix the MIME for any OGG audio.
+	if mimeType == "audio/ogg" || mimeType == "application/ogg" {
+		mimeType = "audio/ogg; codecs=opus"
+	}
+
+	// When --ptt is set, force audio MIME if not already audio.
+	if ptt && !strings.HasPrefix(mimeType, "audio/") {
+		mimeType = "audio/ogg; codecs=opus"
 	}
 
 	mediaType := "document"
@@ -89,7 +106,7 @@ func sendFile(ctx context.Context, a interface {
 			Caption:       proto.String(caption),
 		}
 	case "audio":
-		msg.AudioMessage = &waProto.AudioMessage{
+		audioMsg := &waProto.AudioMessage{
 			URL:           proto.String(up.URL),
 			DirectPath:    proto.String(up.DirectPath),
 			MediaKey:      up.MediaKey,
@@ -97,8 +114,15 @@ func sendFile(ctx context.Context, a interface {
 			FileSHA256:    up.FileSHA256,
 			FileLength:    proto.Uint64(up.FileLength),
 			Mimetype:      proto.String(mimeType),
-			PTT:           proto.Bool(false),
+			PTT:           proto.Bool(ptt),
 		}
+		if ptt {
+			if dur, err := probeAudioDuration(filePath); err == nil && dur > 0 {
+				audioMsg.Seconds = proto.Uint32(dur)
+			}
+			audioMsg.Waveform = generateWaveform(data)
+		}
+		msg.AudioMessage = audioMsg
 	default:
 		msg.DocumentMessage = &waProto.DocumentMessage{
 			URL:           proto.String(up.URL),
@@ -147,6 +171,83 @@ func sendFile(ctx context.Context, a interface {
 		"mime_type": mimeType,
 		"media":     mediaType,
 	}, nil
+}
+
+// probeAudioDuration uses ffprobe to get the duration of an audio file in seconds.
+// Returns 0 if ffprobe is not available or fails.
+func probeAudioDuration(path string) (uint32, error) {
+	out, err := exec.Command("ffprobe",
+		"-v", "error",
+		"-show_entries", "format=duration",
+		"-of", "default=noprint_wrappers=1:nokey=1",
+		path,
+	).Output()
+	if err != nil {
+		return 0, fmt.Errorf("ffprobe: %w", err)
+	}
+	s := strings.TrimSpace(string(out))
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse duration %q: %w", s, err)
+	}
+	return uint32(math.Ceil(f)), nil
+}
+
+// generateWaveform produces a 64-sample waveform (values 0-100) from raw audio data.
+// This is a simplified RMS-based approach that samples evenly across the file.
+// For OGG Opus files this operates on the raw bytes which gives a reasonable
+// approximation of the audio energy distribution.
+func generateWaveform(data []byte) []byte {
+	const numSamples = 64
+	if len(data) == 0 {
+		return make([]byte, numSamples)
+	}
+
+	waveform := make([]byte, numSamples)
+	chunkSize := len(data) / numSamples
+	if chunkSize < 2 {
+		chunkSize = 2
+	}
+
+	var maxRMS float64
+	rmsValues := make([]float64, numSamples)
+
+	for i := 0; i < numSamples; i++ {
+		start := i * (len(data) / numSamples)
+		end := start + chunkSize
+		if end > len(data) {
+			end = len(data)
+		}
+		chunk := data[start:end]
+
+		// Compute RMS of 16-bit little-endian samples from the raw bytes.
+		var sumSq float64
+		var count int
+		for j := 0; j+1 < len(chunk); j += 2 {
+			sample := int16(binary.LittleEndian.Uint16(chunk[j : j+2]))
+			sumSq += float64(sample) * float64(sample)
+			count++
+		}
+		if count > 0 {
+			rmsValues[i] = math.Sqrt(sumSq / float64(count))
+			if rmsValues[i] > maxRMS {
+				maxRMS = rmsValues[i]
+			}
+		}
+	}
+
+	// Normalize to 0-100 range.
+	if maxRMS > 0 {
+		for i, v := range rmsValues {
+			normalized := (v / maxRMS) * 100
+			if normalized > 100 {
+				normalized = 100
+			}
+			waveform[i] = byte(normalized)
+		}
+	}
+
+	return waveform
 }
 
 func chatKindFromJID(j types.JID) string {

--- a/cmd/wacli/send_file_test.go
+++ b/cmd/wacli/send_file_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestGenerateWaveform_EmptyData(t *testing.T) {
+	wf := generateWaveform(nil)
+	if len(wf) != 64 {
+		t.Fatalf("expected 64 samples, got %d", len(wf))
+	}
+	for i, v := range wf {
+		if v != 0 {
+			t.Fatalf("expected 0 at index %d, got %d", i, v)
+		}
+	}
+}
+
+func TestGenerateWaveform_Length(t *testing.T) {
+	// Create fake audio data (16-bit LE samples)
+	data := make([]byte, 64*100*2) // 100 samples per chunk, 64 chunks
+	for i := 0; i < len(data); i += 2 {
+		binary.LittleEndian.PutUint16(data[i:i+2], 1000)
+	}
+	wf := generateWaveform(data)
+	if len(wf) != 64 {
+		t.Fatalf("expected 64 samples, got %d", len(wf))
+	}
+}
+
+func TestGenerateWaveform_ValuesInRange(t *testing.T) {
+	// Create data with varying amplitude
+	var buf bytes.Buffer
+	for i := 0; i < 64*200; i++ {
+		sample := int16(i % 32768)
+		_ = binary.Write(&buf, binary.LittleEndian, sample)
+	}
+	wf := generateWaveform(buf.Bytes())
+	if len(wf) != 64 {
+		t.Fatalf("expected 64 samples, got %d", len(wf))
+	}
+	for i, v := range wf {
+		if v > 100 {
+			t.Fatalf("sample %d out of range: %d", i, v)
+		}
+	}
+}
+
+func TestGenerateWaveform_NotAllZero(t *testing.T) {
+	// Non-silent audio should produce non-zero waveform
+	var buf bytes.Buffer
+	for i := 0; i < 64*200; i++ {
+		sample := int16((i * 137) % 20000) // varying amplitude
+		_ = binary.Write(&buf, binary.LittleEndian, sample)
+	}
+	wf := generateWaveform(buf.Bytes())
+	hasNonZero := false
+	for _, v := range wf {
+		if v > 0 {
+			hasNonZero = true
+			break
+		}
+	}
+	if !hasNonZero {
+		t.Fatal("expected non-zero waveform for non-silent audio")
+	}
+}
+
+func TestGenerateWaveform_MaxIs100(t *testing.T) {
+	// Uniform loud signal should have all samples at 100
+	data := make([]byte, 64*100*2)
+	for i := 0; i < len(data); i += 2 {
+		binary.LittleEndian.PutUint16(data[i:i+2], uint16(10000))
+	}
+	wf := generateWaveform(data)
+	for i, v := range wf {
+		if v != 100 {
+			t.Fatalf("expected 100 at index %d, got %d (uniform signal)", i, v)
+		}
+	}
+}
+
+func TestGenerateWaveform_SmallData(t *testing.T) {
+	// Very small data (less than 128 bytes = 64*2)
+	data := []byte{0x00, 0x10, 0xFF, 0x7F}
+	wf := generateWaveform(data)
+	if len(wf) != 64 {
+		t.Fatalf("expected 64 samples, got %d", len(wf))
+	}
+}

--- a/cmd/wacli/send_voice_cmd.go
+++ b/cmd/wacli/send_voice_cmd.go
@@ -10,17 +10,14 @@ import (
 	"github.com/steipete/wacli/internal/wa"
 )
 
-func newSendFileCmd(flags *rootFlags) *cobra.Command {
+func newSendVoiceCmd(flags *rootFlags) *cobra.Command {
 	var to string
 	var filePath string
-	var filename string
-	var caption string
-	var mimeOverride string
-	var ptt bool
 
 	cmd := &cobra.Command{
-		Use:   "file",
-		Short: "Send a file (image/video/audio/document)",
+		Use:   "voice",
+		Short: "Send a voice note (Push-To-Talk)",
+		Long:  "Send an audio file as a WhatsApp voice note (PTT). This is a shortcut for 'send file --ptt'.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if to == "" || filePath == "" {
 				return fmt.Errorf("--to and --file are required")
@@ -47,7 +44,7 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			msgID, meta, err := sendFile(ctx, a, toJID, filePath, filename, caption, mimeOverride, ptt)
+			msgID, meta, err := sendFile(ctx, a, toJID, filePath, "", "", "", true)
 			if err != nil {
 				return err
 			}
@@ -60,16 +57,12 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 					"file": meta,
 				})
 			}
-			fmt.Fprintf(os.Stdout, "Sent %s to %s (id %s)\n", meta["name"], toJID.String(), msgID)
+			fmt.Fprintf(os.Stdout, "Sent voice note to %s (id %s)\n", toJID.String(), msgID)
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVar(&to, "to", "", "recipient phone number or JID")
-	cmd.Flags().StringVar(&filePath, "file", "", "path to file")
-	cmd.Flags().StringVar(&filename, "filename", "", "display name for the file (defaults to basename of --file)")
-	cmd.Flags().StringVar(&caption, "caption", "", "caption (images/videos/documents)")
-	cmd.Flags().StringVar(&mimeOverride, "mime", "", "override detected mime type")
-	cmd.Flags().BoolVar(&ptt, "ptt", false, "send as voice note (Push-To-Talk)")
+	cmd.Flags().StringVar(&filePath, "file", "", "path to audio file")
 	return cmd
 }


### PR DESCRIPTION
## Summary

Add support for sending WhatsApp voice notes (Push-To-Talk) via `wacli send file --ptt` and a new `wacli send voice` convenience subcommand.

Closes #14, closes #40.

## Changes

### `send file --ptt` flag
Adds a `--ptt` boolean flag that sends audio as a native WhatsApp voice note (green bubble with waveform) instead of a regular audio attachment.

### `send voice` subcommand  
Convenience shortcut — equivalent to `send file --ptt`:
```bash
wacli send voice --to 1234567890 --file voice.ogg
```

### 🐛 Fix: OGG audio delivery failure
**This PR also fixes a pre-existing bug where sending any OGG audio file silently failed** (message ID returned but never delivered to recipient). The root cause: Go's `mime.TypeByExtension` returns `audio/ogg` for `.ogg` files, but WhatsApp requires `audio/ogg; codecs=opus` for audio delivery. Without the codec parameter, WhatsApp accepts the upload but never delivers the message.

### Waveform generation
Generates a 64-sample waveform (values 0-100) from the raw audio data using RMS energy analysis. This gives recipients the visual waveform bar in the voice note bubble.

### Duration detection
Uses `ffprobe` (if available) to auto-detect audio duration and set the `Seconds` field. Falls back gracefully if ffprobe is not installed.

### Tests
Unit tests for waveform generation (empty data, length, value range, non-zero output, max normalization, small data).

## Usage

```bash
# Via --ptt flag
wacli send file --to 1234567890 --file recording.ogg --ptt

# Via voice subcommand (shortcut)
wacli send voice --to 1234567890 --file recording.ogg

# Works with JSON output
wacli --json send voice --to 1234567890 --file voice.ogg
```

## Technical Details

- Sets `PTT: true` on the `AudioMessage` protobuf
- Generates `Waveform` byte array (64 samples, 0-100 range)
- Sets `Seconds` duration via ffprobe (optional)
- Fixes MIME: `audio/ogg` → `audio/ogg; codecs=opus` (fixes silent audio delivery failure)
- No new dependencies — ffprobe is optional