### PR TITLE
fix: show sender names in group message history

### DIFF
--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -82,10 +82,7 @@ func newMessagesListCmd(flags *rootFlags) *cobra.Command {
 			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
 			fmt.Fprintln(w, "TIME\tCHAT\tFROM\tID\tTEXT")
 			for _, m := range msgs {
-				from := m.SenderJID; if showNames && m.SenderName != "" { from = m.SenderName }
-				if m.FromMe {
-					from = "me"
-				}
+				from := senderLabel(m, showNames)
 				chatLabel := m.ChatName
 				if chatLabel == "" {
 					chatLabel = m.ChatJID
@@ -181,10 +178,7 @@ func newMessagesSearchCmd(flags *rootFlags) *cobra.Command {
 			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
 			fmt.Fprintf(w, "TIME\tCHAT\tFROM\tID\tMATCH\n")
 			for _, m := range msgs {
-				fromLabel := m.SenderJID; if showNames && m.SenderName != "" { fromLabel = m.SenderName }
-				if m.FromMe {
-					fromLabel = "me"
-				}
+				fromLabel := senderLabel(m, showNames)
 				chatLabel := m.ChatName
 				if chatLabel == "" {
 					chatLabel = m.ChatJID
@@ -262,7 +256,8 @@ func newMessagesShowCmd(flags *rootFlags) *cobra.Command {
 			if m.FromMe {
 				fmt.Fprintf(os.Stdout, "From: me\n")
 			} else {
-				fromDisplay := m.SenderJID; if showNames && m.SenderName != "" { fromDisplay = m.SenderName }; fmt.Fprintf(os.Stdout, "From: %s\n", fromDisplay)
+				fromDisplay := senderLabel(m, showNames)
+				fmt.Fprintf(os.Stdout, "From: %s\n", fromDisplay)
 			}
 			if m.MediaType != "" {
 				fmt.Fprintf(os.Stdout, "Media: %s\n", m.MediaType)
@@ -314,10 +309,7 @@ func newMessagesContextCmd(flags *rootFlags) *cobra.Command {
 			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
 			fmt.Fprintln(w, "TIME\tFROM\tID\tTEXT")
 			for _, m := range msgs {
-				from := m.SenderJID; if showNames && m.SenderName != "" { from = m.SenderName }
-				if m.FromMe {
-					from = "me"
-				}
+				from := senderLabel(m, showNames)
 				line := m.Text
 				if m.MsgID == id {
 					line = ">> " + line
@@ -339,4 +331,14 @@ func newMessagesContextCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().IntVar(&after, "after", 5, "messages after")
 	cmd.Flags().BoolVar(&showNames, "names", false, "show sender names instead of JIDs")
 	return cmd
+}
+
+func senderLabel(m store.Message, showNames bool) string {
+	if m.FromMe {
+		return "me"
+	}
+	if showNames && m.SenderName != "" {
+		return m.SenderName
+	}
+	return m.SenderJID
 }

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -30,6 +30,7 @@ func newMessagesListCmd(flags *rootFlags) *cobra.Command {
 	var limit int
 	var afterStr string
 	var beforeStr string
+	var showNames bool
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -81,7 +82,7 @@ func newMessagesListCmd(flags *rootFlags) *cobra.Command {
 			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
 			fmt.Fprintln(w, "TIME\tCHAT\tFROM\tID\tTEXT")
 			for _, m := range msgs {
-				from := m.SenderJID
+				from := m.SenderJID; if showNames && m.SenderName != "" { from = m.SenderName }
 				if m.FromMe {
 					from = "me"
 				}
@@ -113,6 +114,7 @@ func newMessagesListCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().IntVar(&limit, "limit", 50, "limit results")
 	cmd.Flags().StringVar(&afterStr, "after", "", "only messages after time (RFC3339 or YYYY-MM-DD)")
 	cmd.Flags().StringVar(&beforeStr, "before", "", "only messages before time (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().BoolVar(&showNames, "names", false, "show sender names instead of JIDs")
 	return cmd
 }
 
@@ -123,6 +125,7 @@ func newMessagesSearchCmd(flags *rootFlags) *cobra.Command {
 	var afterStr string
 	var beforeStr string
 	var msgType string
+	var showNames bool
 
 	cmd := &cobra.Command{
 		Use:   "search <query>",
@@ -178,7 +181,7 @@ func newMessagesSearchCmd(flags *rootFlags) *cobra.Command {
 			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
 			fmt.Fprintf(w, "TIME\tCHAT\tFROM\tID\tMATCH\n")
 			for _, m := range msgs {
-				fromLabel := m.SenderJID
+				fromLabel := m.SenderJID; if showNames && m.SenderName != "" { fromLabel = m.SenderName }
 				if m.FromMe {
 					fromLabel = "me"
 				}
@@ -215,12 +218,14 @@ func newMessagesSearchCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&afterStr, "after", "", "only messages after time (RFC3339 or YYYY-MM-DD)")
 	cmd.Flags().StringVar(&beforeStr, "before", "", "only messages before time (RFC3339 or YYYY-MM-DD)")
 	cmd.Flags().StringVar(&msgType, "type", "", "media type filter (image|video|audio|document)")
+	cmd.Flags().BoolVar(&showNames, "names", false, "show sender names instead of JIDs")
 	return cmd
 }
 
 func newMessagesShowCmd(flags *rootFlags) *cobra.Command {
 	var chat string
 	var id string
+	var showNames bool
 
 	cmd := &cobra.Command{
 		Use:   "show",
@@ -257,7 +262,7 @@ func newMessagesShowCmd(flags *rootFlags) *cobra.Command {
 			if m.FromMe {
 				fmt.Fprintf(os.Stdout, "From: me\n")
 			} else {
-				fmt.Fprintf(os.Stdout, "From: %s\n", m.SenderJID)
+				fromDisplay := m.SenderJID; if showNames && m.SenderName != "" { fromDisplay = m.SenderName }; fmt.Fprintf(os.Stdout, "From: %s\n", fromDisplay)
 			}
 			if m.MediaType != "" {
 				fmt.Fprintf(os.Stdout, "Media: %s\n", m.MediaType)
@@ -269,6 +274,7 @@ func newMessagesShowCmd(flags *rootFlags) *cobra.Command {
 
 	cmd.Flags().StringVar(&chat, "chat", "", "chat JID")
 	cmd.Flags().StringVar(&id, "id", "", "message ID")
+	cmd.Flags().BoolVar(&showNames, "names", false, "show sender names instead of JIDs")
 	return cmd
 }
 
@@ -277,6 +283,7 @@ func newMessagesContextCmd(flags *rootFlags) *cobra.Command {
 	var id string
 	var before int
 	var after int
+	var showNames bool
 
 	cmd := &cobra.Command{
 		Use:   "context",
@@ -307,7 +314,7 @@ func newMessagesContextCmd(flags *rootFlags) *cobra.Command {
 			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
 			fmt.Fprintln(w, "TIME\tFROM\tID\tTEXT")
 			for _, m := range msgs {
-				from := m.SenderJID
+				from := m.SenderJID; if showNames && m.SenderName != "" { from = m.SenderName }
 				if m.FromMe {
 					from = "me"
 				}
@@ -330,5 +337,6 @@ func newMessagesContextCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&id, "id", "", "message ID")
 	cmd.Flags().IntVar(&before, "before", 5, "messages before")
 	cmd.Flags().IntVar(&after, "after", 5, "messages after")
+	cmd.Flags().BoolVar(&showNames, "names", false, "show sender names instead of JIDs")
 	return cmd
 }

--- a/cmd/wacli/messages_test.go
+++ b/cmd/wacli/messages_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/steipete/wacli/internal/store"
+)
+
+func TestSenderLabel(t *testing.T) {
+	t.Run("from_me_always_me", func(t *testing.T) {
+		m := store.Message{
+			FromMe:     true,
+			SenderJID:  "sender@s.whatsapp.net",
+			SenderName: "Alice",
+		}
+		if got := senderLabel(m, false); got != "me" {
+			t.Fatalf("expected me, got %q", got)
+		}
+		if got := senderLabel(m, true); got != "me" {
+			t.Fatalf("expected me, got %q", got)
+		}
+	})
+
+	t.Run("show_names_uses_sender_name_when_present", func(t *testing.T) {
+		m := store.Message{
+			SenderJID:  "sender@s.whatsapp.net",
+			SenderName: "Alice",
+		}
+		if got := senderLabel(m, true); got != "Alice" {
+			t.Fatalf("expected Alice, got %q", got)
+		}
+	})
+
+	t.Run("falls_back_to_jid", func(t *testing.T) {
+		m := store.Message{
+			SenderJID: "sender@s.whatsapp.net",
+		}
+		if got := senderLabel(m, true); got != "sender@s.whatsapp.net" {
+			t.Fatalf("expected sender@s.whatsapp.net, got %q", got)
+		}
+		if got := senderLabel(m, false); got != "sender@s.whatsapp.net" {
+			t.Fatalf("expected sender@s.whatsapp.net, got %q", got)
+		}
+	})
+}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -70,7 +70,7 @@ func (d *DB) ListMessages(p ListMessagesParams) ([]Message, error) {
 		p.Limit = 50
 	}
 	query := `
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		WHERE 1=1`
@@ -94,7 +94,7 @@ func (d *DB) ListMessages(p ListMessagesParams) ([]Message, error) {
 
 func (d *DB) GetMessage(chatJID, msgID string) (Message, error) {
 	row := d.sql.QueryRow(`
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		WHERE m.chat_jid = ? AND m.msg_id = ?
@@ -102,7 +102,7 @@ func (d *DB) GetMessage(chatJID, msgID string) (Message, error) {
 	var m Message
 	var ts int64
 	var fromMe int
-	if err := row.Scan(&m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &ts, &fromMe, &m.Text, &m.DisplayText, &m.MediaType, &m.Snippet); err != nil {
+	if err := row.Scan(&m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &m.SenderName, &ts, &fromMe, &m.Text, &m.DisplayText, &m.MediaType, &m.Snippet); err != nil {
 		return Message{}, err
 	}
 	m.Timestamp = fromUnix(ts)
@@ -155,7 +155,7 @@ func (d *DB) MessageContext(chatJID, msgID string, before, after int) ([]Message
 	}
 
 	beforeRows, err := d.scanMessages(`
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		WHERE m.chat_jid = ? AND m.ts < ?
@@ -167,7 +167,7 @@ func (d *DB) MessageContext(chatJID, msgID string, before, after int) ([]Message
 	}
 
 	afterRows, err := d.scanMessages(`
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		WHERE m.chat_jid = ? AND m.ts > ?
@@ -202,7 +202,7 @@ func (d *DB) scanMessages(query string, args ...interface{}) ([]Message, error) 
 		var m Message
 		var ts int64
 		var fromMe int
-		if err := rows.Scan(&m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &ts, &fromMe, &m.Text, &m.DisplayText, &m.MediaType, &m.Snippet); err != nil {
+		if err := rows.Scan(&m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &m.SenderName, &ts, &fromMe, &m.Text, &m.DisplayText, &m.MediaType, &m.Snippet); err != nil {
 			return nil, err
 		}
 		m.Timestamp = fromUnix(ts)

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -32,7 +32,7 @@ func (d *DB) SearchMessages(p SearchMessagesParams) ([]Message, error) {
 
 func (d *DB) searchLIKE(p SearchMessagesParams) ([]Message, error) {
 	query := `
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		WHERE (LOWER(m.text) LIKE LOWER(?) OR LOWER(m.display_text) LIKE LOWER(?) OR LOWER(m.media_caption) LIKE LOWER(?) OR LOWER(m.filename) LIKE LOWER(?) OR LOWER(COALESCE(m.chat_name,'')) LIKE LOWER(?) OR LOWER(COALESCE(m.sender_name,'')) LIKE LOWER(?) OR LOWER(COALESCE(c.name,'')) LIKE LOWER(?))`
@@ -46,7 +46,7 @@ func (d *DB) searchLIKE(p SearchMessagesParams) ([]Message, error) {
 
 func (d *DB) searchFTS(p SearchMessagesParams) ([]Message, error) {
 	query := `
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''),
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''),
 		       snippet(messages_fts, 0, '[', ']', '…', 12)
 		FROM messages_fts
 		JOIN messages m ON messages_fts.rowid = m.rowid

--- a/internal/store/search_fts_test.go
+++ b/internal/store/search_fts_test.go
@@ -37,6 +37,9 @@ func TestSearchMessagesUsesFTSWhenEnabled(t *testing.T) {
 	if len(ms) != 1 {
 		t.Fatalf("expected 1 result, got %d", len(ms))
 	}
+	if ms[0].SenderName != "Alice" {
+		t.Fatalf("expected sender name Alice, got %q", ms[0].SenderName)
+	}
 	if ms[0].Snippet == "" {
 		t.Fatalf("expected snippet for FTS search, got empty")
 	}

--- a/internal/store/search_nonfts_test.go
+++ b/internal/store/search_nonfts_test.go
@@ -37,6 +37,9 @@ func TestSearchMessagesUsesLIKEWhenFTSDisabled(t *testing.T) {
 	if len(ms) != 1 {
 		t.Fatalf("expected 1 result, got %d", len(ms))
 	}
+	if ms[0].SenderName != "Alice" {
+		t.Fatalf("expected sender name Alice, got %q", ms[0].SenderName)
+	}
 	if ms[0].Snippet != "" {
 		t.Fatalf("expected empty snippet for LIKE search, got %q", ms[0].Snippet)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -128,6 +128,64 @@ func TestMessageUpsertIdempotentAndContext(t *testing.T) {
 	}
 }
 
+func TestMessageQueriesReturnSenderName(t *testing.T) {
+	db := openTestDB(t)
+
+	chat := "group@g.us"
+	if err := db.UpsertChat(chat, "group", "Team", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+
+	base := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+	for i, id := range []string{"m1", "m2", "m3"} {
+		if err := db.UpsertMessage(UpsertMessageParams{
+			ChatJID:    chat,
+			ChatName:   "Team",
+			MsgID:      id,
+			SenderJID:  "sender@s.whatsapp.net",
+			SenderName: "Alice",
+			Timestamp:  base.Add(time.Duration(i+1) * time.Second),
+			Text:       "hello",
+		}); err != nil {
+			t.Fatalf("UpsertMessage %s: %v", id, err)
+		}
+	}
+
+	listed, err := db.ListMessages(ListMessagesParams{ChatJID: chat, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	if len(listed) != 3 {
+		t.Fatalf("expected 3 listed messages, got %d", len(listed))
+	}
+	for _, m := range listed {
+		if m.SenderName != "Alice" {
+			t.Fatalf("expected sender name Alice in list, got %q", m.SenderName)
+		}
+	}
+
+	got, err := db.GetMessage(chat, "m2")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if got.SenderName != "Alice" {
+		t.Fatalf("expected sender name Alice in GetMessage, got %q", got.SenderName)
+	}
+
+	ctx, err := db.MessageContext(chat, "m2", 1, 1)
+	if err != nil {
+		t.Fatalf("MessageContext: %v", err)
+	}
+	if len(ctx) != 3 {
+		t.Fatalf("expected 3 context messages, got %d", len(ctx))
+	}
+	for _, m := range ctx {
+		if m.SenderName != "Alice" {
+			t.Fatalf("expected sender name Alice in context, got %q", m.SenderName)
+		}
+	}
+}
+
 func TestMediaDownloadInfoAndMarkDownloaded(t *testing.T) {
 	db := openTestDB(t)
 

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -50,6 +50,7 @@ type Message struct {
 	ChatName    string
 	MsgID       string
 	SenderJID   string
+	SenderName  string
 	Timestamp   time.Time
 	FromMe      bool
 	Text        string

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -67,9 +67,16 @@ func ParseHistoryMessage(chatJID string, hist *waProto.WebMessageInfo) ParsedMes
 
 	sender := strings.TrimSpace(hist.GetKey().GetParticipant())
 	if sender == "" {
+		// Fall back to top-level Participant field on WebMessageInfo,
+		// which WhatsApp populates for group messages in history sync
+		// even when Key.Participant is empty.
+		sender = strings.TrimSpace(hist.GetParticipant())
+	}
+	if sender == "" {
 		sender = strings.TrimSpace(hist.GetKey().GetRemoteJID())
 	}
 	pm.SenderJID = sender
+	pm.PushName = strings.TrimSpace(hist.GetPushName())
 
 	if hist.GetMessage() != nil {
 		extractWAProto(hist.GetMessage(), &pm)

--- a/internal/wa/messages_test.go
+++ b/internal/wa/messages_test.go
@@ -32,6 +32,44 @@ func TestParseHistoryMessageTextAndSender(t *testing.T) {
 	}
 }
 
+func TestParseHistoryMessageGroupSenderFromTopLevelParticipant(t *testing.T) {
+	h := &waProto.WebMessageInfo{
+		Key: &waProto.MessageKey{
+			ID:        proto.String("msgid"),
+			FromMe:    proto.Bool(false),
+			RemoteJID: proto.String("group@g.us"),
+		},
+		Participant:      proto.String("sender@s.whatsapp.net"),
+		PushName:         proto.String("Alice"),
+		MessageTimestamp: proto.Uint64(uint64(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Unix())),
+		Message:          &waProto.Message{Conversation: proto.String("hello from group")},
+	}
+	pm := ParseHistoryMessage("group@g.us", h)
+	if pm.SenderJID != "sender@s.whatsapp.net" {
+		t.Fatalf("expected sender from top-level Participant, got %q", pm.SenderJID)
+	}
+	if pm.PushName != "Alice" {
+		t.Fatalf("expected PushName 'Alice', got %q", pm.PushName)
+	}
+}
+
+func TestParseHistoryMessagePushNameExtracted(t *testing.T) {
+	h := &waProto.WebMessageInfo{
+		Key: &waProto.MessageKey{
+			ID:          proto.String("msgid"),
+			FromMe:      proto.Bool(false),
+			Participant: proto.String("sender@s.whatsapp.net"),
+		},
+		PushName:         proto.String("Bob"),
+		MessageTimestamp: proto.Uint64(uint64(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Unix())),
+		Message:          &waProto.Message{Conversation: proto.String("hello")},
+	}
+	pm := ParseHistoryMessage("group@g.us", h)
+	if pm.PushName != "Bob" {
+		t.Fatalf("expected PushName 'Bob', got %q", pm.PushName)
+	}
+}
+
 func TestParseLiveMessageImageClonesBytes(t *testing.T) {
 	chat, _ := types.ParseJID("123@s.whatsapp.net")
 	sender, _ := types.ParseJID("sender@s.whatsapp.net")


### PR DESCRIPTION
## Summary

Two fixes for group message sender attribution:

1. **`ParseHistoryMessage` — extract sender identity from history sync:** Fall back to top-level `WebMessageInfo.Participant` when `Key.Participant` is empty (common in history sync for group messages), and extract `PushName` for display name resolution when contact lookup is unavailable.

2. **Include `sender_name` in all message read paths:** `ListMessages`, `GetMessage`, `SearchMessages`, and `MessageContext` queries now select `sender_name`. Added `--names` flag to `messages list/search/show/context` to display sender names instead of raw JIDs.

Default behavior is unchanged (shows JIDs). Pass `--names` to see resolved sender names. JSON output always includes both `SenderJID` and `SenderName`.

## Problem

`wacli messages list` for group chats showed raw LID JIDs (e.g. `247261854470378@lid`) even though sender names were already stored in the database. Additionally, `ParseHistoryMessage` never read `WebMessageInfo.PushName`, so history-synced messages had no fallback when `GetContact()` failed.

## Before / After

```bash
# Before
wacli messages list --chat <group> --limit 3
FROM: 247261854470378@lid
FROM: 43168884089062@lid

# After (default — unchanged)
wacli messages list --chat <group> --limit 3
FROM: 247261854470378@lid
FROM: 43168884089062@lid

# After (with --names)
wacli messages list --chat <group> --limit 3 --names
FROM: Djawad Khorosh
FROM: Daven
```

## Testing

- 2 new unit tests for `ParseHistoryMessage` (top-level Participant fallback, PushName extraction)
- Unit tests for `senderLabel` helper (me > name > JID precedence)
- Store regression tests for `ListMessages`, `GetMessage`, `MessageContext`
- FTS and LIKE search tests assert `SenderName` is returned
- All tests pass (`go test ./...`)

## Notes

- Complements #66 (LID→PN JID resolution) — this PR fixes the display layer while #66 fixes the identity layer
- Non-breaking: default output unchanged, `--names` is opt-in, JSON adds `SenderName` field (additive)

Relates to #18.