### PR TITLE
feat: add `wacli agent` — JSON-RPC 2.0 mode for AI agents

### DIFF
--- a/cmd/wacli/agent.go
+++ b/cmd/wacli/agent.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"github.com/steipete/wacli/internal/app"
+)
+
+func newAgentCmd(flags *rootFlags) *cobra.Command {
+	var autoPresence bool
+
+	cmd := &cobra.Command{
+		Use:   "agent",
+		Short: "Run as a JSON-RPC 2.0 agent (stdin/stdout)",
+		Long: `Start a long-running agent that communicates via JSON-RPC 2.0 over NDJSON.
+
+Reads requests from stdin and writes responses/notifications to stdout.
+Logs and errors go to stderr. Requires prior authentication (wacli auth).
+
+Use --auto-presence to simulate human-like presence when sending messages
+(goes online, shows typing indicator, sends, goes offline).`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+
+			return a.RunAgent(ctx, os.Stdin, os.Stdout, app.AgentOptions{
+				AutoPresence: autoPresence,
+				TypingDelay:  autoPresence,
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&autoPresence, "auto-presence", true, "simulate human-like presence when sending messages")
+	return cmd
+}

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -49,6 +49,7 @@ func execute(args []string) error {
 	rootCmd.AddCommand(newChatsCmd(&flags))
 	rootCmd.AddCommand(newGroupsCmd(&flags))
 	rootCmd.AddCommand(newHistoryCmd(&flags))
+	rootCmd.AddCommand(newAgentCmd(&flags))
 
 	rootCmd.SetArgs(args)
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/wacli/sync.go
+++ b/cmd/wacli/sync.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -20,6 +22,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var downloadMedia bool
 	var refreshContacts bool
 	var refreshGroups bool
+	var stream bool
 
 	cmd := &cobra.Command{
 		Use:   "sync",
@@ -47,14 +50,25 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 				mode = appPkg.SyncModeOnce
 			}
 
-			res, err := a.Sync(ctx, appPkg.SyncOptions{
+			syncOpts := appPkg.SyncOptions{
 				Mode:            mode,
 				AllowQR:         false,
 				DownloadMedia:   downloadMedia,
 				RefreshContacts: refreshContacts,
 				RefreshGroups:   refreshGroups,
 				IdleExit:        idleExit,
-			})
+			}
+			if stream {
+				enc := json.NewEncoder(os.Stdout)
+				var mu sync.Mutex
+				syncOpts.OnMessage = func(sm appPkg.StreamMessage) {
+					mu.Lock()
+					defer mu.Unlock()
+					_ = enc.Encode(sm)
+				}
+			}
+
+			res, err := a.Sync(ctx, syncOpts)
 			if err != nil {
 				return err
 			}
@@ -76,5 +90,6 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().BoolVar(&downloadMedia, "download-media", false, "download media in the background during sync")
 	cmd.Flags().BoolVar(&refreshContacts, "refresh-contacts", false, "refresh contacts from session store into local DB")
 	cmd.Flags().BoolVar(&refreshGroups, "refresh-groups", false, "refresh joined groups (live) into local DB")
+	cmd.Flags().BoolVar(&stream, "stream", false, "emit each message as a JSON line to stdout")
 	return cmd
 }

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -1,0 +1,650 @@
+package app
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/steipete/wacli/internal/store"
+	"github.com/steipete/wacli/internal/wa"
+	"go.mau.fi/whatsmeow"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+)
+
+// AgentOptions configures the agent loop.
+type AgentOptions struct {
+	AutoPresence bool
+	TypingDelay  bool
+}
+
+// RunAgent starts the JSON-RPC 2.0 agent loop, reading requests from r and
+// writing responses/notifications to w. It blocks until ctx is cancelled or
+// stdin reaches EOF.
+func (a *App) RunAgent(ctx context.Context, r io.Reader, w io.Writer, opts AgentOptions) error {
+	if err := a.OpenWA(); err != nil {
+		return err
+	}
+	if !a.wa.IsAuthed() {
+		return fmt.Errorf("not authenticated; run `wacli auth`")
+	}
+
+	writer := newRPCWriter(w)
+
+	// Register event handler before connecting.
+	handlerID := a.wa.AddEventHandler(func(evt interface{}) {
+		a.handleAgentEvent(ctx, writer, evt)
+	})
+	defer a.wa.RemoveEventHandler(handlerID)
+
+	if err := a.Connect(ctx, false, nil); err != nil {
+		return err
+	}
+
+	// Start offline and force delivery receipts.
+	_ = a.wa.SendPresence(ctx, types.PresenceUnavailable)
+	a.wa.SetForceActiveDeliveryReceipts(true)
+
+	writer.notify("agent.ready", map[string]any{
+		"version": a.opts.Version,
+	})
+
+	// Read stdin line-by-line (NDJSON) for robust error recovery.
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return nil
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var req rpcRequest
+		if err := json.Unmarshal([]byte(line), &req); err != nil {
+			writer.respondError(nil, errCodeParse, "parse error: "+err.Error())
+			continue
+		}
+		if req.JSONRPC != "2.0" {
+			writer.respondError(req.ID, errCodeParse, "invalid jsonrpc version")
+			continue
+		}
+		a.dispatchRPC(ctx, writer, req, opts)
+	}
+	return nil
+}
+
+func (a *App) dispatchRPC(ctx context.Context, w *rpcWriter, req rpcRequest, opts AgentOptions) {
+	switch req.Method {
+	case "send_text":
+		a.rpcSendText(ctx, w, req, opts)
+	case "send_file":
+		a.rpcSendFile(ctx, w, req, opts)
+	case "mark_read":
+		a.rpcMarkRead(ctx, w, req)
+	case "set_typing":
+		a.rpcSetTyping(ctx, w, req)
+	case "set_presence":
+		a.rpcSetPresence(ctx, w, req)
+	case "list_chats":
+		a.rpcListChats(ctx, w, req)
+	case "list_messages":
+		a.rpcListMessages(ctx, w, req)
+	case "search":
+		a.rpcSearch(ctx, w, req)
+	case "get_message":
+		a.rpcGetMessage(ctx, w, req)
+	default:
+		w.respondError(req.ID, errCodeMethodNotFound, "method not found: "+req.Method)
+	}
+}
+
+// --- RPC handlers ---
+
+func (a *App) rpcSendText(ctx context.Context, w *rpcWriter, req rpcRequest, opts AgentOptions) {
+	var p struct {
+		To   string `json:"to"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		w.respondError(req.ID, errCodeInvalidParams, "invalid params: "+err.Error())
+		return
+	}
+	if p.To == "" || p.Text == "" {
+		w.respondError(req.ID, errCodeInvalidParams, "to and text are required")
+		return
+	}
+	toJID, err := wa.ParseUserOrJID(p.To)
+	if err != nil {
+		w.respondError(req.ID, errCodeInvalidParams, "invalid to: "+err.Error())
+		return
+	}
+
+	if opts.AutoPresence {
+		a.simulateTyping(ctx, toJID, p.Text)
+	}
+
+	msgID, err := a.wa.SendText(ctx, toJID, p.Text)
+	if err != nil {
+		w.respondError(req.ID, errCodeSendFailed, "send failed: "+err.Error())
+		return
+	}
+
+	if opts.AutoPresence {
+		_ = a.wa.SendPresence(ctx, types.PresenceUnavailable)
+	}
+
+	// Persist sent message locally.
+	now := time.Now().UTC()
+	chatName := a.wa.ResolveChatName(ctx, toJID, "")
+	_ = a.db.UpsertChat(toJID.String(), chatKind(toJID), chatName, now)
+	_ = a.db.UpsertMessage(store.UpsertMessageParams{
+		ChatJID:    toJID.String(),
+		ChatName:   chatName,
+		MsgID:      string(msgID),
+		SenderName: "me",
+		Timestamp:  now,
+		FromMe:     true,
+		Text:       p.Text,
+	})
+
+	w.respond(req.ID, map[string]any{"message_id": msgID})
+}
+
+func (a *App) rpcSendFile(ctx context.Context, w *rpcWriter, req rpcRequest, opts AgentOptions) {
+	var p struct {
+		To       string `json:"to"`
+		File     string `json:"file"`
+		Filename string `json:"filename"`
+		Caption  string `json:"caption"`
+		Mime     string `json:"mime"`
+	}
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		w.respondError(req.ID, errCodeInvalidParams, "invalid params: "+err.Error())
+		return
+	}
+	if p.To == "" || p.File == "" {
+		w.respondError(req.ID, errCodeInvalidParams, "to and file are required")
+		return
+	}
+	toJID, err := wa.ParseUserOrJID(p.To)
+	if err != nil {
+		w.respondError(req.ID, errCodeInvalidParams, "invalid to: "+err.Error())
+		return
+	}
+
+	data, err := os.ReadFile(p.File)
+	if err != nil {
+		w.respondError(req.ID, errCodeInvalidParams, "read file: "+err.Error())
+		return
+	}
+
+	name := strings.TrimSpace(p.Filename)
+	if name == "" {
+		name = filepath.Base(p.File)
+	}
+	mimeType := strings.TrimSpace(p.Mime)
+	if mimeType == "" {
+		mimeType = mime.TypeByExtension(strings.ToLower(filepath.Ext(p.File)))
+	}
+	if mimeType == "" {
+		sniff := data
+		if len(sniff) > 512 {
+			sniff = sniff[:512]
+		}
+		mimeType = http.DetectContentType(sniff)
+	}
+
+	mediaType := "document"
+	uploadType, _ := wa.MediaTypeFromString("document")
+	switch {
+	case strings.HasPrefix(mimeType, "image/"):
+		mediaType = "image"
+		uploadType, _ = wa.MediaTypeFromString("image")
+	case strings.HasPrefix(mimeType, "video/"):
+		mediaType = "video"
+		uploadType, _ = wa.MediaTypeFromString("video")
+	case strings.HasPrefix(mimeType, "audio/"):
+		mediaType = "audio"
+		uploadType, _ = wa.MediaTypeFromString("audio")
+	}
+
+	if opts.AutoPresence {
+		a.simulateTyping(ctx, toJID, "file")
+	}
+
+	up, err := a.wa.Upload(ctx, data, uploadType)
+	if err != nil {
+		w.respondError(req.ID, errCodeSendFailed, "upload failed: "+err.Error())
+		return
+	}
+
+	msg := buildMediaProto(mediaType, mimeType, name, p.Caption, up)
+	msgID, err := a.wa.SendProtoMessage(ctx, toJID, msg)
+	if err != nil {
+		w.respondError(req.ID, errCodeSendFailed, "send failed: "+err.Error())
+		return
+	}
+
+	if opts.AutoPresence {
+		_ = a.wa.SendPresence(ctx, types.PresenceUnavailable)
+	}
+
+	now := time.Now().UTC()
+	chatName := a.wa.ResolveChatName(ctx, toJID, "")
+	_ = a.db.UpsertChat(toJID.String(), chatKind(toJID), chatName, now)
+	_ = a.db.UpsertMessage(store.UpsertMessageParams{
+		ChatJID:       toJID.String(),
+		ChatName:      chatName,
+		MsgID:         msgID,
+		SenderName:    "me",
+		Timestamp:     now,
+		FromMe:        true,
+		Text:          p.Caption,
+		MediaType:     mediaType,
+		MediaCaption:  p.Caption,
+		Filename:      name,
+		MimeType:      mimeType,
+		DirectPath:    up.DirectPath,
+		MediaKey:      up.MediaKey,
+		FileSHA256:    up.FileSHA256,
+		FileEncSHA256: up.FileEncSHA256,
+		FileLength:    up.FileLength,
+	})
+
+	w.respond(req.ID, map[string]any{"message_id": msgID, "media_type": mediaType})
+}
+
+func (a *App) rpcMarkRead(ctx context.Context, w *rpcWriter, req rpcRequest) {
+	var p struct {
+		Chat       string   `json:"chat"`
+		MessageIDs []string `json:"message_ids"`
+		Sender     string   `json:"sender"`
+	}
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		w.respondError(req.ID, errCodeInvalidParams, "invalid params: "+err.Error())
+		return
+	}
+	if p.Chat == "" || len(p.MessageIDs) == 0 {
+		w.respondError(req.ID, errCodeInvalidParams, "chat and message_ids are required")
+		return
+	}
+	chatJID, err := wa.ParseUserOrJID(p.Chat)
+	if err != nil {
+		w.respondError(req.ID, errCodeInvalidParams, "invalid chat: "+err.Error())
+		return
+	}
+	ids := make([]types.MessageID, len(p.MessageIDs))
+	for i, id := range p.MessageIDs {
+		ids[i] = types.MessageID(id)
+	}
+	var senderJID types.JID
+	if p.Sender != "" {
+		senderJID, err = wa.ParseUserOrJID(p.Sender)
+		if err != nil {
+			w.respondError(req.ID, errCodeInvalidParams, "invalid sender: "+err.Error())
+			return
+		}
+	}
+	if err := a.wa.MarkRead(ctx, ids, time.Now(), chatJID, senderJID); err != nil {
+		w.respondError(req.ID, errCodeSendFailed, "mark read failed: "+err.Error())
+		return
+	}
+	w.respond(req.ID, map[string]any{})
+}
+
+func (a *App) rpcSetTyping(ctx context.Context, w *rpcWriter, req rpcRequest) {
+	var p struct {
+		Chat  string `json:"chat"`
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		w.respondError(req.ID, errCodeInvalidParams, "invalid params: "+err.Error())
+		return
+	}
+	if p.Chat == "" || p.State == "" {
+		w.respondError(req.ID, errCodeInvalidParams, "chat and state are required")
+		return
+	}
+	chatJID, err := wa.ParseUserOrJID(p.Chat)
+	if err != nil {
+		w.respondError(req.ID, errCodeInvalidParams, "invalid chat: "+err.Error())
+		return
+	}
+	var state types.ChatPresence
+	switch p.State {
+	case "composing":
+		state = types.ChatPresenceComposing
+	case "paused":
+		state = types.ChatPresencePaused
+	default:
+		w.respondError(req.ID, errCodeInvalidParams, "state must be composing or paused")
+		return
+	}
+	if err := a.wa.SendChatPresence(ctx, chatJID, state, ""); err != nil {
+		w.respondError(req.ID, errCodeSendFailed, "set typing failed: "+err.Error())
+		return
+	}
+	w.respond(req.ID, map[string]any{})
+}
+
+func (a *App) rpcSetPresence(ctx context.Context, w *rpcWriter, req rpcRequest) {
+	var p struct {
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		w.respondError(req.ID, errCodeInvalidParams, "invalid params: "+err.Error())
+		return
+	}
+	var state types.Presence
+	switch p.State {
+	case "available":
+		state = types.PresenceAvailable
+	case "unavailable":
+		state = types.PresenceUnavailable
+	default:
+		w.respondError(req.ID, errCodeInvalidParams, "state must be available or unavailable")
+		return
+	}
+	if err := a.wa.SendPresence(ctx, state); err != nil {
+		w.respondError(req.ID, errCodeSendFailed, "set presence failed: "+err.Error())
+		return
+	}
+	w.respond(req.ID, map[string]any{})
+}
+
+func (a *App) rpcListChats(ctx context.Context, w *rpcWriter, req rpcRequest) {
+	var p struct {
+		Limit int    `json:"limit"`
+		Query string `json:"query"`
+	}
+	if req.Params != nil {
+		if err := json.Unmarshal(req.Params, &p); err != nil {
+			w.respondError(req.ID, errCodeInvalidParams, "invalid params: "+err.Error())
+			return
+		}
+	}
+	chats, err := a.db.ListChats(p.Query, p.Limit)
+	if err != nil {
+		w.respondError(req.ID, errCodeSendFailed, "list chats: "+err.Error())
+		return
+	}
+	out := make([]map[string]any, len(chats))
+	for i, c := range chats {
+		out[i] = map[string]any{
+			"jid":             c.JID,
+			"name":            c.Name,
+			"kind":            c.Kind,
+			"last_message_ts": c.LastMessageTS.Unix(),
+		}
+	}
+	w.respond(req.ID, out)
+}
+
+func (a *App) rpcListMessages(ctx context.Context, w *rpcWriter, req rpcRequest) {
+	var p struct {
+		Chat   string `json:"chat"`
+		Limit  int    `json:"limit"`
+		Before *int64 `json:"before"`
+		After  *int64 `json:"after"`
+	}
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		w.respondError(req.ID, errCodeInvalidParams, "invalid params: "+err.Error())
+		return
+	}
+	if p.Chat == "" {
+		w.respondError(req.ID, errCodeInvalidParams, "chat is required")
+		return
+	}
+	params := store.ListMessagesParams{
+		ChatJID: p.Chat,
+		Limit:   p.Limit,
+	}
+	if p.Before != nil {
+		t := time.Unix(*p.Before, 0).UTC()
+		params.Before = &t
+	}
+	if p.After != nil {
+		t := time.Unix(*p.After, 0).UTC()
+		params.After = &t
+	}
+	msgs, err := a.db.ListMessages(params)
+	if err != nil {
+		w.respondError(req.ID, errCodeSendFailed, "list messages: "+err.Error())
+		return
+	}
+	w.respond(req.ID, messagesToJSON(msgs))
+}
+
+func (a *App) rpcSearch(ctx context.Context, w *rpcWriter, req rpcRequest) {
+	var p struct {
+		Query string `json:"query"`
+		Chat  string `json:"chat"`
+		From  string `json:"from"`
+		Limit int    `json:"limit"`
+	}
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		w.respondError(req.ID, errCodeInvalidParams, "invalid params: "+err.Error())
+		return
+	}
+	if p.Query == "" {
+		w.respondError(req.ID, errCodeInvalidParams, "query is required")
+		return
+	}
+	msgs, err := a.db.SearchMessages(store.SearchMessagesParams{
+		Query:   p.Query,
+		ChatJID: p.Chat,
+		From:    p.From,
+		Limit:   p.Limit,
+	})
+	if err != nil {
+		w.respondError(req.ID, errCodeSendFailed, "search: "+err.Error())
+		return
+	}
+	w.respond(req.ID, messagesToJSON(msgs))
+}
+
+func (a *App) rpcGetMessage(ctx context.Context, w *rpcWriter, req rpcRequest) {
+	var p struct {
+		Chat string `json:"chat"`
+		ID   string `json:"id"`
+	}
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		w.respondError(req.ID, errCodeInvalidParams, "invalid params: "+err.Error())
+		return
+	}
+	if p.Chat == "" || p.ID == "" {
+		w.respondError(req.ID, errCodeInvalidParams, "chat and id are required")
+		return
+	}
+	msg, err := a.db.GetMessage(p.Chat, p.ID)
+	if err != nil {
+		if store.IsNotFound(err) {
+			w.respondError(req.ID, errCodeInvalidParams, "message not found")
+		} else {
+			w.respondError(req.ID, errCodeSendFailed, "get message: "+err.Error())
+		}
+		return
+	}
+	w.respond(req.ID, messageToJSON(msg))
+}
+
+// --- Event handler ---
+
+func (a *App) handleAgentEvent(ctx context.Context, w *rpcWriter, evt interface{}) {
+	switch v := evt.(type) {
+	case *events.Message:
+		pm := wa.ParseLiveMessage(v)
+		if sm, err := a.storeParsedMessage(ctx, pm); err == nil {
+			w.notify("message", streamMessageToJSON(sm))
+		}
+	case *events.HistorySync:
+		for _, conv := range v.Data.Conversations {
+			chatID := strings.TrimSpace(conv.GetID())
+			if chatID == "" {
+				continue
+			}
+			for _, m := range conv.Messages {
+				if m.Message == nil {
+					continue
+				}
+				pm := wa.ParseHistoryMessage(chatID, m.Message)
+				if pm.ID == "" || pm.Chat.IsEmpty() {
+					continue
+				}
+				if sm, err := a.storeParsedMessage(ctx, pm); err == nil {
+					w.notify("message", streamMessageToJSON(sm))
+				}
+			}
+		}
+	case *events.Receipt:
+		w.notify("receipt", map[string]any{
+			"chat_jid":    v.Chat.String(),
+			"sender_jid":  v.Sender.String(),
+			"message_ids": v.MessageIDs,
+			"type":        string(v.Type),
+			"timestamp":   v.Timestamp.Unix(),
+		})
+	case *events.Presence:
+		w.notify("presence", map[string]any{
+			"from_jid":    v.From.String(),
+			"unavailable": v.Unavailable,
+			"last_seen":   v.LastSeen.Unix(),
+		})
+	case *events.ChatPresence:
+		w.notify("chat_presence", map[string]any{
+			"chat_jid":   v.Chat.String(),
+			"sender_jid": v.Sender.String(),
+			"state":      string(v.State),
+			"media":      string(v.Media),
+		})
+	case *events.Connected:
+		w.notify("connection", map[string]any{"state": "connected"})
+	case *events.Disconnected:
+		w.notify("connection", map[string]any{"state": "disconnected"})
+	}
+}
+
+// --- Typing simulation ---
+
+func (a *App) simulateTyping(ctx context.Context, chat types.JID, text string) {
+	_ = a.wa.SendPresence(ctx, types.PresenceAvailable)
+	_ = a.wa.SendChatPresence(ctx, chat, types.ChatPresenceComposing, "")
+
+	delay := time.Duration(len(text)) * 30 * time.Millisecond
+	if delay < 500*time.Millisecond {
+		delay = 500 * time.Millisecond
+	}
+	if delay > 3*time.Second {
+		delay = 3 * time.Second
+	}
+
+	select {
+	case <-time.After(delay):
+	case <-ctx.Done():
+	}
+
+	_ = a.wa.SendChatPresence(ctx, chat, types.ChatPresencePaused, "")
+}
+
+// --- Helpers ---
+
+func messagesToJSON(msgs []store.Message) []map[string]any {
+	out := make([]map[string]any, len(msgs))
+	for i, m := range msgs {
+		out[i] = messageToJSON(m)
+	}
+	return out
+}
+
+func messageToJSON(m store.Message) map[string]any {
+	return map[string]any{
+		"chat_jid":     m.ChatJID,
+		"chat_name":    m.ChatName,
+		"msg_id":       m.MsgID,
+		"sender_jid":   m.SenderJID,
+		"timestamp":    m.Timestamp.Unix(),
+		"from_me":      m.FromMe,
+		"text":         m.Text,
+		"display_text": m.DisplayText,
+		"media_type":   m.MediaType,
+	}
+}
+
+func streamMessageToJSON(sm StreamMessage) map[string]any {
+	return map[string]any{
+		"chat_jid":     sm.ChatJID,
+		"chat_name":    sm.ChatName,
+		"msg_id":       sm.MsgID,
+		"sender_jid":   sm.SenderJID,
+		"sender_name":  sm.SenderName,
+		"timestamp":    sm.Timestamp,
+		"from_me":      sm.FromMe,
+		"text":         sm.Text,
+		"display_text": sm.DisplayText,
+		"media_type":   sm.MediaType,
+	}
+}
+
+func buildMediaProto(mediaType, mimeType, name, caption string, up whatsmeow.UploadResponse) *waProto.Message {
+	msg := &waProto.Message{}
+	switch mediaType {
+	case "image":
+		msg.ImageMessage = &waProto.ImageMessage{
+			URL:           proto.String(up.URL),
+			DirectPath:    proto.String(up.DirectPath),
+			MediaKey:      up.MediaKey,
+			FileEncSHA256: up.FileEncSHA256,
+			FileSHA256:    up.FileSHA256,
+			FileLength:    proto.Uint64(up.FileLength),
+			Mimetype:      proto.String(mimeType),
+			Caption:       proto.String(caption),
+		}
+	case "video":
+		msg.VideoMessage = &waProto.VideoMessage{
+			URL:           proto.String(up.URL),
+			DirectPath:    proto.String(up.DirectPath),
+			MediaKey:      up.MediaKey,
+			FileEncSHA256: up.FileEncSHA256,
+			FileSHA256:    up.FileSHA256,
+			FileLength:    proto.Uint64(up.FileLength),
+			Mimetype:      proto.String(mimeType),
+			Caption:       proto.String(caption),
+		}
+	case "audio":
+		msg.AudioMessage = &waProto.AudioMessage{
+			URL:           proto.String(up.URL),
+			DirectPath:    proto.String(up.DirectPath),
+			MediaKey:      up.MediaKey,
+			FileEncSHA256: up.FileEncSHA256,
+			FileSHA256:    up.FileSHA256,
+			FileLength:    proto.Uint64(up.FileLength),
+			Mimetype:      proto.String(mimeType),
+			PTT:           proto.Bool(false),
+		}
+	default:
+		msg.DocumentMessage = &waProto.DocumentMessage{
+			URL:           proto.String(up.URL),
+			DirectPath:    proto.String(up.DirectPath),
+			MediaKey:      up.MediaKey,
+			FileEncSHA256: up.FileEncSHA256,
+			FileSHA256:    up.FileSHA256,
+			FileLength:    proto.Uint64(up.FileLength),
+			Mimetype:      proto.String(mimeType),
+			FileName:      proto.String(name),
+			Caption:       proto.String(caption),
+			Title:         proto.String(name),
+		}
+	}
+	return msg
+}

--- a/internal/app/agent_test.go
+++ b/internal/app/agent_test.go
@@ -1,0 +1,449 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steipete/wacli/internal/store"
+)
+
+func newAgentTestApp(t *testing.T) (*App, *fakeWA) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "wacli.db")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	fw := newFakeWA()
+	return &App{
+		opts: Options{StoreDir: dir, Version: "0.5.0-test"},
+		wa:   fw,
+		db:   db,
+	}, fw
+}
+
+func TestAgentReady(t *testing.T) {
+	a, _ := newAgentTestApp(t)
+
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Empty stdin → agent reads EOF and exits.
+	err := a.RunAgent(ctx, strings.NewReader(""), &out, AgentOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should contain both connection and agent.ready notifications.
+	dec := json.NewDecoder(&out)
+	found := false
+	for {
+		var notif rpcNotification
+		if err := dec.Decode(&notif); err != nil {
+			break
+		}
+		if notif.Method == "agent.ready" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected agent.ready notification")
+	}
+}
+
+func TestAgentListChats(t *testing.T) {
+	a, _ := newAgentTestApp(t)
+
+	// Seed a chat.
+	_ = a.db.UpsertChat("5511999@s.whatsapp.net", "dm", "Alice", time.Now())
+
+	req := `{"jsonrpc":"2.0","id":1,"method":"list_chats","params":{"limit":10}}` + "\n"
+
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := a.RunAgent(ctx, strings.NewReader(req), &out, AgentOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Parse: first line is agent.ready, second line is the response.
+	dec := json.NewDecoder(&out)
+
+	// Skip agent.ready
+	var notif rpcNotification
+	if err := dec.Decode(&notif); err != nil {
+		t.Fatal(err)
+	}
+
+	// Skip connection notification
+	var notif2 rpcNotification
+	if err := dec.Decode(&notif2); err != nil {
+		t.Fatal(err)
+	}
+
+	var resp rpcResponse
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+
+	// Result should be an array with one chat.
+	data, _ := json.Marshal(resp.Result)
+	var chats []map[string]any
+	if err := json.Unmarshal(data, &chats); err != nil {
+		t.Fatal(err)
+	}
+	if len(chats) != 1 {
+		t.Fatalf("expected 1 chat, got %d", len(chats))
+	}
+	if chats[0]["name"] != "Alice" {
+		t.Fatalf("expected name Alice, got %v", chats[0]["name"])
+	}
+}
+
+func TestAgentSendText(t *testing.T) {
+	a, _ := newAgentTestApp(t)
+
+	req := `{"jsonrpc":"2.0","id":2,"method":"send_text","params":{"to":"5511999@s.whatsapp.net","text":"hello"}}` + "\n"
+
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := a.RunAgent(ctx, strings.NewReader(req), &out, AgentOptions{AutoPresence: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dec := json.NewDecoder(&out)
+
+	// Skip agent.ready
+	var notif rpcNotification
+	if err := dec.Decode(&notif); err != nil {
+		t.Fatal(err)
+	}
+	// Skip connection notification
+	var notif2 rpcNotification
+	if err := dec.Decode(&notif2); err != nil {
+		t.Fatal(err)
+	}
+
+	var resp rpcResponse
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+
+	data, _ := json.Marshal(resp.Result)
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["message_id"] == nil || result["message_id"] == "" {
+		t.Fatal("expected non-empty message_id")
+	}
+}
+
+func TestAgentMethodNotFound(t *testing.T) {
+	a, _ := newAgentTestApp(t)
+
+	req := `{"jsonrpc":"2.0","id":3,"method":"bogus","params":{}}` + "\n"
+
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := a.RunAgent(ctx, strings.NewReader(req), &out, AgentOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dec := json.NewDecoder(&out)
+
+	// Skip agent.ready
+	var notif rpcNotification
+	if err := dec.Decode(&notif); err != nil {
+		t.Fatal(err)
+	}
+	// Skip connection notification
+	var notif2 rpcNotification
+	if err := dec.Decode(&notif2); err != nil {
+		t.Fatal(err)
+	}
+
+	var resp rpcResponse
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error response")
+	}
+	if resp.Error.Code != errCodeMethodNotFound {
+		t.Fatalf("expected code %d, got %d", errCodeMethodNotFound, resp.Error.Code)
+	}
+}
+
+func TestAgentSearch(t *testing.T) {
+	a, _ := newAgentTestApp(t)
+
+	// Seed a message.
+	_ = a.db.UpsertChat("5511999@s.whatsapp.net", "dm", "Alice", time.Now())
+	_ = a.db.UpsertMessage(store.UpsertMessageParams{
+		ChatJID:   "5511999@s.whatsapp.net",
+		ChatName:  "Alice",
+		MsgID:     "msg1",
+		Timestamp: time.Now(),
+		FromMe:    false,
+		Text:      "hello world",
+	})
+
+	req := `{"jsonrpc":"2.0","id":4,"method":"search","params":{"query":"hello"}}` + "\n"
+
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := a.RunAgent(ctx, strings.NewReader(req), &out, AgentOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dec := json.NewDecoder(&out)
+	// Skip agent.ready
+	var notif rpcNotification
+	if err := dec.Decode(&notif); err != nil {
+		t.Fatal(err)
+	}
+	// Skip connection notification
+	var notif2 rpcNotification
+	if err := dec.Decode(&notif2); err != nil {
+		t.Fatal(err)
+	}
+
+	var resp rpcResponse
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+
+	data, _ := json.Marshal(resp.Result)
+	var msgs []map[string]any
+	if err := json.Unmarshal(data, &msgs); err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) == 0 {
+		t.Fatal("expected at least 1 search result")
+	}
+}
+
+func TestAgentGetMessage(t *testing.T) {
+	a, _ := newAgentTestApp(t)
+
+	_ = a.db.UpsertChat("5511999@s.whatsapp.net", "dm", "Alice", time.Now())
+	_ = a.db.UpsertMessage(store.UpsertMessageParams{
+		ChatJID:   "5511999@s.whatsapp.net",
+		ChatName:  "Alice",
+		MsgID:     "msg1",
+		Timestamp: time.Now(),
+		FromMe:    false,
+		Text:      "test message",
+	})
+
+	req := `{"jsonrpc":"2.0","id":5,"method":"get_message","params":{"chat":"5511999@s.whatsapp.net","id":"msg1"}}` + "\n"
+
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := a.RunAgent(ctx, strings.NewReader(req), &out, AgentOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dec := json.NewDecoder(&out)
+	// Skip agent.ready
+	var notif rpcNotification
+	if err := dec.Decode(&notif); err != nil {
+		t.Fatal(err)
+	}
+	// Skip connection notification
+	var notif2 rpcNotification
+	if err := dec.Decode(&notif2); err != nil {
+		t.Fatal(err)
+	}
+
+	var resp rpcResponse
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+
+	data, _ := json.Marshal(resp.Result)
+	var msg map[string]any
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatal(err)
+	}
+	if msg["text"] != "test message" {
+		t.Fatalf("expected text 'test message', got %v", msg["text"])
+	}
+}
+
+func TestAgentSendFile(t *testing.T) {
+	a, _ := newAgentTestApp(t)
+
+	// Create a temp file to send.
+	tmpFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(tmpFile, []byte("file content"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	req := `{"jsonrpc":"2.0","id":6,"method":"send_file","params":{"to":"5511999@s.whatsapp.net","file":"` + tmpFile + `"}}` + "\n"
+
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := a.RunAgent(ctx, strings.NewReader(req), &out, AgentOptions{AutoPresence: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dec := json.NewDecoder(&out)
+	// Skip agent.ready
+	var notif rpcNotification
+	if err := dec.Decode(&notif); err != nil {
+		t.Fatal(err)
+	}
+	// Skip connection notification
+	var notif2 rpcNotification
+	if err := dec.Decode(&notif2); err != nil {
+		t.Fatal(err)
+	}
+
+	var resp rpcResponse
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+
+	data, _ := json.Marshal(resp.Result)
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["message_id"] == nil || result["message_id"] == "" {
+		t.Fatal("expected non-empty message_id")
+	}
+}
+
+func TestAgentMultipleRequests(t *testing.T) {
+	a, _ := newAgentTestApp(t)
+
+	_ = a.db.UpsertChat("5511999@s.whatsapp.net", "dm", "Alice", time.Now())
+
+	requests := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"list_chats","params":{}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"send_text","params":{"to":"5511999@s.whatsapp.net","text":"hi"}}`,
+	}, "\n") + "\n"
+
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := a.RunAgent(ctx, strings.NewReader(requests), &out, AgentOptions{AutoPresence: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dec := json.NewDecoder(&out)
+
+	// Skip agent.ready and connection
+	for i := 0; i < 2; i++ {
+		var n rpcNotification
+		if err := dec.Decode(&n); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Two responses.
+	for i := 0; i < 2; i++ {
+		var resp rpcResponse
+		if err := dec.Decode(&resp); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatal(err)
+		}
+		if resp.Error != nil {
+			t.Fatalf("request %d: unexpected error: %s", i+1, resp.Error.Message)
+		}
+	}
+}
+
+func TestAgentParseError(t *testing.T) {
+	a, _ := newAgentTestApp(t)
+
+	// Send invalid JSON then valid request.
+	input := "not json\n" +
+		`{"jsonrpc":"2.0","id":1,"method":"list_chats","params":{}}` + "\n"
+
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := a.RunAgent(ctx, strings.NewReader(input), &out, AgentOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Collect all output messages.
+	dec := json.NewDecoder(&out)
+	var foundParseError, foundListChats bool
+	for {
+		// Try to decode as a generic JSON object.
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			break
+		}
+		// Try as response (has id field).
+		var resp rpcResponse
+		if err := json.Unmarshal(raw, &resp); err == nil && resp.JSONRPC == "2.0" {
+			if resp.Error != nil && resp.Error.Code == errCodeParse {
+				foundParseError = true
+			}
+			if resp.Error == nil && resp.ID != nil {
+				foundListChats = true
+			}
+		}
+	}
+	if !foundParseError {
+		t.Fatal("expected parse error response")
+	}
+	if !foundListChats {
+		t.Fatal("expected successful list_chats response after parse error recovery")
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -45,6 +45,11 @@ type WAClient interface {
 	DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error)
 	RequestHistorySyncOnDemand(ctx context.Context, lastKnown types.MessageInfo, count int) (types.MessageID, error)
 	Logout(ctx context.Context) error
+
+	SendPresence(ctx context.Context, state types.Presence) error
+	SendChatPresence(ctx context.Context, jid types.JID, state types.ChatPresence, media types.ChatPresenceMedia) error
+	MarkRead(ctx context.Context, ids []types.MessageID, timestamp time.Time, chat, sender types.JID) error
+	SetForceActiveDeliveryReceipts(active bool)
 }
 
 type Options struct {

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -250,3 +250,12 @@ func (f *fakeWA) Logout(ctx context.Context) error {
 	f.authed = false
 	return nil
 }
+
+func (f *fakeWA) SendPresence(ctx context.Context, state types.Presence) error { return nil }
+func (f *fakeWA) SendChatPresence(ctx context.Context, jid types.JID, state types.ChatPresence, media types.ChatPresenceMedia) error {
+	return nil
+}
+func (f *fakeWA) MarkRead(ctx context.Context, ids []types.MessageID, timestamp time.Time, chat, sender types.JID) error {
+	return nil
+}
+func (f *fakeWA) SetForceActiveDeliveryReceipts(active bool) {}

--- a/internal/app/jsonrpc.go
+++ b/internal/app/jsonrpc.go
@@ -1,0 +1,85 @@
+package app
+
+import (
+	"encoding/json"
+	"io"
+	"sync"
+)
+
+// JSON-RPC 2.0 types.
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcNotification struct {
+	JSONRPC string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+// Standard JSON-RPC error codes.
+const (
+	errCodeParse          = -32700
+	errCodeMethodNotFound = -32601
+	errCodeInvalidParams  = -32602
+	errCodeNotConnected   = -32000
+	errCodeNotAuthed      = -32001
+	errCodeSendFailed     = -32002
+)
+
+// rpcWriter is a mutex-protected JSON encoder for writing to stdout.
+type rpcWriter struct {
+	mu  sync.Mutex
+	enc *json.Encoder
+}
+
+func newRPCWriter(w io.Writer) *rpcWriter {
+	return &rpcWriter{enc: json.NewEncoder(w)}
+}
+
+func (w *rpcWriter) respond(id json.RawMessage, result any) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	_ = w.enc.Encode(rpcResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	})
+}
+
+func (w *rpcWriter) respondError(id json.RawMessage, code int, msg string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	_ = w.enc.Encode(rpcResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &rpcError{Code: code, Message: msg},
+	})
+}
+
+func (w *rpcWriter) notify(method string, params any) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	_ = w.enc.Encode(rpcNotification{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  params,
+	})
+}

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -32,6 +32,21 @@ type SyncOptions struct {
 	RefreshGroups   bool
 	IdleExit        time.Duration // only used for bootstrap/once
 	Verbosity       int           // future
+	OnMessage       func(StreamMessage)
+}
+
+// StreamMessage is emitted for each stored message when OnMessage is set.
+type StreamMessage struct {
+	ChatJID     string `json:"chat_jid"`
+	ChatName    string `json:"chat_name,omitempty"`
+	MsgID       string `json:"msg_id"`
+	SenderJID   string `json:"sender_jid,omitempty"`
+	SenderName  string `json:"sender_name,omitempty"`
+	Timestamp   int64  `json:"timestamp"`
+	FromMe      bool   `json:"from_me"`
+	Text        string `json:"text,omitempty"`
+	DisplayText string `json:"display_text,omitempty"`
+	MediaType   string `json:"media_type,omitempty"`
 }
 
 type SyncResult struct {
@@ -95,8 +110,11 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 					}
 				}
 			}
-			if err := a.storeParsedMessage(ctx, pm); err == nil {
+			if sm, err := a.storeParsedMessage(ctx, pm); err == nil {
 				messagesStored.Add(1)
+				if opts.OnMessage != nil {
+					opts.OnMessage(sm)
+				}
 			}
 			if opts.DownloadMedia && pm.Media != nil && pm.ID != "" {
 				enqueueMedia(pm.Chat.String(), pm.ID)
@@ -121,8 +139,11 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 					if pm.ID == "" || pm.Chat.IsEmpty() {
 						continue
 					}
-					if err := a.storeParsedMessage(ctx, pm); err == nil {
+					if sm, err := a.storeParsedMessage(ctx, pm); err == nil {
 						messagesStored.Add(1)
+						if opts.OnMessage != nil {
+							opts.OnMessage(sm)
+						}
 					}
 					if opts.DownloadMedia && pm.Media != nil && pm.ID != "" {
 						enqueueMedia(pm.Chat.String(), pm.ID)
@@ -223,11 +244,11 @@ func chatKind(chat types.JID) string {
 	return "unknown"
 }
 
-func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error {
+func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) (StreamMessage, error) {
 	chatJID := pm.Chat.String()
 	chatName := a.wa.ResolveChatName(ctx, pm.Chat, pm.PushName)
 	if err := a.db.UpsertChat(chatJID, chatKind(pm.Chat), chatName, pm.Timestamp); err != nil {
-		return err
+		return StreamMessage{}, err
 	}
 
 	// Best-effort: store contact info for DMs.
@@ -307,7 +328,20 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 
 	displayText := a.buildDisplayText(ctx, pm)
 
-	return a.db.UpsertMessage(store.UpsertMessageParams{
+	sm := StreamMessage{
+		ChatJID:     chatJID,
+		ChatName:    chatName,
+		MsgID:       pm.ID,
+		SenderJID:   pm.SenderJID,
+		SenderName:  senderName,
+		Timestamp:   pm.Timestamp.Unix(),
+		FromMe:      pm.FromMe,
+		Text:        pm.Text,
+		DisplayText: displayText,
+		MediaType:   mediaType,
+	}
+
+	err := a.db.UpsertMessage(store.UpsertMessageParams{
 		ChatJID:       chatJID,
 		ChatName:      chatName,
 		MsgID:         pm.ID,
@@ -327,6 +361,10 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 		FileEncSHA256: fileEncSha,
 		FileLength:    fileLen,
 	})
+	if err != nil {
+		return StreamMessage{}, err
+	}
+	return sm, nil
 }
 
 func (a *App) buildDisplayText(ctx context.Context, pm wa.ParsedMessage) string {

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -349,6 +349,46 @@ func (c *Client) Logout(ctx context.Context) error {
 	return cli.Logout(ctx)
 }
 
+func (c *Client) SendPresence(ctx context.Context, state types.Presence) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	return cli.SendPresence(ctx, state)
+}
+
+func (c *Client) SendChatPresence(ctx context.Context, jid types.JID, state types.ChatPresence, media types.ChatPresenceMedia) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	return cli.SendChatPresence(ctx, jid, state, media)
+}
+
+func (c *Client) MarkRead(ctx context.Context, ids []types.MessageID, timestamp time.Time, chat, sender types.JID) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	return cli.MarkRead(ctx, ids, timestamp, chat, sender)
+}
+
+func (c *Client) SetForceActiveDeliveryReceipts(active bool) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil {
+		return
+	}
+	cli.SetForceActiveDeliveryReceipts(active)
+}
+
 // Reconnect loop helper.
 func (c *Client) ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay time.Duration) error {
 	delay := minDelay


### PR DESCRIPTION
## Summary

- Adds `wacli agent` subcommand: a long-lived JSON-RPC 2.0 server over NDJSON (stdin/stdout)
- Solves the lock contention between `sync --follow` and `send text` — one process handles both directions
- 9 RPC methods: `send_text`, `send_file`, `mark_read`, `set_typing`, `set_presence`, `list_chats`, `list_messages`, `search`, `get_message`
- 6 notification types: `message`, `receipt`, `presence`, `chat_presence`, `connection`, `agent.ready`
- Optional `--auto-presence`: simulates human-like behavior (online → typing → send → offline)
- Read receipts are explicit only (`mark_read` method) — the consumer decides when to show blue ticks

## Files changed

| File | Change |
|------|--------|
| `internal/wa/client.go` | 4 new wrapper methods (SendPresence, SendChatPresence, MarkRead, SetForceActiveDeliveryReceipts) |
| `internal/app/app.go` | Extend WAClient interface |
| `internal/app/jsonrpc.go` | **New** — JSON-RPC 2.0 types + mutex-protected writer |
| `internal/app/agent.go` | **New** — Agent loop, dispatcher, 9 handlers, event notifications, typing simulation |
| `internal/app/sync.go` | Refactor `storeParsedMessage` to return `StreamMessage`; add `OnMessage` callback |
| `cmd/wacli/sync.go` | Add `--stream` flag |
| `cmd/wacli/agent.go` | **New** — Cobra command |
| `cmd/wacli/root.go` | Register agent command |
| `internal/app/agent_test.go` | **New** — 9 tests |
| `internal/app/fake_wa_test.go` | Stubs for new interface methods |

## Test plan

- [x] `go test -tags sqlite_fts5 ./...` — all pass
- [x] `go test ./...` (without FTS5) — all pass
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [x] Build: `go build -tags sqlite_fts5 -o ./dist/wacli ./cmd/wacli`
- [x] Manual test: interactive session with real WhatsApp (send, receive, receipts)

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)