### PR TITLE
Strip + prefix from phone numbers in ParseUserOrJID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Media: recover panics per download job so one bad payload no longer drains the worker pool. (#179 — thanks @shaun0927)
 - Messages: show display text for replies, reactions, and media in `messages context`. (#183 — thanks @fuleinist)
+- Send: strip a leading `+` from phone-number recipients before building WhatsApp JIDs. (#74 — thanks @FrederickStempfle)
 - Search: keep FTS5 enabled after reopening existing databases with already-applied migrations. (#185 — thanks @iamhitarth)
 - Send: persist retry-message plaintext so linked devices can decrypt retried messages. (#186 — thanks @SimDamDev)
 - Sync: start `sync --once` idle timing after the `Connected` event. (#171 — thanks @fuleinist)

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -266,6 +266,10 @@ func ParseUserOrJID(s string) (types.JID, error) {
 	if strings.Contains(s, "@") {
 		return types.ParseJID(s)
 	}
+	s = strings.TrimPrefix(s, "+")
+	if s == "" {
+		return types.JID{}, fmt.Errorf("recipient is required")
+	}
 	return types.JID{User: s, Server: types.DefaultUserServer}, nil
 }
 

--- a/internal/wa/client_test.go
+++ b/internal/wa/client_test.go
@@ -23,20 +23,36 @@ func TestNewEnablesRetryMessageStore(t *testing.T) {
 }
 
 func TestParseUserOrJID(t *testing.T) {
-	j, err := ParseUserOrJID("1234567890")
-	if err != nil {
-		t.Fatalf("ParseUserOrJID: %v", err)
-	}
-	if j.Server != types.DefaultUserServer || j.User != "1234567890" {
-		t.Fatalf("unexpected jid: %+v", j)
+	tests := []struct {
+		name       string
+		input      string
+		wantUser   string
+		wantServer string
+		wantErr    bool
+	}{
+		{name: "phone", input: "1234567890", wantUser: "1234567890", wantServer: types.DefaultUserServer},
+		{name: "phone with plus", input: "+1234567890", wantUser: "1234567890", wantServer: types.DefaultUserServer},
+		{name: "phone with spaces and plus", input: " +1234567890 ", wantUser: "1234567890", wantServer: types.DefaultUserServer},
+		{name: "group jid", input: "123@g.us", wantUser: "123", wantServer: types.GroupServer},
+		{name: "empty after plus", input: "+", wantErr: true},
 	}
 
-	j, err = ParseUserOrJID("123@g.us")
-	if err != nil {
-		t.Fatalf("ParseUserOrJID group: %v", err)
-	}
-	if !IsGroupJID(j) {
-		t.Fatalf("expected group jid, got %+v", j)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j, err := ParseUserOrJID(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", j)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseUserOrJID: %v", err)
+			}
+			if j.Server != tt.wantServer || j.User != tt.wantUser {
+				t.Fatalf("unexpected jid: %+v", j)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Phone numbers with a `+` prefix (like `+49123456789`) get passed straight
into the JID as `+49123456789@s.whatsapp.net`, which is invalid and causes
usync to time out. Just strips the `+` before building the JID.

Added a test case for it too.

Fixes #28