### PR TITLE
feat: chat state commands (archive, pin, mute, mark-read)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.5.0 - Unreleased
 
+### Added
+
+- Chats: archive/unarchive, pin/unpin, mute/unmute, mark-read/mark-unread commands.
+- Chats: `chats list` shows archived/pinned/muted/unread flags; filter with `--archived`, `--pinned`, `--muted`, `--unread` (and `--no-*` negations).
+- Chats: `chats show` displays chat state fields.
+- Sync: chat states (archive, pin, mute, read) synced from WhatsApp during bootstrap and live follow mode.
+
 ### Changed
 
 - Internal architecture: split store and groups command logic into focused modules for cleaner maintenance and safer follow-up changes.

--- a/cmd/wacli/chats.go
+++ b/cmd/wacli/chats.go
@@ -4,30 +4,79 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/steipete/wacli/internal/out"
+	"github.com/steipete/wacli/internal/store"
 )
 
 func newChatsCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "chats",
-		Short: "List chats from the local DB",
+		Short: "List and manage chats",
 	}
 	cmd.AddCommand(newChatsListCmd(flags))
 	cmd.AddCommand(newChatsShowCmd(flags))
+	cmd.AddCommand(newChatStateCmd(flags, chatStateAction{
+		use: "archive", short: "Archive a chat",
+		run: func(ctx context.Context, a *appHandle, jid string) error { return a.app.ArchiveChat(ctx, a.jid, true) },
+	}))
+	cmd.AddCommand(newChatStateCmd(flags, chatStateAction{
+		use: "unarchive", short: "Unarchive a chat",
+		run: func(ctx context.Context, a *appHandle, jid string) error { return a.app.ArchiveChat(ctx, a.jid, false) },
+	}))
+	cmd.AddCommand(newChatStateCmd(flags, chatStateAction{
+		use: "pin", short: "Pin a chat",
+		run: func(ctx context.Context, a *appHandle, jid string) error { return a.app.PinChat(ctx, a.jid, true) },
+	}))
+	cmd.AddCommand(newChatStateCmd(flags, chatStateAction{
+		use: "unpin", short: "Unpin a chat",
+		run: func(ctx context.Context, a *appHandle, jid string) error { return a.app.PinChat(ctx, a.jid, false) },
+	}))
+	cmd.AddCommand(newChatsMuteCmd(flags))
+	cmd.AddCommand(newChatStateCmd(flags, chatStateAction{
+		use: "unmute", short: "Unmute a chat",
+		run: func(ctx context.Context, a *appHandle, jid string) error { return a.app.MuteChat(ctx, a.jid, false, 0) },
+	}))
+	cmd.AddCommand(newChatStateCmd(flags, chatStateAction{
+		use: "mark-read", short: "Mark a chat as read",
+		run: func(ctx context.Context, a *appHandle, jid string) error { return a.app.MarkChatRead(ctx, a.jid, true) },
+	}))
+	cmd.AddCommand(newChatStateCmd(flags, chatStateAction{
+		use: "mark-unread", short: "Mark a chat as unread",
+		run: func(ctx context.Context, a *appHandle, jid string) error { return a.app.MarkChatRead(ctx, a.jid, false) },
+	}))
 	return cmd
 }
 
 func newChatsListCmd(flags *rootFlags) *cobra.Command {
 	var query string
 	var limit int
+	var archived, noArchived bool
+	var pinned, noPinned bool
+	var muted, noMuted bool
+	var unread, noUnread bool
+
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List chats",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if archived && noArchived {
+				return fmt.Errorf("--archived and --no-archived are mutually exclusive")
+			}
+			if pinned && noPinned {
+				return fmt.Errorf("--pinned and --no-pinned are mutually exclusive")
+			}
+			if muted && noMuted {
+				return fmt.Errorf("--muted and --no-muted are mutually exclusive")
+			}
+			if unread && noUnread {
+				return fmt.Errorf("--unread and --no-unread are mutually exclusive")
+			}
+
 			ctx, cancel := withTimeout(context.Background(), flags)
 			defer cancel()
 
@@ -37,7 +86,13 @@ func newChatsListCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			chats, err := a.DB().ListChats(query, limit)
+			f := store.ChatListFilter{Query: query, Limit: limit}
+			f.Archived = boolFilter(archived, noArchived)
+			f.Pinned = boolFilter(pinned, noPinned)
+			f.Muted = boolFilter(muted, noMuted)
+			f.Unread = boolFilter(unread, noUnread)
+
+			chats, err := a.DB().ListChats(f)
 			if err != nil {
 				return err
 			}
@@ -46,13 +101,13 @@ func newChatsListCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
-			fmt.Fprintln(w, "KIND\tNAME\tJID\tLAST")
+			fmt.Fprintln(w, "KIND\tNAME\tJID\tLAST\tFLAGS")
 			for _, c := range chats {
 				name := c.Name
 				if name == "" {
 					name = c.JID
 				}
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", c.Kind, truncate(name, 28), c.JID, c.LastMessageTS.Local().Format("2006-01-02 15:04:05"))
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", c.Kind, truncate(name, 28), c.JID, c.LastMessageTS.Local().Format("2006-01-02 15:04:05"), chatFlagsString(c))
 			}
 			_ = w.Flush()
 			return nil
@@ -60,6 +115,14 @@ func newChatsListCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&query, "query", "", "search query")
 	cmd.Flags().IntVar(&limit, "limit", 50, "limit")
+	cmd.Flags().BoolVar(&archived, "archived", false, "show only archived chats")
+	cmd.Flags().BoolVar(&noArchived, "no-archived", false, "exclude archived chats")
+	cmd.Flags().BoolVar(&pinned, "pinned", false, "show only pinned chats")
+	cmd.Flags().BoolVar(&noPinned, "no-pinned", false, "exclude pinned chats")
+	cmd.Flags().BoolVar(&muted, "muted", false, "show only muted chats")
+	cmd.Flags().BoolVar(&noMuted, "no-muted", false, "exclude muted chats")
+	cmd.Flags().BoolVar(&unread, "unread", false, "show only unread chats")
+	cmd.Flags().BoolVar(&noUnread, "no-unread", false, "exclude unread chats")
 	return cmd
 }
 
@@ -88,10 +151,41 @@ func newChatsShowCmd(flags *rootFlags) *cobra.Command {
 			if flags.asJSON {
 				return out.WriteJSON(os.Stdout, c)
 			}
-			fmt.Fprintf(os.Stdout, "JID: %s\nKind: %s\nName: %s\nLast: %s\n", c.JID, c.Kind, c.Name, c.LastMessageTS.Local().Format(time.RFC3339))
+			fmt.Fprintf(os.Stdout, "JID: %s\nKind: %s\nName: %s\nLast: %s\nArchived: %t\nPinned: %t\nMuted: %t\nUnread: %t\n",
+				c.JID, c.Kind, c.Name, c.LastMessageTS.Local().Format(time.RFC3339),
+				c.Archived, c.Pinned, c.Muted(), c.Unread)
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&jid, "jid", "", "chat JID")
 	return cmd
+}
+
+func boolFilter(pos, neg bool) *bool {
+	if pos {
+		v := true
+		return &v
+	}
+	if neg {
+		v := false
+		return &v
+	}
+	return nil
+}
+
+func chatFlagsString(c store.Chat) string {
+	var flags []string
+	if c.Pinned {
+		flags = append(flags, "pinned")
+	}
+	if c.Archived {
+		flags = append(flags, "archived")
+	}
+	if c.Muted() {
+		flags = append(flags, "muted")
+	}
+	if c.Unread {
+		flags = append(flags, "unread")
+	}
+	return strings.Join(flags, ",")
 }

--- a/cmd/wacli/chats_state.go
+++ b/cmd/wacli/chats_state.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steipete/wacli/internal/app"
+	"github.com/steipete/wacli/internal/out"
+	"github.com/steipete/wacli/internal/wa"
+	"go.mau.fi/whatsmeow/types"
+)
+
+type appHandle struct {
+	app *app.App
+	jid types.JID
+}
+
+type chatStateAction struct {
+	use   string
+	short string
+	run   func(ctx context.Context, a *appHandle, jid string) error
+}
+
+func newChatStateCmd(flags *rootFlags, action chatStateAction) *cobra.Command {
+	var jidStr string
+	cmd := &cobra.Command{
+		Use:   action.use,
+		Short: action.short,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(jidStr) == "" {
+				return fmt.Errorf("--jid is required")
+			}
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+
+			jid, err := wa.ParseUserOrJID(jidStr)
+			if err != nil {
+				return err
+			}
+
+			h := &appHandle{app: a, jid: jid}
+			if err := action.run(ctx, h, jidStr); err != nil {
+				return err
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"jid":    jid.String(),
+					"action": action.use,
+					"ok":     true,
+				})
+			}
+			fmt.Fprintln(os.Stdout, "OK")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&jidStr, "jid", "", "chat JID")
+	return cmd
+}
+
+func newChatsMuteCmd(flags *rootFlags) *cobra.Command {
+	var jidStr string
+	var durStr string
+	cmd := &cobra.Command{
+		Use:   "mute",
+		Short: "Mute a chat",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(jidStr) == "" {
+				return fmt.Errorf("--jid is required")
+			}
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+
+			jid, err := wa.ParseUserOrJID(jidStr)
+			if err != nil {
+				return err
+			}
+
+			var dur time.Duration
+			if strings.TrimSpace(durStr) != "" {
+				dur, err = time.ParseDuration(durStr)
+				if err != nil {
+					return fmt.Errorf("invalid --duration: %w", err)
+				}
+			}
+
+			if err := a.MuteChat(ctx, jid, true, dur); err != nil {
+				return err
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"jid":    jid.String(),
+					"action": "mute",
+					"ok":     true,
+				})
+			}
+			fmt.Fprintln(os.Stdout, "OK")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&jidStr, "jid", "", "chat JID")
+	cmd.Flags().StringVar(&durStr, "duration", "", "mute duration (e.g. 8h, 24h, 168h); empty = forever")
+	return cmd
+}

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -94,7 +94,7 @@ Immediately after QR pairing success, `wacli auth` runs a bootstrap sync:
 ### Tables (proposed)
 
 - `chats`
-  - `jid` (PK), `name`, `kind` (`dm|group|broadcast`), `last_message_ts`, …
+  - `jid` (PK), `name`, `kind` (`dm|group|broadcast`), `last_message_ts`, `archived`, `pinned`, `muted_until`, `unread`
 - `contacts`
   - `jid` (PK), `push_name`, `full_name`, `business_name`, `phone`, …
 - `groups`
@@ -185,8 +185,16 @@ WhatsApp Web history is best-effort. If you want to try fetching *older* message
 
 ### Chats
 
-- `wacli chats list [--query TEXT]`
+- `wacli chats list [--query TEXT] [--limit N] [--archived] [--no-archived] [--pinned] [--no-pinned] [--muted] [--no-muted] [--unread] [--no-unread]`
 - `wacli chats show --jid JID`
+- `wacli chats archive --jid JID`
+- `wacli chats unarchive --jid JID`
+- `wacli chats pin --jid JID`
+- `wacli chats unpin --jid JID`
+- `wacli chats mute --jid JID [--duration DURATION]`
+- `wacli chats unmute --jid JID`
+- `wacli chats mark-read --jid JID`
+- `wacli chats mark-unread --jid JID`
 
 ### Groups
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/steipete/wacli/internal/wa"
 	"go.mau.fi/whatsmeow"
 	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/proto/waCommon"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 )
@@ -45,6 +46,11 @@ type WAClient interface {
 	DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error)
 	RequestHistorySyncOnDemand(ctx context.Context, lastKnown types.MessageInfo, count int) (types.MessageID, error)
 	Logout(ctx context.Context) error
+
+	ArchiveChat(ctx context.Context, target types.JID, archive bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey) error
+	PinChat(ctx context.Context, target types.JID, pin bool) error
+	MuteChat(ctx context.Context, target types.JID, mute bool, duration time.Duration) error
+	MarkChatAsRead(ctx context.Context, target types.JID, read bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey) error
 }
 
 type Options struct {

--- a/internal/app/chat_state.go
+++ b/internal/app/chat_state.go
@@ -1,0 +1,44 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+func (a *App) ArchiveChat(ctx context.Context, jid types.JID, archive bool) error {
+	if err := a.wa.ArchiveChat(ctx, jid, archive, time.Time{}, nil); err != nil {
+		return err
+	}
+	return a.db.SetChatArchived(jid.String(), archive)
+}
+
+func (a *App) PinChat(ctx context.Context, jid types.JID, pin bool) error {
+	if err := a.wa.PinChat(ctx, jid, pin); err != nil {
+		return err
+	}
+	return a.db.SetChatPinned(jid.String(), pin)
+}
+
+func (a *App) MuteChat(ctx context.Context, jid types.JID, mute bool, duration time.Duration) error {
+	if err := a.wa.MuteChat(ctx, jid, mute, duration); err != nil {
+		return err
+	}
+	var mu int64
+	if mute {
+		if duration <= 0 {
+			mu = -1
+		} else {
+			mu = time.Now().Add(duration).Unix()
+		}
+	}
+	return a.db.SetChatMutedUntil(jid.String(), mu)
+}
+
+func (a *App) MarkChatRead(ctx context.Context, jid types.JID, read bool) error {
+	if err := a.wa.MarkChatAsRead(ctx, jid, read, time.Time{}, nil); err != nil {
+		return err
+	}
+	return a.db.SetChatUnread(jid.String(), !read)
+}

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/steipete/wacli/internal/wa"
 	"go.mau.fi/whatsmeow"
 	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/proto/waCommon"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 )
@@ -248,5 +249,21 @@ func (f *fakeWA) Logout(ctx context.Context) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.authed = false
+	return nil
+}
+
+func (f *fakeWA) ArchiveChat(ctx context.Context, target types.JID, archive bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey) error {
+	return nil
+}
+
+func (f *fakeWA) PinChat(ctx context.Context, target types.JID, pin bool) error {
+	return nil
+}
+
+func (f *fakeWA) MuteChat(ctx context.Context, target types.JID, mute bool, duration time.Duration) error {
+	return nil
+}
+
+func (f *fakeWA) MarkChatAsRead(ctx context.Context, target types.JID, read bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey) error {
 	return nil
 }

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -8,10 +8,18 @@ import (
 )
 
 type Chat struct {
-	JID           string
-	Kind          string
-	Name          string
-	LastMessageTS time.Time
+	JID           string    `json:"jid"`
+	Kind          string    `json:"kind"`
+	Name          string    `json:"name"`
+	LastMessageTS time.Time `json:"last_message_ts"`
+	Archived      bool      `json:"archived"`
+	Pinned        bool      `json:"pinned"`
+	MutedUntil    int64     `json:"muted_until"`
+	Unread        bool      `json:"unread"`
+}
+
+func (c Chat) Muted() bool {
+	return c.MutedUntil == -1 || (c.MutedUntil > 0 && time.Now().Unix() < c.MutedUntil)
 }
 
 type Group struct {

--- a/internal/wa/appstate.go
+++ b/internal/wa/appstate.go
@@ -1,0 +1,37 @@
+package wa
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.mau.fi/whatsmeow/appstate"
+	"go.mau.fi/whatsmeow/proto/waCommon"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func (c *Client) SendAppState(ctx context.Context, patch appstate.PatchInfo) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	return cli.SendAppState(ctx, patch)
+}
+
+func (c *Client) ArchiveChat(ctx context.Context, target types.JID, archive bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey) error {
+	return c.SendAppState(ctx, appstate.BuildArchive(target, archive, lastMsgTS, lastMsgKey))
+}
+
+func (c *Client) PinChat(ctx context.Context, target types.JID, pin bool) error {
+	return c.SendAppState(ctx, appstate.BuildPin(target, pin))
+}
+
+func (c *Client) MuteChat(ctx context.Context, target types.JID, mute bool, duration time.Duration) error {
+	return c.SendAppState(ctx, appstate.BuildMute(target, mute, duration))
+}
+
+func (c *Client) MarkChatAsRead(ctx context.Context, target types.JID, read bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey) error {
+	return c.SendAppState(ctx, appstate.BuildMarkChatAsRead(target, read, lastMsgTS, lastMsgKey))
+}


### PR DESCRIPTION
## Summary

- **8 new subcommands**: `chats archive/unarchive`, `pin/unpin`, `mute/unmute` (with `--duration`), `mark-read/mark-unread`
- **`chats list` gains filter flags**: `--archived`, `--pinned`, `--muted`, `--unread` (and `--no-*` negations), plus a FLAGS column and pinned-first sort order
- **`chats show` displays state fields**: Archived, Pinned, Muted, Unread
- **Bidirectional sync**: inbound via `events.Archive/Pin/Mute/MarkChatAsRead` during bootstrap and live follow; outbound via whatsmeow `SendAppState` + builder functions

## Changes

| Layer | Files | What |
|-------|-------|------|
| Store | `migrations.go`, `types.go`, `chats_contacts_groups.go` | Migration v4 (4 new columns), `ChatListFilter` struct, `ListChats`/`GetChat` extended, 4 setter methods, `Muted()` helper |
| WA | `appstate.go` (new) | Thin wrappers around whatsmeow appstate builders |
| App | `app.go`, `chat_state.go` (new), `sync.go`, `fake_wa_test.go` | Interface extended, 4 convenience methods, 4 event handler cases, mock updated |
| CLI | `chats.go`, `chats_state.go` (new) | Filter flags, FLAGS column, DRY command factory for 8 subcommands |
| Tests | `store_test.go`, `sync_test.go` | State columns, `Muted()` method, list filters, migration idempotency, sync event handling |
| Docs | `spec.md`, `CHANGELOG.md` | Schema + CLI docs updated, changelog entries |

## Test plan

- [x] `go build ./...` — compiles
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass (new tests: `TestChatStateColumns`, `TestChatMutedMethod`, `TestListChatsFilters`, `TestMigrationIdempotent`, `TestSyncChatStateEvents`)
- [x] Smoke: `chats list --limit 5` — FLAGS column visible
- [x] Smoke: `chats list --json` — all 4 fields present
- [x] Smoke: `chats show --jid <jid>` — state lines displayed
- [x] Smoke: all filter flags (`--archived`, `--pinned`, `--muted`, `--unread`, `--no-*`)
- [x] Smoke: mutual exclusion errors (`--archived --no-archived`)
- [x] Live: archive → verify in list → **confirmed on phone** → unarchive
- [x] Live: pin → pinned-first sort → unpin
- [x] Live: mute with `--duration 1h` → mute forever → unmute
- [x] Live: mark-unread → mark-read
- [x] Live: combined flags (pin + mute)
- [x] Live: JSON output on write commands
- [x] DB migration safe: new binary against existing DB adds columns without data loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)