### PR TITLE
fix: resolve LID JIDs to phone number JIDs

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -26,6 +26,7 @@ type WAClient interface {
 	ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay time.Duration) error
 
 	ResolveChatName(ctx context.Context, chat types.JID, pushName string) string
+	ResolveLIDToPN(ctx context.Context, jid types.JID) types.JID
 	GetContact(ctx context.Context, jid types.JID) (types.ContactInfo, error)
 	GetAllContacts(ctx context.Context) (map[types.JID]types.ContactInfo, error)
 

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -116,6 +116,10 @@ func (f *fakeWA) ResolveChatName(ctx context.Context, chat types.JID, pushName s
 	return chat.String()
 }
 
+func (f *fakeWA) ResolveLIDToPN(ctx context.Context, jid types.JID) types.JID {
+	return jid
+}
+
 func (f *fakeWA) GetContact(ctx context.Context, jid types.JID) (types.ContactInfo, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -224,6 +224,10 @@ func chatKind(chat types.JID) string {
 }
 
 func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error {
+	// Resolve LID chat JIDs to Phone Number JIDs so messages are stored
+	// under the canonical PN-based chat instead of a separate LID chat.
+	pm.Chat = a.wa.ResolveLIDToPN(ctx, pm.Chat)
+
 	chatJID := pm.Chat.String()
 	chatName := a.wa.ResolveChatName(ctx, pm.Chat, pm.PushName)
 	if err := a.db.UpsertChat(chatJID, chatKind(pm.Chat), chatName, pm.Timestamp); err != nil {


### PR DESCRIPTION
## Summary

- Add `ResolveLIDToPN()` to `WAClient` interface and `wa.Client`
- Resolve Linked Identity (LID) JIDs to Phone Number JIDs when storing messages
- Prevents the "split chat" issue caused by WhatsApp's LID migration

## Problem

WhatsApp is migrating to Linked Identity (LID) JIDs (with server `lid`), which causes messages to be stored under separate chat entries instead of the canonical phone-number-based chat. This results in "split chats" where the same conversation appears as two different chats in the local database (see #18, #28).

## Solution

Before storing a message, resolve any LID-based chat JID to its corresponding Phone Number JID using the whatsmeow store's `LIDs.GetPNForLID()`. If resolution fails (e.g., the LID is unknown), the original JID is kept unchanged.

## Testing

- `go test ./...` — all tests pass
- `go build ./...` — builds cleanly

Relates to #18, #28