### PR TITLE
feat: add presence typing/paused commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - CLI: add `--full` to disable table truncation; piped output now keeps full message IDs. (#13 — thanks @rickhallett)
+- CLI: add `presence typing` and `presence paused` commands for WhatsApp composing indicators. (#76 — thanks @redemerco)
 - Messages: add `messages list --sender`, `--from-me`, `--from-them`, and `--asc` filters. (#153 — thanks @draix)
 - Messages: extract searchable/display text from WhatsApp Business templates, buttons, interactive messages, and list replies. (#79 — thanks @terry-li-hm)
 

--- a/cmd/wacli/presence.go
+++ b/cmd/wacli/presence.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/steipete/wacli/internal/out"
+	"github.com/steipete/wacli/internal/wa"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func newPresenceCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "presence",
+		Short: "Send presence indicators (typing, paused)",
+	}
+	cmd.AddCommand(newPresenceTypingCmd(flags))
+	cmd.AddCommand(newPresencePausedCmd(flags))
+	return cmd
+}
+
+func newPresenceTypingCmd(flags *rootFlags) *cobra.Command {
+	var to string
+	var media string
+
+	cmd := &cobra.Command{
+		Use:   "typing",
+		Short: "Send a 'composing' (typing) indicator to a chat",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPresence(flags, to, types.ChatPresenceComposing, media)
+		},
+	}
+
+	cmd.Flags().StringVar(&to, "to", "", "recipient phone number or JID")
+	cmd.Flags().StringVar(&media, "media", "", "media type: 'audio' for recording indicator (default: typing text)")
+	return cmd
+}
+
+func newPresencePausedCmd(flags *rootFlags) *cobra.Command {
+	var to string
+
+	cmd := &cobra.Command{
+		Use:   "paused",
+		Short: "Send a 'paused' indicator (stop typing) to a chat",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPresence(flags, to, types.ChatPresencePaused, "")
+		},
+	}
+
+	cmd.Flags().StringVar(&to, "to", "", "recipient phone number or JID")
+	return cmd
+}
+
+func runPresence(flags *rootFlags, to string, state types.ChatPresence, media string) error {
+	if strings.TrimSpace(to) == "" {
+		return fmt.Errorf("--to is required")
+	}
+
+	ctx, cancel := withTimeout(context.Background(), flags)
+	defer cancel()
+
+	a, lk, err := newApp(ctx, flags, true, false)
+	if err != nil {
+		return err
+	}
+	defer closeApp(a, lk)
+
+	if err := a.EnsureAuthed(); err != nil {
+		return err
+	}
+	if err := a.Connect(ctx, false, nil); err != nil {
+		return err
+	}
+
+	toJID, err := wa.ParseUserOrJID(to)
+	if err != nil {
+		return err
+	}
+
+	chatMedia, err := presenceMediaFromString(media)
+	if err != nil {
+		return err
+	}
+
+	if err := a.WA().SendChatPresence(ctx, toJID, state, chatMedia); err != nil {
+		return err
+	}
+
+	if flags.asJSON {
+		return out.WriteJSON(os.Stdout, map[string]any{
+			"sent":  true,
+			"to":    toJID.String(),
+			"state": string(state),
+		})
+	}
+	fmt.Fprintf(os.Stdout, "Presence '%s' sent to %s\n", state, toJID.String())
+	return nil
+}
+
+func presenceMediaFromString(media string) (types.ChatPresenceMedia, error) {
+	switch strings.ToLower(strings.TrimSpace(media)) {
+	case "":
+		return "", nil
+	case "audio":
+		return types.ChatPresenceMediaAudio, nil
+	default:
+		return "", fmt.Errorf("unsupported --media %q (supported: audio)", media)
+	}
+}

--- a/cmd/wacli/presence_test.go
+++ b/cmd/wacli/presence_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestPresenceMediaFromString(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    types.ChatPresenceMedia
+		wantErr bool
+	}{
+		{name: "empty", input: "", want: ""},
+		{name: "audio", input: "audio", want: types.ChatPresenceMediaAudio},
+		{name: "trimmed case", input: " Audio ", want: types.ChatPresenceMediaAudio},
+		{name: "unknown", input: "video", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := presenceMediaFromString(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("presenceMediaFromString(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -51,6 +51,7 @@ func execute(args []string) error {
 	rootCmd.AddCommand(newChatsCmd(&flags))
 	rootCmd.AddCommand(newGroupsCmd(&flags))
 	rootCmd.AddCommand(newHistoryCmd(&flags))
+	rootCmd.AddCommand(newPresenceCmd(&flags))
 
 	rootCmd.SetArgs(args)
 	if err := rootCmd.Execute(); err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -42,6 +42,7 @@ type WAClient interface {
 	Upload(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error)
 	DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error)
 
+	SendChatPresence(ctx context.Context, jid types.JID, state types.ChatPresence, media types.ChatPresenceMedia) error
 	DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error)
 	RequestHistorySyncOnDemand(ctx context.Context, lastKnown types.MessageInfo, count int) (types.MessageID, error)
 	Logout(ctx context.Context) error

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -225,6 +225,10 @@ func (f *fakeWA) Upload(ctx context.Context, data []byte, mediaType whatsmeow.Me
 	return whatsmeow.UploadResponse{}, nil
 }
 
+func (f *fakeWA) SendChatPresence(ctx context.Context, jid types.JID, state types.ChatPresence, media types.ChatPresenceMedia) error {
+	return nil
+}
+
 func (f *fakeWA) DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error) {
 	return nil, fmt.Errorf("not supported")
 }

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -300,6 +300,17 @@ func (c *Client) GetGroupInfo(ctx context.Context, jid types.JID) (*types.GroupI
 	return cli.GetGroupInfo(ctx, jid)
 }
 
+// SendChatPresence sends a typing or paused indicator to a chat.
+func (c *Client) SendChatPresence(ctx context.Context, jid types.JID, state types.ChatPresence, media types.ChatPresenceMedia) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	return cli.SendChatPresence(ctx, jid, state, media)
+}
+
 func (c *Client) Logout(ctx context.Context) error {
 	c.mu.Lock()
 	cli := c.client


### PR DESCRIPTION
## Summary

- Adds `wacli presence typing --to <JID>` to send a "composing" (typing) indicator
- Adds `wacli presence paused --to <JID>` to stop the typing indicator
- Supports `--media audio` flag for recording indicator
- Includes `--json` output support

This wraps whatsmeow's existing `SendChatPresence()` method which was not exposed via the CLI.

## Motivation

Useful for bot integrations that want to show "typing..." before sending a reply, making conversations feel more natural.

## Changes

- `internal/wa/client.go`: Added `SendChatPresence` wrapper method
- `internal/app/app.go`: Added `SendChatPresence` to `WAClient` interface
- `internal/app/fake_wa_test.go`: Added stub for test fake
- `cmd/wacli/presence.go`: New command file with `typing` and `paused` subcommands
- `cmd/wacli/root.go`: Registered `presence` command

## Usage

```bash
# Show typing indicator
wacli presence typing --to 1234567890

# Show recording indicator
wacli presence typing --to 1234567890 --media audio

# Stop typing indicator
wacli presence paused --to 1234567890

# JSON output
wacli --json presence typing --to 1234567890
```

## Test plan

- [ ] Verify `wacli presence typing --to <JID>` sends composing state
- [ ] Verify `wacli presence paused --to <JID>` sends paused state
- [ ] Verify `--media audio` sends recording indicator
- [ ] Verify `--json` output format
- [ ] Verify existing tests still pass (fake implements new interface method)

🤖 Generated with [Claude Code](https://claude.com/claude-code)