### PR TITLE
feat: add WhatsApp channels (newsletters) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ pnpm wacli send text --to 1234567890 --message "hello"
 # List groups and manage participants
 pnpm wacli groups list
 pnpm wacli groups rename --jid 123456789@g.us --name "New name"
+
+# WhatsApp channels (newsletters): list, join via invite, send messages
+pnpm wacli channels list
+pnpm wacli channels join --invite "https://whatsapp.com/channel/..."
+pnpm wacli send text --to 12345678901234567@newsletter --message "Hello channel"
 ```
 
 ## Prior Art / Credit

--- a/cmd/wacli/channels.go
+++ b/cmd/wacli/channels.go
@@ -1,0 +1,15 @@
+package main
+
+import "github.com/spf13/cobra"
+
+func newChannelsCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "channels",
+		Short: "WhatsApp channel (newsletter) management",
+	}
+	cmd.AddCommand(newChannelsListCmd(flags))
+	cmd.AddCommand(newChannelsInfoCmd(flags))
+	cmd.AddCommand(newChannelsJoinCmd(flags))
+	cmd.AddCommand(newChannelsLeaveCmd(flags))
+	return cmd
+}

--- a/cmd/wacli/channels_join_leave.go
+++ b/cmd/wacli/channels_join_leave.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steipete/wacli/internal/out"
+	"github.com/steipete/wacli/internal/wa"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func newChannelsJoinCmd(flags *rootFlags) *cobra.Command {
+	var invite string
+	cmd := &cobra.Command{
+		Use:   "join",
+		Short: "Join a channel via invite link or code",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(invite) == "" {
+				return fmt.Errorf("--invite is required (full link or code after https://whatsapp.com/channel/)")
+			}
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+
+			meta, err := a.WA().GetNewsletterInfoWithInvite(ctx, invite)
+			if err != nil {
+				return err
+			}
+			if meta == nil {
+				return fmt.Errorf("could not resolve channel from invite")
+			}
+
+			if err := a.WA().FollowNewsletter(ctx, meta.ID); err != nil {
+				return err
+			}
+
+			name := wa.NewsletterName(meta)
+			if name == "" {
+				name = meta.ID.String()
+			}
+			now := time.Now().UTC()
+			_ = a.DB().UpsertChat(meta.ID.String(), "newsletter", name, now)
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"jid":   meta.ID.String(),
+					"name":  name,
+					"joined": true,
+				})
+			}
+			fmt.Fprintf(os.Stdout, "Joined channel %s (%s).\n", name, meta.ID.String())
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&invite, "invite", "", "invite link or code (e.g. https://whatsapp.com/channel/... or just the code)")
+	return cmd
+}
+
+func newChannelsLeaveCmd(flags *rootFlags) *cobra.Command {
+	var jidStr string
+	cmd := &cobra.Command{
+		Use:   "leave",
+		Short: "Leave (unfollow) a channel",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(jidStr) == "" {
+				return fmt.Errorf("--jid is required")
+			}
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+
+			jid, err := types.ParseJID(jidStr)
+			if err != nil {
+				return err
+			}
+			if jid.Server != types.NewsletterServer {
+				return fmt.Errorf("JID must be a channel (…@newsletter)")
+			}
+
+			if err := a.WA().UnfollowNewsletter(ctx, jid); err != nil {
+				return err
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{"left": jid.String()})
+			}
+			fmt.Fprintf(os.Stdout, "Left channel %s.\n", jid.String())
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&jidStr, "jid", "", "channel JID (…@newsletter)")
+	return cmd
+}

--- a/cmd/wacli/channels_list_info.go
+++ b/cmd/wacli/channels_list_info.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/steipete/wacli/internal/out"
+	"github.com/steipete/wacli/internal/wa"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func newChannelsListCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List subscribed channels (live)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+
+			list, err := a.WA().GetSubscribedNewsletters(ctx)
+			if err != nil {
+				return err
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, list)
+			}
+
+			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "NAME\tJID\tROLE\tDESCRIPTION")
+			for _, meta := range list {
+				if meta == nil {
+					continue
+				}
+				name := wa.NewsletterName(meta)
+				if name == "" {
+					name = meta.ID.String()
+				}
+				desc := ""
+				if meta.ThreadMeta.Description.Text != "" {
+					desc = truncate(strings.ReplaceAll(meta.ThreadMeta.Description.Text, "\n", " "), 50)
+				}
+				role := ""
+				if meta.ViewerMeta != nil {
+					role = string(meta.ViewerMeta.Role)
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", truncate(name, 40), meta.ID.String(), role, desc)
+			}
+			_ = w.Flush()
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newChannelsInfoCmd(flags *rootFlags) *cobra.Command {
+	var jidStr string
+	cmd := &cobra.Command{
+		Use:   "info",
+		Short: "Fetch channel info (live)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(jidStr) == "" {
+				return fmt.Errorf("--jid is required")
+			}
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+
+			jid, err := types.ParseJID(jidStr)
+			if err != nil {
+				return err
+			}
+			if jid.Server != types.NewsletterServer {
+				return fmt.Errorf("JID must be a channel (…@newsletter)")
+			}
+
+			meta, err := a.WA().GetNewsletterInfo(ctx, jid)
+			if err != nil {
+				return err
+			}
+			if meta == nil {
+				return fmt.Errorf("channel not found")
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, meta)
+			}
+
+			name := wa.NewsletterName(meta)
+			if name == "" {
+				name = meta.ID.String()
+			}
+			fmt.Fprintf(os.Stdout, "JID: %s\nName: %s\nDescription: %s\nState: %s\n",
+				meta.ID.String(),
+				name,
+				meta.ThreadMeta.Description.Text,
+				meta.State.Type,
+			)
+			if meta.ViewerMeta != nil {
+				fmt.Fprintf(os.Stdout, "Role: %s\nMute: %s\n", meta.ViewerMeta.Role, meta.ViewerMeta.Mute)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&jidStr, "jid", "", "channel JID (…@newsletter)")
+	return cmd
+}

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -48,6 +48,7 @@ func execute(args []string) error {
 	rootCmd.AddCommand(newContactsCmd(&flags))
 	rootCmd.AddCommand(newChatsCmd(&flags))
 	rootCmd.AddCommand(newGroupsCmd(&flags))
+	rootCmd.AddCommand(newChannelsCmd(&flags))
 	rootCmd.AddCommand(newHistoryCmd(&flags))
 
 	rootCmd.SetArgs(args)

--- a/cmd/wacli/send_file.go
+++ b/cmd/wacli/send_file.go
@@ -57,13 +57,115 @@ func sendFile(ctx context.Context, a interface {
 		uploadType, _ = wa.MediaTypeFromString("audio")
 	}
 
-	up, err := a.WA().Upload(ctx, data, uploadType)
-	if err != nil {
-		return "", nil, err
+	var up struct {
+		URL           string
+		DirectPath    string
+		MediaKey      []byte
+		FileEncSHA256 []byte
+		FileSHA256    []byte
+		FileLength    uint64
+		Handle        string
+	}
+	isNewsletter := to.Server == types.NewsletterServer
+	if isNewsletter {
+		resp, err := a.WA().UploadNewsletter(ctx, data, uploadType)
+		if err != nil {
+			return "", nil, err
+		}
+		up.URL = resp.URL
+		up.DirectPath = resp.DirectPath
+		up.FileSHA256 = resp.FileSHA256
+		up.FileLength = resp.FileLength
+		up.Handle = resp.Handle
+	} else {
+		resp, err := a.WA().Upload(ctx, data, uploadType)
+		if err != nil {
+			return "", nil, err
+		}
+		up.URL = resp.URL
+		up.DirectPath = resp.DirectPath
+		up.MediaKey = resp.MediaKey
+		up.FileEncSHA256 = resp.FileEncSHA256
+		up.FileSHA256 = resp.FileSHA256
+		up.FileLength = resp.FileLength
 	}
 
 	now := time.Now().UTC()
 	msg := &waProto.Message{}
+
+	if isNewsletter {
+		switch mediaType {
+		case "image":
+			msg.ImageMessage = &waProto.ImageMessage{
+				URL:        proto.String(up.URL),
+				DirectPath: proto.String(up.DirectPath),
+				FileSHA256: up.FileSHA256,
+				FileLength: proto.Uint64(up.FileLength),
+				Mimetype:   proto.String(mimeType),
+				Caption:    proto.String(caption),
+			}
+		case "video":
+			msg.VideoMessage = &waProto.VideoMessage{
+				URL:        proto.String(up.URL),
+				DirectPath: proto.String(up.DirectPath),
+				FileSHA256: up.FileSHA256,
+				FileLength: proto.Uint64(up.FileLength),
+				Mimetype:   proto.String(mimeType),
+				Caption:    proto.String(caption),
+			}
+		case "audio":
+			msg.AudioMessage = &waProto.AudioMessage{
+				URL:        proto.String(up.URL),
+				DirectPath: proto.String(up.DirectPath),
+				FileSHA256: up.FileSHA256,
+				FileLength: proto.Uint64(up.FileLength),
+				Mimetype:   proto.String(mimeType),
+				PTT:        proto.Bool(false),
+			}
+		default:
+			msg.DocumentMessage = &waProto.DocumentMessage{
+				URL:        proto.String(up.URL),
+				DirectPath: proto.String(up.DirectPath),
+				FileSHA256: up.FileSHA256,
+				FileLength: proto.Uint64(up.FileLength),
+				Mimetype:   proto.String(mimeType),
+				FileName:   proto.String(name),
+				Caption:    proto.String(caption),
+				Title:      proto.String(name),
+			}
+		}
+		id, err := a.WA().SendProtoMessageWithExtra(ctx, to, msg, up.Handle)
+		if err != nil {
+			return "", nil, err
+		}
+		chatName := a.WA().ResolveChatName(ctx, to, "")
+		kind := chatKindFromJID(to)
+		_ = a.DB().UpsertChat(to.String(), kind, chatName, now)
+		_ = a.DB().UpsertMessage(store.UpsertMessageParams{
+			ChatJID:       to.String(),
+			ChatName:      chatName,
+			MsgID:         id,
+			SenderJID:     "",
+			SenderName:    "me",
+			Timestamp:     now,
+			FromMe:        true,
+			Text:          caption,
+			MediaType:     mediaType,
+			MediaCaption:  caption,
+			Filename:      name,
+			MimeType:      mimeType,
+			DirectPath:    up.DirectPath,
+			MediaKey:      up.MediaKey,
+			FileSHA256:    up.FileSHA256,
+			FileEncSHA256: up.FileEncSHA256,
+			FileLength:    up.FileLength,
+		})
+		return id, map[string]string{
+			"name":      name,
+			"mime_type": mimeType,
+			"media":     mediaType,
+		}, nil
+	}
 
 	switch mediaType {
 	case "image":
@@ -150,6 +252,9 @@ func sendFile(ctx context.Context, a interface {
 }
 
 func chatKindFromJID(j types.JID) string {
+	if j.Server == types.NewsletterServer {
+		return "newsletter"
+	}
 	if j.Server == types.GroupServer {
 		return "group"
 	}

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -20,7 +20,7 @@ This document defines the v1 plan for `wacli`: a WhatsApp CLI that syncs message
 
 ## Terminology
 
-- **JID**: WhatsApp Jabber ID, e.g. `1234567890@s.whatsapp.net` (user) or `123456789@g.us` (group).
+- **JID**: WhatsApp Jabber ID, e.g. `1234567890@s.whatsapp.net` (user), `123456789@g.us` (group), or `12345678901234567@newsletter` (channel).
 - **Store directory**: directory containing all local state, default `~/.wacli`.
 
 ## Storage layout
@@ -94,7 +94,7 @@ Immediately after QR pairing success, `wacli auth` runs a bootstrap sync:
 ### Tables (proposed)
 
 - `chats`
-  - `jid` (PK), `name`, `kind` (`dm|group|broadcast`), `last_message_ts`, …
+  - `jid` (PK), `name`, `kind` (`dm|group|broadcast|newsletter|unknown`), `last_message_ts`, …
 - `contacts`
   - `jid` (PK), `push_name`, `full_name`, `business_name`, `phone`, …
 - `groups`
@@ -173,6 +173,15 @@ WhatsApp Web history is best-effort. If you want to try fetching *older* message
 
 - `wacli send text --to PHONE_OR_JID --message TEXT`
 - `wacli send file --to PHONE_OR_JID --file PATH [--caption TEXT] [--mime TYPE]`
+
+`--to` can be a user (phone or JID), group JID (`…@g.us`), or channel JID (`…@newsletter`). Sending to a channel requires admin/owner role; file uploads to channels use unencrypted newsletter media.
+
+### Channels (newsletters)
+
+- `wacli channels list` — list subscribed channels (live)
+- `wacli channels info --jid JID` — fetch channel metadata (JID: `…@newsletter`)
+- `wacli channels join --invite LINK_OR_KEY` — join a channel (full invite link or code after `https://whatsapp.com/channel/`)
+- `wacli channels leave --jid JID` — unfollow a channel
 
 ### Contacts (read + local management)
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -37,8 +37,16 @@ type WAClient interface {
 	JoinGroupWithLink(ctx context.Context, code string) (types.JID, error)
 	LeaveGroup(ctx context.Context, group types.JID) error
 
+	GetNewsletterInfoWithInvite(ctx context.Context, key string) (*types.NewsletterMetadata, error)
+	FollowNewsletter(ctx context.Context, jid types.JID) error
+	UnfollowNewsletter(ctx context.Context, jid types.JID) error
+	GetSubscribedNewsletters(ctx context.Context) ([]*types.NewsletterMetadata, error)
+	GetNewsletterInfo(ctx context.Context, jid types.JID) (*types.NewsletterMetadata, error)
+	UploadNewsletter(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error)
+
 	SendText(ctx context.Context, to types.JID, text string) (types.MessageID, error)
 	SendProtoMessage(ctx context.Context, to types.JID, msg *waProto.Message) (types.MessageID, error)
+	SendProtoMessageWithExtra(ctx context.Context, to types.JID, msg *waProto.Message, mediaHandle string) (types.MessageID, error)
 	Upload(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error)
 	DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error)
 

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -3,6 +3,8 @@ package app
 import (
 	"context"
 	"time"
+
+	"github.com/steipete/wacli/internal/wa"
 )
 
 func (a *App) refreshContacts(ctx context.Context) error {
@@ -41,6 +43,28 @@ func (a *App) refreshGroups(ctx context.Context) error {
 		}
 		_ = a.db.UpsertGroup(g.JID.String(), g.GroupName.Name, g.OwnerJID.String(), g.GroupCreated)
 		_ = a.db.UpsertChat(g.JID.String(), "group", g.GroupName.Name, now)
+	}
+	return nil
+}
+
+func (a *App) refreshNewsletters(ctx context.Context) error {
+	if err := a.OpenWA(); err != nil {
+		return err
+	}
+	list, err := a.wa.GetSubscribedNewsletters(ctx)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	for _, meta := range list {
+		if meta == nil {
+			continue
+		}
+		name := wa.NewsletterName(meta)
+		if name == "" {
+			name = meta.ID.String()
+		}
+		_ = a.db.UpsertChat(meta.ID.String(), "newsletter", name, now)
 	}
 	return nil
 }

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -204,11 +204,39 @@ func (f *fakeWA) JoinGroupWithLink(ctx context.Context, code string) (types.JID,
 
 func (f *fakeWA) LeaveGroup(ctx context.Context, group types.JID) error { return nil }
 
+func (f *fakeWA) GetNewsletterInfoWithInvite(ctx context.Context, key string) (*types.NewsletterMetadata, error) {
+	return nil, nil
+}
+
+func (f *fakeWA) FollowNewsletter(ctx context.Context, jid types.JID) error {
+	return nil
+}
+
+func (f *fakeWA) UnfollowNewsletter(ctx context.Context, jid types.JID) error {
+	return nil
+}
+
+func (f *fakeWA) GetSubscribedNewsletters(ctx context.Context) ([]*types.NewsletterMetadata, error) {
+	return nil, nil
+}
+
+func (f *fakeWA) GetNewsletterInfo(ctx context.Context, jid types.JID) (*types.NewsletterMetadata, error) {
+	return nil, nil
+}
+
+func (f *fakeWA) UploadNewsletter(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error) {
+	return whatsmeow.UploadResponse{}, nil
+}
+
 func (f *fakeWA) SendText(ctx context.Context, to types.JID, text string) (types.MessageID, error) {
 	return types.MessageID("msgid"), nil
 }
 
 func (f *fakeWA) SendProtoMessage(ctx context.Context, to types.JID, msg *waProto.Message) (types.MessageID, error) {
+	return f.SendProtoMessageWithExtra(ctx, to, msg, "")
+}
+
+func (f *fakeWA) SendProtoMessageWithExtra(ctx context.Context, to types.JID, msg *waProto.Message, mediaHandle string) (types.MessageID, error) {
 	return types.MessageID("msgid"), nil
 }
 

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -161,6 +161,7 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 	}
 	if opts.RefreshGroups {
 		_ = a.refreshGroups(ctx)
+		_ = a.refreshNewsletters(ctx)
 	}
 	if opts.AfterConnect != nil {
 		if err := opts.AfterConnect(ctx); err != nil {
@@ -211,6 +212,9 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 }
 
 func chatKind(chat types.JID) string {
+	if chat.Server == types.NewsletterServer {
+		return "newsletter"
+	}
 	if chat.Server == types.GroupServer {
 		return "group"
 	}

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -73,7 +73,7 @@ func migrateCoreSchema(d *DB) error {
 	if _, err := d.sql.Exec(`
 		CREATE TABLE IF NOT EXISTS chats (
 			jid TEXT PRIMARY KEY,
-			kind TEXT NOT NULL, -- dm|group|broadcast|unknown
+			kind TEXT NOT NULL, -- dm|group|broadcast|newsletter|unknown
 			name TEXT,
 			last_message_ts INTEGER
 		);

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -184,13 +184,21 @@ func (c *Client) SendText(ctx context.Context, to types.JID, text string) (types
 }
 
 func (c *Client) SendProtoMessage(ctx context.Context, to types.JID, msg *waProto.Message) (types.MessageID, error) {
+	return c.SendProtoMessageWithExtra(ctx, to, msg, "")
+}
+
+func (c *Client) SendProtoMessageWithExtra(ctx context.Context, to types.JID, msg *waProto.Message, mediaHandle string) (types.MessageID, error) {
 	c.mu.Lock()
 	cli := c.client
 	c.mu.Unlock()
 	if cli == nil || !cli.IsConnected() {
 		return "", fmt.Errorf("not connected")
 	}
-	resp, err := cli.SendMessage(ctx, to, msg)
+	var extra whatsmeow.SendRequestExtra
+	if mediaHandle != "" {
+		extra.MediaHandle = mediaHandle
+	}
+	resp, err := cli.SendMessage(ctx, to, msg, extra)
 	if err != nil {
 		return "", err
 	}
@@ -307,7 +315,14 @@ func BestContactName(info types.ContactInfo) string {
 func (c *Client) ResolveChatName(ctx context.Context, chat types.JID, pushName string) string {
 	fallback := chat.String()
 
-	if chat.Server == types.GroupServer || chat.IsBroadcastList() {
+	if chat.Server == types.NewsletterServer {
+		meta, err := c.GetNewsletterInfo(ctx, chat)
+		if err == nil && meta != nil {
+			if name := NewsletterName(meta); name != "" {
+				return name
+			}
+		}
+	} else if chat.Server == types.GroupServer || chat.IsBroadcastList() {
 		info, err := c.GetGroupInfo(ctx, chat)
 		if err == nil && info != nil {
 			if name := strings.TrimSpace(info.GroupName.Name); name != "" {

--- a/internal/wa/newsletters.go
+++ b/internal/wa/newsletters.go
@@ -1,0 +1,78 @@
+package wa
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func (c *Client) GetNewsletterInfoWithInvite(ctx context.Context, key string) (*types.NewsletterMetadata, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return nil, fmt.Errorf("not connected")
+	}
+	return cli.GetNewsletterInfoWithInvite(ctx, key)
+}
+
+func (c *Client) FollowNewsletter(ctx context.Context, jid types.JID) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	return cli.FollowNewsletter(ctx, jid)
+}
+
+func (c *Client) UnfollowNewsletter(ctx context.Context, jid types.JID) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	return cli.UnfollowNewsletter(ctx, jid)
+}
+
+func (c *Client) GetSubscribedNewsletters(ctx context.Context) ([]*types.NewsletterMetadata, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return nil, fmt.Errorf("not connected")
+	}
+	return cli.GetSubscribedNewsletters(ctx)
+}
+
+func (c *Client) GetNewsletterInfo(ctx context.Context, jid types.JID) (*types.NewsletterMetadata, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return nil, fmt.Errorf("not connected")
+	}
+	return cli.GetNewsletterInfo(ctx, jid)
+}
+
+func (c *Client) UploadNewsletter(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return whatsmeow.UploadResponse{}, fmt.Errorf("not connected")
+	}
+	return cli.UploadNewsletter(ctx, data, mediaType)
+}
+
+// NewsletterName returns the display name from newsletter metadata.
+func NewsletterName(meta *types.NewsletterMetadata) string {
+	if meta == nil || meta.ThreadMeta.Name.Text == "" {
+		return ""
+	}
+	return strings.TrimSpace(meta.ThreadMeta.Name.Text)
+}


### PR DESCRIPTION
- Add internal/wa/newsletters.go: GetNewsletterInfoWithInvite, FollowNewsletter, UnfollowNewsletter, GetSubscribedNewsletters, GetNewsletterInfo, UploadNewsletter
- ResolveChatName: resolve channel names via GetNewsletterInfo
- SendProtoMessageWithExtra for newsletter media (MediaHandle)
- Store/sync: chatKind newsletter, migrations comment, refreshNewsletters on bootstrap
- WAClient interface + fake_wa stubs for newsletter methods
- CLI: wacli channels list|info|join|leave
- send file: use UploadNewsletter + MediaHandle when target is @newsletter
- docs: spec.md and README with channels section