### PR TITLE
feat: Refactor CLI commands for testability and better config

### DIFF
--- a/cmd/wacli/auth.go
+++ b/cmd/wacli/auth.go
@@ -37,7 +37,7 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 				mode = appPkg.SyncModeFollow
 			}
 
-			fmt.Fprintln(os.Stderr, "Starting authentication…")
+			fmt.Fprintln(cmd.ErrOrStderr(), "Starting authentication…")
 			res, err := a.Sync(ctx, appPkg.SyncOptions{
 				Mode:            mode,
 				AllowQR:         true,
@@ -46,9 +46,9 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 				RefreshGroups:   true,
 				IdleExit:        idleExit,
 				OnQRCode: func(code string) {
-					fmt.Fprintln(os.Stderr, "\nScan this QR code with WhatsApp (Linked Devices):")
-					qrterminal.GenerateHalfBlock(code, qrterminal.M, os.Stderr)
-					fmt.Fprintln(os.Stderr)
+					fmt.Fprintln(cmd.ErrOrStderr(), "\nScan this QR code with WhatsApp (Linked Devices):")
+					qrterminal.GenerateHalfBlock(code, qrterminal.M, cmd.ErrOrStderr())
+					fmt.Fprintln(cmd.ErrOrStderr())
 				},
 			})
 			if err != nil {
@@ -56,13 +56,13 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]interface{}{
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]interface{}{
 					"authenticated":   true,
 					"messages_stored": res.MessagesStored,
 				})
 			}
 
-			fmt.Fprintf(os.Stdout, "Authenticated. Messages stored: %d\n", res.MessagesStored)
+			fmt.Fprintf(cmd.OutOrStdout(), "Authenticated. Messages stored: %d\n", res.MessagesStored)
 			return nil
 		},
 	}
@@ -97,14 +97,14 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 			authed := a.WA().IsAuthed()
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{
 					"authenticated": authed,
 				})
 			}
 			if authed {
-				fmt.Fprintln(os.Stdout, "Authenticated.")
+				fmt.Fprintln(cmd.OutOrStdout(), "Authenticated.")
 			} else {
-				fmt.Fprintln(os.Stdout, "Not authenticated. Run `wacli auth`.")
+				fmt.Fprintln(cmd.OutOrStdout(), "Not authenticated. Run `wacli auth`.")
 			}
 			return nil
 		},
@@ -136,9 +136,9 @@ func newAuthLogoutCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{"logged_out": true})
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{"logged_out": true})
 			}
-			fmt.Fprintln(os.Stdout, "Logged out.")
+			fmt.Fprintln(cmd.OutOrStdout(), "Logged out.")
 			return nil
 		},
 	}

--- a/cmd/wacli/chats.go
+++ b/cmd/wacli/chats.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"text/tabwriter"
 	"time"
 
@@ -42,10 +41,10 @@ func newChatsListCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, chats)
+				return out.WriteJSON(cmd.OutOrStdout(), chats)
 			}
 
-			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
 			fmt.Fprintln(w, "KIND\tNAME\tJID\tLAST")
 			for _, c := range chats {
 				name := c.Name
@@ -86,9 +85,9 @@ func newChatsShowCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, c)
+				return out.WriteJSON(cmd.OutOrStdout(), c)
 			}
-			fmt.Fprintf(os.Stdout, "JID: %s\nKind: %s\nName: %s\nLast: %s\n", c.JID, c.Kind, c.Name, c.LastMessageTS.Local().Format(time.RFC3339))
+			fmt.Fprintf(cmd.OutOrStdout(), "JID: %s\nKind: %s\nName: %s\nLast: %s\n", c.JID, c.Kind, c.Name, c.LastMessageTS.Local().Format(time.RFC3339))
 			return nil
 		},
 	}

--- a/cmd/wacli/contacts.go
+++ b/cmd/wacli/contacts.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"text/tabwriter"
 
@@ -46,10 +45,10 @@ func newContactsSearchCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, cs)
+				return out.WriteJSON(cmd.OutOrStdout(), cs)
 			}
 
-			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
 			fmt.Fprintln(w, "ALIAS\tNAME\tPHONE\tJID")
 			for _, c := range cs {
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
@@ -91,21 +90,21 @@ func newContactsShowCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, c)
+				return out.WriteJSON(cmd.OutOrStdout(), c)
 			}
 
-			fmt.Fprintf(os.Stdout, "JID: %s\n", c.JID)
+			fmt.Fprintf(cmd.OutOrStdout(), "JID: %s\n", c.JID)
 			if c.Phone != "" {
-				fmt.Fprintf(os.Stdout, "Phone: %s\n", c.Phone)
+				fmt.Fprintf(cmd.OutOrStdout(), "Phone: %s\n", c.Phone)
 			}
 			if c.Name != "" {
-				fmt.Fprintf(os.Stdout, "Name: %s\n", c.Name)
+				fmt.Fprintf(cmd.OutOrStdout(), "Name: %s\n", c.Name)
 			}
 			if c.Alias != "" {
-				fmt.Fprintf(os.Stdout, "Alias: %s\n", c.Alias)
+				fmt.Fprintf(cmd.OutOrStdout(), "Alias: %s\n", c.Alias)
 			}
 			if len(c.Tags) > 0 {
-				fmt.Fprintf(os.Stdout, "Tags: %s\n", strings.Join(c.Tags, ", "))
+				fmt.Fprintf(cmd.OutOrStdout(), "Tags: %s\n", strings.Join(c.Tags, ", "))
 			}
 			return nil
 		},
@@ -150,9 +149,9 @@ func newContactsRefreshCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{"contacts": count})
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{"contacts": count})
 			}
-			fmt.Fprintf(os.Stdout, "Imported %d contacts.\n", count)
+			fmt.Fprintf(cmd.OutOrStdout(), "Imported %d contacts.\n", count)
 			return nil
 		},
 	}
@@ -184,9 +183,9 @@ func newContactsAliasCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{"jid": jid, "alias": alias})
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{"jid": jid, "alias": alias})
 			}
-			fmt.Fprintln(os.Stdout, "OK")
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
 			return nil
 		},
 	})
@@ -209,9 +208,9 @@ func newContactsAliasCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{"jid": jid, "removed": true})
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{"jid": jid, "removed": true})
 			}
-			fmt.Fprintln(os.Stdout, "OK")
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
 			return nil
 		},
 	})
@@ -246,9 +245,9 @@ func newContactsTagsCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{"jid": jid, "tag": tag})
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{"jid": jid, "tag": tag})
 			}
-			fmt.Fprintln(os.Stdout, "OK")
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
 			return nil
 		},
 	})
@@ -272,9 +271,9 @@ func newContactsTagsCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{"jid": jid, "tag": tag, "removed": true})
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{"jid": jid, "tag": tag, "removed": true})
 			}
-			fmt.Fprintln(os.Stdout, "OK")
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
 			return nil
 		},
 	})

--- a/cmd/wacli/doctor.go
+++ b/cmd/wacli/doctor.go
@@ -77,10 +77,10 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, rep)
+				return out.WriteJSON(cmd.OutOrStdout(), rep)
 			}
 
-			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
 			fmt.Fprintf(w, "STORE\t%s\n", rep.StoreDir)
 			fmt.Fprintf(w, "LOCKED\t%v\n", rep.LockHeld)
 			if rep.LockHeld && rep.LockInfo != "" {
@@ -92,7 +92,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			_ = w.Flush()
 
 			if rep.LockHeld {
-				fmt.Fprintln(os.Stdout, "\nTip: stop the running `wacli sync` before running write operations.")
+				fmt.Fprintln(cmd.OutOrStdout(), "\nTip: stop the running `wacli sync` before running write operations.")
 			}
 			return nil
 		},

--- a/cmd/wacli/groups_info_rename.go
+++ b/cmd/wacli/groups_info_rename.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -50,10 +49,10 @@ func newGroupsInfoCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, info)
+				return out.WriteJSON(cmd.OutOrStdout(), info)
 			}
 
-			fmt.Fprintf(os.Stdout, "JID: %s\nName: %s\nOwner: %s\nCreated: %s\nParticipants: %d\n",
+			fmt.Fprintf(cmd.OutOrStdout(), "JID: %s\nName: %s\nOwner: %s\nCreated: %s\nParticipants: %d\n",
 				info.JID.String(),
 				info.GroupName.Name,
 				info.OwnerJID.String(),
@@ -104,9 +103,9 @@ func newGroupsRenameCmd(flags *rootFlags) *cobra.Command {
 				_ = persistGroupInfo(a.DB(), info)
 			}
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{"jid": gjid.String(), "name": name})
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{"jid": gjid.String(), "name": name})
 			}
-			fmt.Fprintln(os.Stdout, "OK")
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
 			return nil
 		},
 	}
@@ -147,9 +146,9 @@ func newGroupsLeaveCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{"jid": gjid.String(), "left": true})
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{"jid": gjid.String(), "left": true})
 			}
-			fmt.Fprintln(os.Stdout, "OK")
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
 			return nil
 		},
 	}

--- a/cmd/wacli/groups_invite_join.go
+++ b/cmd/wacli/groups_invite_join.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -63,9 +62,9 @@ func newGroupsInviteLinkGetCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{"jid": gjid.String(), "link": link})
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{"jid": gjid.String(), "link": link})
 			}
-			fmt.Fprintln(os.Stdout, link)
+			fmt.Fprintln(cmd.OutOrStdout(), link)
 			return nil
 		},
 	}
@@ -106,9 +105,9 @@ func newGroupsInviteLinkRevokeCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{"jid": gjid.String(), "link": link, "revoked": true})
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{"jid": gjid.String(), "link": link, "revoked": true})
 			}
-			fmt.Fprintln(os.Stdout, link)
+			fmt.Fprintln(cmd.OutOrStdout(), link)
 			return nil
 		},
 	}
@@ -148,9 +147,9 @@ func newGroupsJoinCmd(flags *rootFlags) *cobra.Command {
 				_ = persistGroupInfo(a.DB(), info)
 			}
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{"jid": jid.String(), "joined": true})
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{"jid": jid.String(), "joined": true})
 			}
-			fmt.Fprintf(os.Stdout, "Joined: %s\n", jid.String())
+			fmt.Fprintf(cmd.OutOrStdout(), "Joined: %s\n", jid.String())
 			return nil
 		},
 	}

--- a/cmd/wacli/groups_participants.go
+++ b/cmd/wacli/groups_participants.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -72,9 +71,9 @@ func newGroupsParticipantsActionCmd(flags *rootFlags, action string) *cobra.Comm
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, updated)
+				return out.WriteJSON(cmd.OutOrStdout(), updated)
 			}
-			fmt.Fprintln(os.Stdout, "OK")
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
 			return nil
 		},
 	}

--- a/cmd/wacli/groups_refresh_list.go
+++ b/cmd/wacli/groups_refresh_list.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"text/tabwriter"
 	"time"
 
@@ -45,9 +44,9 @@ func newGroupsRefreshCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{"groups": len(gs)})
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{"groups": len(gs)})
 			}
-			fmt.Fprintf(os.Stdout, "Imported %d groups.\n", len(gs))
+			fmt.Fprintf(cmd.OutOrStdout(), "Imported %d groups.\n", len(gs))
 			return nil
 		},
 	}
@@ -75,10 +74,10 @@ func newGroupsListCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, gs)
+				return out.WriteJSON(cmd.OutOrStdout(), gs)
 			}
 
-			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
 			fmt.Fprintln(w, "NAME\tJID\tCREATED")
 			for _, g := range gs {
 				name := g.Name

--- a/cmd/wacli/helpers.go
+++ b/cmd/wacli/helpers.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -9,8 +10,12 @@ import (
 	"golang.org/x/term"
 )
 
-func isTTY() bool {
-	return term.IsTerminal(int(os.Stdout.Fd()))
+func isTTY(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd()))
 }
 
 func parseTime(s string) (time.Time, error) {

--- a/cmd/wacli/history.go
+++ b/cmd/wacli/history.go
@@ -58,7 +58,7 @@ func newHistoryBackfillCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{
 					"chat":            res.ChatJID,
 					"requests_sent":   res.RequestsSent,
 					"responses_seen":  res.ResponsesSeen,
@@ -67,7 +67,7 @@ func newHistoryBackfillCmd(flags *rootFlags) *cobra.Command {
 				})
 			}
 
-			fmt.Fprintf(os.Stdout, "Backfill complete for %s. Added %d messages (%d requests).\n", res.ChatJID, res.MessagesAdded, res.RequestsSent)
+			fmt.Fprintf(cmd.OutOrStdout(), "Backfill complete for %s. Added %d messages (%d requests).\n", res.ChatJID, res.MessagesAdded, res.RequestsSent)
 			return nil
 		},
 	}

--- a/cmd/wacli/main.go
+++ b/cmd/wacli/main.go
@@ -2,43 +2,13 @@ package main
 
 import (
 	"os"
-	"strings"
 
-	"go.mau.fi/whatsmeow/proto/waCompanionReg"
-	"go.mau.fi/whatsmeow/store"
-	"google.golang.org/protobuf/proto"
+	"github.com/steipete/wacli/internal/config"
 )
 
 func main() {
-	applyDeviceLabel()
-	if err := execute(os.Args[1:]); err != nil {
+	config.ApplyDeviceConfigFromEnv()
+	if err := execute(os.Args[1:], os.Stdout, os.Stderr); err != nil {
 		os.Exit(1)
 	}
-}
-
-func applyDeviceLabel() {
-	label := strings.TrimSpace(os.Getenv("WACLI_DEVICE_LABEL"))
-	platformRaw := strings.TrimSpace(os.Getenv("WACLI_DEVICE_PLATFORM"))
-	if platformRaw != "" {
-		platform := parsePlatformType(platformRaw)
-		store.DeviceProps.PlatformType = platform.Enum()
-	}
-	if label == "" {
-		return
-	}
-	store.SetOSInfo(label, [3]uint32{0, 1, 0})
-	store.BaseClientPayload.UserAgent.Device = proto.String(label)
-	store.BaseClientPayload.UserAgent.Manufacturer = proto.String(label)
-}
-
-func parsePlatformType(raw string) waCompanionReg.DeviceProps_PlatformType {
-	value := strings.TrimSpace(raw)
-	if value == "" {
-		return waCompanionReg.DeviceProps_CHROME
-	}
-	value = strings.ToUpper(value)
-	if enumValue, ok := waCompanionReg.DeviceProps_PlatformType_value[value]; ok {
-		return waCompanionReg.DeviceProps_PlatformType(enumValue)
-	}
-	return waCompanionReg.DeviceProps_CHROME
 }

--- a/cmd/wacli/media.go
+++ b/cmd/wacli/media.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -80,9 +79,9 @@ func newMediaDownloadCmd(flags *rootFlags) *cobra.Command {
 				"downloaded_at": now.Format(time.RFC3339Nano),
 			}
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, resp)
+				return out.WriteJSON(cmd.OutOrStdout(), resp)
 			}
-			fmt.Fprintf(os.Stdout, "%s (%d bytes)\n", target, bytes)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s (%d bytes)\n", target, bytes)
 			return nil
 		},
 	}

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -72,13 +71,13 @@ func newMessagesListCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{
 					"messages": msgs,
 					"fts":      a.DB().HasFTS(),
 				})
 			}
 
-			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
 			fmt.Fprintln(w, "TIME\tCHAT\tFROM\tID\tTEXT")
 			for _, m := range msgs {
 				from := m.SenderJID
@@ -169,13 +168,13 @@ func newMessagesSearchCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{
 					"messages": msgs,
 					"fts":      a.DB().HasFTS(),
 				})
 			}
 
-			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
 			fmt.Fprintf(w, "TIME\tCHAT\tFROM\tID\tMATCH\n")
 			for _, m := range msgs {
 				fromLabel := m.SenderJID
@@ -203,7 +202,7 @@ func newMessagesSearchCmd(flags *rootFlags) *cobra.Command {
 			}
 			_ = w.Flush()
 			if !a.DB().HasFTS() {
-				fmt.Fprintln(os.Stderr, "Note: FTS5 not enabled; search is using LIKE (slow).")
+				fmt.Fprintln(cmd.ErrOrStderr(), "Note: FTS5 not enabled; search is using LIKE (slow).")
 			}
 			return nil
 		},
@@ -245,24 +244,24 @@ func newMessagesShowCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, m)
+				return out.WriteJSON(cmd.OutOrStdout(), m)
 			}
 
-			fmt.Fprintf(os.Stdout, "Chat: %s\n", m.ChatJID)
+			fmt.Fprintf(cmd.OutOrStdout(), "Chat: %s\n", m.ChatJID)
 			if m.ChatName != "" {
-				fmt.Fprintf(os.Stdout, "Chat name: %s\n", m.ChatName)
+				fmt.Fprintf(cmd.OutOrStdout(), "Chat name: %s\n", m.ChatName)
 			}
-			fmt.Fprintf(os.Stdout, "ID: %s\n", m.MsgID)
-			fmt.Fprintf(os.Stdout, "Time: %s\n", m.Timestamp.Local().Format(time.RFC3339))
+			fmt.Fprintf(cmd.OutOrStdout(), "ID: %s\n", m.MsgID)
+			fmt.Fprintf(cmd.OutOrStdout(), "Time: %s\n", m.Timestamp.Local().Format(time.RFC3339))
 			if m.FromMe {
-				fmt.Fprintf(os.Stdout, "From: me\n")
+				fmt.Fprintf(cmd.OutOrStdout(), "From: me\n")
 			} else {
-				fmt.Fprintf(os.Stdout, "From: %s\n", m.SenderJID)
+				fmt.Fprintf(cmd.OutOrStdout(), "From: %s\n", m.SenderJID)
 			}
 			if m.MediaType != "" {
-				fmt.Fprintf(os.Stdout, "Media: %s\n", m.MediaType)
+				fmt.Fprintf(cmd.OutOrStdout(), "Media: %s\n", m.MediaType)
 			}
-			fmt.Fprintf(os.Stdout, "\n%s\n", m.Text)
+			fmt.Fprintf(cmd.OutOrStdout(), "\n%s\n", m.Text)
 			return nil
 		},
 	}
@@ -301,10 +300,10 @@ func newMessagesContextCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, msgs)
+				return out.WriteJSON(cmd.OutOrStdout(), msgs)
 			}
 
-			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
 			fmt.Fprintln(w, "TIME\tFROM\tID\tTEXT")
 			for _, m := range msgs {
 				from := m.SenderJID

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
+	"io"
 	"path/filepath"
 	"time"
 
@@ -23,7 +23,7 @@ type rootFlags struct {
 	timeout  time.Duration
 }
 
-func execute(args []string) error {
+func execute(args []string, stdout, stderr io.Writer) error {
 	var flags rootFlags
 
 	rootCmd := &cobra.Command{
@@ -32,6 +32,8 @@ func execute(args []string) error {
 		SilenceErrors: true,
 		Version:       version,
 	}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stderr)
 	rootCmd.SetVersionTemplate("wacli {{.Version}}\n")
 
 	rootCmd.PersistentFlags().StringVar(&flags.storeDir, "store", "", "store directory (default: ~/.wacli)")
@@ -52,7 +54,7 @@ func execute(args []string) error {
 
 	rootCmd.SetArgs(args)
 	if err := rootCmd.Execute(); err != nil {
-		_ = out.WriteError(os.Stderr, flags.asJSON, err)
+		_ = out.WriteError(stderr, flags.asJSON, err)
 		return err
 	}
 	return nil

--- a/cmd/wacli/root_test.go
+++ b/cmd/wacli/root_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestExecute_Version(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	// Execute "version" command
+	// We pass stdout/stderr, hoping the command writes to them.
+	err := execute([]string{"version"}, stdout, stderr)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, version) {
+		t.Errorf("expected output to contain version %q, got %q", version, out)
+	}
+}

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -77,13 +76,13 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 			})
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{
 					"sent": true,
 					"to":   chat.String(),
 					"id":   msgID,
 				})
 			}
-			fmt.Fprintf(os.Stdout, "Sent to %s (id %s)\n", chat.String(), msgID)
+			fmt.Fprintf(cmd.OutOrStdout(), "Sent to %s (id %s)\n", chat.String(), msgID)
 			return nil
 		},
 	}

--- a/cmd/wacli/send_file_cmd.go
+++ b/cmd/wacli/send_file_cmd.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/steipete/wacli/internal/out"
@@ -52,14 +51,14 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{
 					"sent": true,
 					"to":   toJID.String(),
 					"id":   msgID,
 					"file": meta,
 				})
 			}
-			fmt.Fprintf(os.Stdout, "Sent %s to %s (id %s)\n", meta["name"], toJID.String(), msgID)
+			fmt.Fprintf(cmd.OutOrStdout(), "Sent %s to %s (id %s)\n", meta["name"], toJID.String(), msgID)
 			return nil
 		},
 	}

--- a/cmd/wacli/sync.go
+++ b/cmd/wacli/sync.go
@@ -60,12 +60,12 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{
+				return out.WriteJSON(cmd.OutOrStdout(), map[string]any{
 					"synced":          true,
 					"messages_stored": res.MessagesStored,
 				})
 			}
-			fmt.Fprintf(os.Stdout, "Messages stored: %d\n", res.MessagesStored)
+			fmt.Fprintf(cmd.OutOrStdout(), "Messages stored: %d\n", res.MessagesStored)
 			return nil
 		},
 	}

--- a/cmd/wacli/version.go
+++ b/cmd/wacli/version.go
@@ -11,7 +11,7 @@ func newVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print version",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(version)
+			fmt.Fprintln(cmd.OutOrStdout(), version)
 		},
 	}
 }

--- a/internal/config/device.go
+++ b/internal/config/device.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"os"
+	"strings"
+
+	"go.mau.fi/whatsmeow/proto/waCompanionReg"
+	"go.mau.fi/whatsmeow/store"
+	"google.golang.org/protobuf/proto"
+)
+
+// ApplyDeviceConfigFromEnv reads WACLI_DEVICE_LABEL and WACLI_DEVICE_PLATFORM
+// from environment variables and configures the global whatsmeow store settings.
+func ApplyDeviceConfigFromEnv() {
+	label := strings.TrimSpace(os.Getenv("WACLI_DEVICE_LABEL"))
+	platformRaw := strings.TrimSpace(os.Getenv("WACLI_DEVICE_PLATFORM"))
+	
+	if platformRaw != "" {
+		platform := parsePlatformType(platformRaw)
+		store.DeviceProps.PlatformType = platform.Enum()
+	}
+	
+	if label != "" {
+		store.SetOSInfo(label, [3]uint32{0, 1, 0})
+		store.BaseClientPayload.UserAgent.Device = proto.String(label)
+		store.BaseClientPayload.UserAgent.Manufacturer = proto.String(label)
+	}
+}
+
+func parsePlatformType(raw string) waCompanionReg.DeviceProps_PlatformType {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return waCompanionReg.DeviceProps_CHROME
+	}
+	value = strings.ToUpper(value)
+	if enumValue, ok := waCompanionReg.DeviceProps_PlatformType_value[value]; ok {
+		return waCompanionReg.DeviceProps_PlatformType(enumValue)
+	}
+	return waCompanionReg.DeviceProps_CHROME
+}

--- a/internal/config/device_test.go
+++ b/internal/config/device_test.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/proto/waCompanionReg"
+	"go.mau.fi/whatsmeow/store"
+)
+
+func TestApplyDeviceConfigFromEnv(t *testing.T) {
+	// Reset store state before each test if possible, but store global state is persistent.
+	// Since tests run sequentially (unless t.Parallel()), we rely on setting env vars.
+	// Note: We cannot easily reset store globals completely without manual resets.
+	// We will just verify specific changes.
+
+	t.Run("Default", func(t *testing.T) {
+		t.Setenv("WACLI_DEVICE_LABEL", "")
+		t.Setenv("WACLI_DEVICE_PLATFORM", "")
+		
+		// Reset to default manually for test baseline
+		store.DeviceProps.PlatformType = waCompanionReg.DeviceProps_CHROME.Enum()
+		store.SetOSInfo("Go", [3]uint32{0, 1, 0}) // default in whatsmeow
+
+		ApplyDeviceConfigFromEnv()
+
+		if store.DeviceProps.GetPlatformType() != waCompanionReg.DeviceProps_CHROME {
+			t.Errorf("expected default platform CHROME, got %v", store.DeviceProps.GetPlatformType())
+		}
+	})
+
+	t.Run("OverridePlatform", func(t *testing.T) {
+		t.Setenv("WACLI_DEVICE_PLATFORM", "SAFARI")
+		ApplyDeviceConfigFromEnv()
+
+		if store.DeviceProps.GetPlatformType() != waCompanionReg.DeviceProps_SAFARI {
+			t.Errorf("expected platform SAFARI, got %v", store.DeviceProps.GetPlatformType())
+		}
+	})
+
+	t.Run("OverrideLabel", func(t *testing.T) {
+		label := "TestDevice"
+		t.Setenv("WACLI_DEVICE_LABEL", label)
+		ApplyDeviceConfigFromEnv()
+
+		if store.DeviceProps.GetOs() != label {
+			t.Errorf("expected OS label %q, got %q", label, store.DeviceProps.GetOs())
+		}
+		
+		// Verify protobuf fields
+		if got := store.BaseClientPayload.UserAgent.GetDevice(); got != label {
+			t.Errorf("expected UserAgent.Device %q, got %q", label, got)
+		}
+		if got := store.BaseClientPayload.UserAgent.GetManufacturer(); got != label {
+			t.Errorf("expected UserAgent.Manufacturer %q, got %q", label, got)
+		}
+	})
+
+	t.Run("InvalidPlatformDefaultsToChrome", func(t *testing.T) {
+		t.Setenv("WACLI_DEVICE_PLATFORM", "INVALID_PLATFORM_XYZ")
+		// Manually set to something else first to ensure change happens (or stays default)
+		// Wait, if it's invalid, it should reset to Chrome? Or just ignore?
+		// Logic: if platformRaw != "", it calls parsePlatformType.
+		// parsePlatformType returns CHROME for invalid input.
+		// So it should reset to CHROME.
+		
+		// Set to IE first
+		store.DeviceProps.PlatformType = waCompanionReg.DeviceProps_IE.Enum()
+		
+		ApplyDeviceConfigFromEnv()
+
+		if store.DeviceProps.GetPlatformType() != waCompanionReg.DeviceProps_CHROME {
+			t.Errorf("expected fallback to CHROME for invalid platform, got %v", store.DeviceProps.GetPlatformType())
+		}
+	})
+}
+
+func TestParsePlatformType(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected waCompanionReg.DeviceProps_PlatformType
+	}{
+		{"", waCompanionReg.DeviceProps_CHROME},
+		{"chrome", waCompanionReg.DeviceProps_CHROME},
+		{"CHROME", waCompanionReg.DeviceProps_CHROME},
+		{"safari", waCompanionReg.DeviceProps_SAFARI},
+		{"FIREFOX", waCompanionReg.DeviceProps_FIREFOX},
+		{"ie", waCompanionReg.DeviceProps_IE},
+		{"unknown", waCompanionReg.DeviceProps_UNKNOWN},
+		{"GARBAGE_VALUE", waCompanionReg.DeviceProps_CHROME},
+		{"  safari  ", waCompanionReg.DeviceProps_SAFARI},
+	}
+
+	for _, tc := range tests {
+		got := parsePlatformType(tc.input)
+		if got != tc.expected {
+			t.Errorf("parsePlatformType(%q) = %v, want %v", tc.input, got, tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
This PR refactors the CLI commands to use cmd.OutOrStdout() and cmd.ErrOrStderr() instead of hardcoded os.Stdout/os.Stderr. This enables better testing by allowing output capture in buffers.

Additionally:
- Moves device configuration logic from main.go to internal/config/device.go.
- Adds unit tests for device configuration logic (fixing missing coverage).
- Adds a basic integration test for the version command in cmd/wacli/root_test.go.

This change paves the way for adding more comprehensive CLI tests in the future.