### PR TITLE
feat: store structured reaction data (reaction_to_id, reaction_emoji)

### DIFF
--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -326,6 +326,8 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 		FileSHA256:    fileSha,
 		FileEncSHA256: fileEncSha,
 		FileLength:    fileLen,
+		ReactionToID:  pm.ReactionToID,
+		ReactionEmoji: pm.ReactionEmoji,
 	})
 }
 

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -25,6 +25,8 @@ type UpsertMessageParams struct {
 	FileSHA256    []byte
 	FileEncSHA256 []byte
 	FileLength    uint64
+	ReactionToID  string
+	ReactionEmoji string
 }
 
 func (d *DB) UpsertMessage(p UpsertMessageParams) error {
@@ -32,8 +34,9 @@ func (d *DB) UpsertMessage(p UpsertMessageParams) error {
 		INSERT INTO messages(
 			chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, display_text,
 			media_type, media_caption, filename, mime_type, direct_path,
-			media_key, file_sha256, file_enc_sha256, file_length
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			media_key, file_sha256, file_enc_sha256, file_length,
+			reaction_to_id, reaction_emoji
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
 			chat_name=COALESCE(NULLIF(excluded.chat_name,''), messages.chat_name),
 			sender_jid=excluded.sender_jid,
@@ -50,10 +53,13 @@ func (d *DB) UpsertMessage(p UpsertMessageParams) error {
 			media_key=CASE WHEN excluded.media_key IS NOT NULL AND length(excluded.media_key)>0 THEN excluded.media_key ELSE messages.media_key END,
 			file_sha256=CASE WHEN excluded.file_sha256 IS NOT NULL AND length(excluded.file_sha256)>0 THEN excluded.file_sha256 ELSE messages.file_sha256 END,
 			file_enc_sha256=CASE WHEN excluded.file_enc_sha256 IS NOT NULL AND length(excluded.file_enc_sha256)>0 THEN excluded.file_enc_sha256 ELSE messages.file_enc_sha256 END,
-			file_length=CASE WHEN excluded.file_length>0 THEN excluded.file_length ELSE messages.file_length END
+			file_length=CASE WHEN excluded.file_length>0 THEN excluded.file_length ELSE messages.file_length END,
+			reaction_to_id=COALESCE(NULLIF(excluded.reaction_to_id,''), messages.reaction_to_id),
+			reaction_emoji=COALESCE(NULLIF(excluded.reaction_emoji,''), messages.reaction_emoji)
 	`, p.ChatJID, nullIfEmpty(p.ChatName), p.MsgID, nullIfEmpty(p.SenderJID), nullIfEmpty(p.SenderName), unix(p.Timestamp), boolToInt(p.FromMe), nullIfEmpty(p.Text), nullIfEmpty(p.DisplayText),
 		nullIfEmpty(p.MediaType), nullIfEmpty(p.MediaCaption), nullIfEmpty(p.Filename), nullIfEmpty(p.MimeType), nullIfEmpty(p.DirectPath),
 		p.MediaKey, p.FileSHA256, p.FileEncSHA256, int64(p.FileLength),
+		nullIfEmpty(p.ReactionToID), nullIfEmpty(p.ReactionEmoji),
 	)
 	return err
 }


### PR DESCRIPTION
## Summary

- Add `reaction_to_id` and `reaction_emoji` columns to the messages table via migration v4
- Pass structured reaction data through `UpsertMessageParams` and into the database
- Complements the `display_text` approach from PR #5 with machine-readable reaction data

## Problem

PR #5 added `display_text` for reactions (e.g., "Reacted 👍 to hello"), which is great for human-readable output. However, there is no way to programmatically query which message a reaction targets or what emoji was used. This makes it difficult to build downstream tools that need to process reactions (e.g., counting reactions, filtering by emoji).

## Solution

Store the raw `reaction_to_id` (stanza ID of the message being reacted to) and `reaction_emoji` (the emoji text) as separate columns. These are populated from the existing `ParsedMessage.ReactionToID` and `ParsedMessage.ReactionEmoji` fields that are already parsed by the `wa` package.

## Testing

- `go test ./...` — all tests pass
- `go build ./...` — builds cleanly