### PR TITLE
feat: add --reply-to support for send text and send file

### DIFF
--- a/cmd/wacli/send_file_cmd.go
+++ b/cmd/wacli/send_file_cmd.go
@@ -16,6 +16,8 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 	var filename string
 	var caption string
 	var mimeOverride string
+	var replyTo string
+	var replyToParticipant string
 
 	cmd := &cobra.Command{
 		Use:   "file",
@@ -46,7 +48,7 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			msgID, meta, err := sendFile(ctx, a, toJID, filePath, filename, caption, mimeOverride)
+			msgID, meta, err := sendFile(ctx, a, toJID, filePath, filename, caption, mimeOverride, replyTo, replyToParticipant)
 			if err != nil {
 				return err
 			}
@@ -69,5 +71,7 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&filename, "filename", "", "display name for the file (defaults to basename of --file)")
 	cmd.Flags().StringVar(&caption, "caption", "", "caption (images/videos/documents)")
 	cmd.Flags().StringVar(&mimeOverride, "mime", "", "override detected mime type")
+	cmd.Flags().StringVar(&replyTo, "reply-to", "", "message ID to reply to (stanza ID)")
+	cmd.Flags().StringVar(&replyToParticipant, "reply-to-participant", "", "JID of the sender of the quoted message (use 'self' for own messages)")
 	return cmd
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -37,6 +37,7 @@ type WAClient interface {
 	JoinGroupWithLink(ctx context.Context, code string) (types.JID, error)
 	LeaveGroup(ctx context.Context, group types.JID) error
 
+	GetOwnJID() types.JID
 	SendText(ctx context.Context, to types.JID, text string) (types.MessageID, error)
 	SendProtoMessage(ctx context.Context, to types.JID, msg *waProto.Message) (types.MessageID, error)
 	Upload(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error)

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -204,6 +204,10 @@ func (f *fakeWA) JoinGroupWithLink(ctx context.Context, code string) (types.JID,
 
 func (f *fakeWA) LeaveGroup(ctx context.Context, group types.JID) error { return nil }
 
+func (f *fakeWA) GetOwnJID() types.JID {
+	return types.JID{User: "1234567890", Server: types.DefaultUserServer}
+}
+
 func (f *fakeWA) SendText(ctx context.Context, to types.JID, text string) (types.MessageID, error) {
 	return types.MessageID("msgid"), nil
 }

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -168,6 +168,17 @@ func (c *Client) RemoveEventHandler(id uint32) {
 	cli.RemoveEventHandler(id)
 }
 
+// GetOwnJID returns the authenticated user's JID in non-AD form.
+func (c *Client) GetOwnJID() types.JID {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || cli.Store == nil || cli.Store.ID == nil {
+		return types.JID{}
+	}
+	return cli.Store.ID.ToNonAD()
+}
+
 func (c *Client) SendText(ctx context.Context, to types.JID, text string) (types.MessageID, error) {
 	c.mu.Lock()
 	cli := c.client


### PR DESCRIPTION
## Summary

- Add `--reply-to` and `--reply-to-participant` flags to `send text` and `send file`
- Use `ContextInfo` with `StanzaID` for quoted replies on both text and media messages
- Support `self` as a special value for `--reply-to-participant` that resolves to own JID
- Add `GetOwnJID()` to `WAClient` interface for JID resolution

## Problem

There is no way to send a quoted reply to an existing message via `wacli send` (see #16). This limits wacli's usefulness for conversational workflows and bot integrations that need to reply in context.

## Solution

Add reply-to flags that construct a `ContextInfo` with the quoted message's stanza ID. For text messages, this wraps the content in an `ExtendedTextMessage`. For media messages, the `ContextInfo` is attached directly to the media proto message (ImageMessage, VideoMessage, AudioMessage, DocumentMessage).

## Usage

```bash
# Reply to a text message
wacli send text --to +1234567890 --message "I agree!" \
  --reply-to ABC123 --reply-to-participant 9876543210@s.whatsapp.net

# Reply with a file
wacli send file --to +1234567890 --file photo.jpg --caption "Here it is" \
  --reply-to ABC123 --reply-to-participant self
```

## Testing

- `go test ./...` — all tests pass
- `go build ./...` — builds cleanly

Closes #16