### PR TITLE
feat: message edit and delete (revoke) for sent messages

### DIFF
--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steipete/wacli/internal/out"
 	"github.com/steipete/wacli/internal/store"
+	"github.com/steipete/wacli/internal/wa"
+	"go.mau.fi/whatsmeow/types"
 )
 
 func newMessagesCmd(flags *rootFlags) *cobra.Command {
@@ -22,6 +24,8 @@ func newMessagesCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newMessagesSearchCmd(flags))
 	cmd.AddCommand(newMessagesShowCmd(flags))
 	cmd.AddCommand(newMessagesContextCmd(flags))
+	cmd.AddCommand(newMessagesDeleteCmd(flags))
+	cmd.AddCommand(newMessagesEditCmd(flags))
 	return cmd
 }
 
@@ -330,5 +334,149 @@ func newMessagesContextCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&id, "id", "", "message ID")
 	cmd.Flags().IntVar(&before, "before", 5, "messages before")
 	cmd.Flags().IntVar(&after, "after", 5, "messages after")
+	return cmd
+}
+
+func newMessagesDeleteCmd(flags *rootFlags) *cobra.Command {
+	var chat string
+	var id string
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete (revoke) a message for everyone",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if chat == "" || id == "" {
+				return fmt.Errorf("--chat and --id are required")
+			}
+
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+
+			m, err := a.DB().GetMessage(chat, id)
+			if err != nil {
+				return err
+			}
+			if !m.FromMe {
+				return fmt.Errorf("can only delete your own messages")
+			}
+
+			chatJID, err := wa.ParseUserOrJID(chat)
+			if err != nil {
+				return err
+			}
+
+			if err := a.WA().RevokeMessage(ctx, chatJID, types.MessageID(id)); err != nil {
+				return err
+			}
+			if err := a.DB().MarkRevoked(chat, id); err != nil {
+				return err
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"revoked": true,
+					"chat":    chat,
+					"id":      id,
+				})
+			}
+			fmt.Fprintf(os.Stdout, "Revoked message %s in %s\n", id, chat)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&chat, "chat", "", "chat JID")
+	cmd.Flags().StringVar(&id, "id", "", "message ID")
+	return cmd
+}
+
+func newMessagesEditCmd(flags *rootFlags) *cobra.Command {
+	var chat string
+	var id string
+	var message string
+
+	cmd := &cobra.Command{
+		Use:   "edit",
+		Short: "Edit a message you sent (within WhatsApp's edit window)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if chat == "" || id == "" || message == "" {
+				return fmt.Errorf("--chat, --id and --message are required")
+			}
+
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+
+			m, err := a.DB().GetMessage(chat, id)
+			if err != nil {
+				return err
+			}
+			if !m.FromMe {
+				return fmt.Errorf("can only edit your own messages")
+			}
+
+			chatJID, err := wa.ParseUserOrJID(chat)
+			if err != nil {
+				return err
+			}
+
+			_, err = a.WA().EditMessage(ctx, chatJID, types.MessageID(id), message)
+			if err != nil {
+				return err
+			}
+
+			chatName := m.ChatName
+			if chatName == "" {
+				chatName = a.WA().ResolveChatName(ctx, chatJID, "")
+			}
+			_ = a.DB().UpsertMessage(store.UpsertMessageParams{
+				ChatJID:     chat,
+				ChatName:    chatName,
+				MsgID:       id,
+				SenderJID:   "",
+				SenderName:  "me",
+				Timestamp:   m.Timestamp,
+				FromMe:      true,
+				Text:       message,
+				DisplayText: message,
+			})
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"edited": true,
+					"chat":   chat,
+					"id":     id,
+				})
+			}
+			fmt.Fprintf(os.Stdout, "Edited message %s in %s\n", id, chat)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&chat, "chat", "", "chat JID")
+	cmd.Flags().StringVar(&id, "id", "", "message ID")
+	cmd.Flags().StringVar(&message, "message", "", "new message text")
 	return cmd
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -39,6 +39,8 @@ type WAClient interface {
 
 	SendText(ctx context.Context, to types.JID, text string) (types.MessageID, error)
 	SendProtoMessage(ctx context.Context, to types.JID, msg *waProto.Message) (types.MessageID, error)
+	RevokeMessage(ctx context.Context, chat types.JID, msgID types.MessageID) error
+	EditMessage(ctx context.Context, chat types.JID, msgID types.MessageID, newText string) (types.MessageID, error)
 	Upload(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error)
 	DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error)
 

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -212,6 +212,14 @@ func (f *fakeWA) SendProtoMessage(ctx context.Context, to types.JID, msg *waProt
 	return types.MessageID("msgid"), nil
 }
 
+func (f *fakeWA) RevokeMessage(ctx context.Context, chat types.JID, msgID types.MessageID) error {
+	return nil
+}
+
+func (f *fakeWA) EditMessage(ctx context.Context, chat types.JID, msgID types.MessageID, newText string) (types.MessageID, error) {
+	return types.MessageID("edit-msgid"), nil
+}
+
 func (f *fakeWA) Upload(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error) {
 	return whatsmeow.UploadResponse{}, nil
 }

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -84,22 +84,32 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 
 		switch v := evt.(type) {
 		case *events.Message:
-			pm := wa.ParseLiveMessage(v)
-			if pm.ReactionToID != "" && pm.ReactionEmoji == "" && v.Message != nil && v.Message.GetEncReactionMessage() != nil {
-				if reaction, err := a.wa.DecryptReaction(ctx, v); err == nil && reaction != nil {
-					pm.ReactionEmoji = reaction.GetText()
-					if pm.ReactionToID == "" {
-						if key := reaction.GetKey(); key != nil {
-							pm.ReactionToID = key.GetID()
+			if chatJID, msgID, isRevoke := wa.RevokeInfo(v); isRevoke {
+				if err := a.db.MarkRevoked(chatJID, msgID); err == nil {
+					messagesStored.Add(1)
+				}
+			} else if editPM, isEdit := wa.ParseEditEvent(v); isEdit {
+				if err := a.storeParsedMessage(ctx, editPM); err == nil {
+					messagesStored.Add(1)
+				}
+			} else {
+				pm := wa.ParseLiveMessage(v)
+				if pm.ReactionToID != "" && pm.ReactionEmoji == "" && v.Message != nil && v.Message.GetEncReactionMessage() != nil {
+					if reaction, err := a.wa.DecryptReaction(ctx, v); err == nil && reaction != nil {
+						pm.ReactionEmoji = reaction.GetText()
+						if pm.ReactionToID == "" {
+							if key := reaction.GetKey(); key != nil {
+								pm.ReactionToID = key.GetID()
+							}
 						}
 					}
 				}
-			}
-			if err := a.storeParsedMessage(ctx, pm); err == nil {
-				messagesStored.Add(1)
-			}
-			if opts.DownloadMedia && pm.Media != nil && pm.ID != "" {
-				enqueueMedia(pm.Chat.String(), pm.ID)
+				if err := a.storeParsedMessage(ctx, pm); err == nil {
+					messagesStored.Add(1)
+				}
+				if opts.DownloadMedia && pm.Media != nil && pm.ID != "" {
+					enqueueMedia(pm.Chat.String(), pm.ID)
+				}
 			}
 			if messagesStored.Load()%25 == 0 {
 				fmt.Fprintf(os.Stderr, "\rSynced %d messages...", messagesStored.Load())

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -25,6 +25,7 @@ type UpsertMessageParams struct {
 	FileSHA256    []byte
 	FileEncSHA256 []byte
 	FileLength    uint64
+	Revoked       bool
 }
 
 func (d *DB) UpsertMessage(p UpsertMessageParams) error {
@@ -32,8 +33,8 @@ func (d *DB) UpsertMessage(p UpsertMessageParams) error {
 		INSERT INTO messages(
 			chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, display_text,
 			media_type, media_caption, filename, mime_type, direct_path,
-			media_key, file_sha256, file_enc_sha256, file_length
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			media_key, file_sha256, file_enc_sha256, file_length, revoked
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
 			chat_name=COALESCE(NULLIF(excluded.chat_name,''), messages.chat_name),
 			sender_jid=excluded.sender_jid,
@@ -50,11 +51,17 @@ func (d *DB) UpsertMessage(p UpsertMessageParams) error {
 			media_key=CASE WHEN excluded.media_key IS NOT NULL AND length(excluded.media_key)>0 THEN excluded.media_key ELSE messages.media_key END,
 			file_sha256=CASE WHEN excluded.file_sha256 IS NOT NULL AND length(excluded.file_sha256)>0 THEN excluded.file_sha256 ELSE messages.file_sha256 END,
 			file_enc_sha256=CASE WHEN excluded.file_enc_sha256 IS NOT NULL AND length(excluded.file_enc_sha256)>0 THEN excluded.file_enc_sha256 ELSE messages.file_enc_sha256 END,
-			file_length=CASE WHEN excluded.file_length>0 THEN excluded.file_length ELSE messages.file_length END
+			file_length=CASE WHEN excluded.file_length>0 THEN excluded.file_length ELSE messages.file_length END,
+			revoked=CASE WHEN excluded.revoked != 0 THEN excluded.revoked ELSE messages.revoked END
 	`, p.ChatJID, nullIfEmpty(p.ChatName), p.MsgID, nullIfEmpty(p.SenderJID), nullIfEmpty(p.SenderName), unix(p.Timestamp), boolToInt(p.FromMe), nullIfEmpty(p.Text), nullIfEmpty(p.DisplayText),
 		nullIfEmpty(p.MediaType), nullIfEmpty(p.MediaCaption), nullIfEmpty(p.Filename), nullIfEmpty(p.MimeType), nullIfEmpty(p.DirectPath),
-		p.MediaKey, p.FileSHA256, p.FileEncSHA256, int64(p.FileLength),
+		p.MediaKey, p.FileSHA256, p.FileEncSHA256, int64(p.FileLength), boolToInt(p.Revoked),
 	)
+	return err
+}
+
+func (d *DB) MarkRevoked(chatJID, msgID string) error {
+	_, err := d.sql.Exec(`UPDATE messages SET revoked = 1 WHERE chat_jid = ? AND msg_id = ?`, chatJID, msgID)
 	return err
 }
 
@@ -70,10 +77,10 @@ func (d *DB) ListMessages(p ListMessagesParams) ([]Message, error) {
 		p.Limit = 50
 	}
 	query := `
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), '', COALESCE(m.revoked,0)
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
-		WHERE 1=1`
+		WHERE (m.revoked = 0 OR m.revoked IS NULL)`
 	var args []interface{}
 	if strings.TrimSpace(p.ChatJID) != "" {
 		query += " AND m.chat_jid = ?"
@@ -94,7 +101,7 @@ func (d *DB) ListMessages(p ListMessagesParams) ([]Message, error) {
 
 func (d *DB) GetMessage(chatJID, msgID string) (Message, error) {
 	row := d.sql.QueryRow(`
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), '', COALESCE(m.revoked,0)
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		WHERE m.chat_jid = ? AND m.msg_id = ?
@@ -102,11 +109,13 @@ func (d *DB) GetMessage(chatJID, msgID string) (Message, error) {
 	var m Message
 	var ts int64
 	var fromMe int
-	if err := row.Scan(&m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &ts, &fromMe, &m.Text, &m.DisplayText, &m.MediaType, &m.Snippet); err != nil {
+	var revoked int
+	if err := row.Scan(&m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &ts, &fromMe, &m.Text, &m.DisplayText, &m.MediaType, &m.Snippet, &revoked); err != nil {
 		return Message{}, err
 	}
 	m.Timestamp = fromUnix(ts)
 	m.FromMe = fromMe != 0
+	m.Revoked = revoked != 0
 	return m, nil
 }
 
@@ -127,7 +136,7 @@ func (d *DB) GetOldestMessageInfo(chatJID string) (MessageInfo, error) {
 	row := d.sql.QueryRow(`
 		SELECT m.chat_jid, m.msg_id, m.ts, m.from_me, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,'')
 		FROM messages m
-		WHERE m.chat_jid = ?
+		WHERE m.chat_jid = ? AND (m.revoked = 0 OR m.revoked IS NULL)
 		ORDER BY m.ts ASC
 		LIMIT 1
 	`, chatJID)
@@ -155,7 +164,7 @@ func (d *DB) MessageContext(chatJID, msgID string, before, after int) ([]Message
 	}
 
 	beforeRows, err := d.scanMessages(`
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), '', COALESCE(m.revoked,0)
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		WHERE m.chat_jid = ? AND m.ts < ?
@@ -167,7 +176,7 @@ func (d *DB) MessageContext(chatJID, msgID string, before, after int) ([]Message
 	}
 
 	afterRows, err := d.scanMessages(`
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), '', COALESCE(m.revoked,0)
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		WHERE m.chat_jid = ? AND m.ts > ?
@@ -202,11 +211,13 @@ func (d *DB) scanMessages(query string, args ...interface{}) ([]Message, error) 
 		var m Message
 		var ts int64
 		var fromMe int
-		if err := rows.Scan(&m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &ts, &fromMe, &m.Text, &m.DisplayText, &m.MediaType, &m.Snippet); err != nil {
+		var revoked int
+		if err := rows.Scan(&m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &ts, &fromMe, &m.Text, &m.DisplayText, &m.MediaType, &m.Snippet, &revoked); err != nil {
 			return nil, err
 		}
 		m.Timestamp = fromUnix(ts)
 		m.FromMe = fromMe != 0
+		m.Revoked = revoked != 0
 		out = append(out, m)
 	}
 	return out, rows.Err()

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -18,6 +18,7 @@ var schemaMigrations = []migration{
 	{version: 1, name: "core schema", up: migrateCoreSchema},
 	{version: 2, name: "messages display_text column", up: migrateMessagesDisplayText},
 	{version: 3, name: "messages fts", up: migrateMessagesFTS},
+	{version: 4, name: "messages revoked column", up: migrateMessagesRevoked},
 }
 
 func (d *DB) ensureSchema() error {
@@ -163,6 +164,20 @@ func migrateMessagesDisplayText(d *DB) error {
 	}
 	if _, err := d.sql.Exec(`ALTER TABLE messages ADD COLUMN display_text TEXT`); err != nil {
 		return fmt.Errorf("add display_text column: %w", err)
+	}
+	return nil
+}
+
+func migrateMessagesRevoked(d *DB) error {
+	hasRevoked, err := d.tableHasColumn("messages", "revoked")
+	if err != nil {
+		return err
+	}
+	if hasRevoked {
+		return nil
+	}
+	if _, err := d.sql.Exec(`ALTER TABLE messages ADD COLUMN revoked INTEGER NOT NULL DEFAULT 0`); err != nil {
+		return fmt.Errorf("add revoked column: %w", err)
 	}
 	return nil
 }

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -32,10 +32,10 @@ func (d *DB) SearchMessages(p SearchMessagesParams) ([]Message, error) {
 
 func (d *DB) searchLIKE(p SearchMessagesParams) ([]Message, error) {
 	query := `
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), '', COALESCE(m.revoked,0)
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
-		WHERE (LOWER(m.text) LIKE LOWER(?) OR LOWER(m.display_text) LIKE LOWER(?) OR LOWER(m.media_caption) LIKE LOWER(?) OR LOWER(m.filename) LIKE LOWER(?) OR LOWER(COALESCE(m.chat_name,'')) LIKE LOWER(?) OR LOWER(COALESCE(m.sender_name,'')) LIKE LOWER(?) OR LOWER(COALESCE(c.name,'')) LIKE LOWER(?))`
+		WHERE (m.revoked = 0 OR m.revoked IS NULL) AND (LOWER(m.text) LIKE LOWER(?) OR LOWER(m.display_text) LIKE LOWER(?) OR LOWER(m.media_caption) LIKE LOWER(?) OR LOWER(m.filename) LIKE LOWER(?) OR LOWER(COALESCE(m.chat_name,'')) LIKE LOWER(?) OR LOWER(COALESCE(m.sender_name,'')) LIKE LOWER(?) OR LOWER(COALESCE(c.name,'')) LIKE LOWER(?))`
 	needle := "%" + p.Query + "%"
 	args := []interface{}{needle, needle, needle, needle, needle, needle, needle}
 	query, args = applyMessageFilters(query, args, p)
@@ -47,11 +47,12 @@ func (d *DB) searchLIKE(p SearchMessagesParams) ([]Message, error) {
 func (d *DB) searchFTS(p SearchMessagesParams) ([]Message, error) {
 	query := `
 		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''),
-		       snippet(messages_fts, 0, '[', ']', '…', 12)
+		       snippet(messages_fts, 0, '[', ']', '…', 12),
+		       COALESCE(m.revoked,0)
 		FROM messages_fts
 		JOIN messages m ON messages_fts.rowid = m.rowid
 		LEFT JOIN chats c ON c.jid = m.chat_jid
-		WHERE messages_fts MATCH ?`
+		WHERE (m.revoked = 0 OR m.revoked IS NULL) AND messages_fts MATCH ?`
 	args := []interface{}{p.Query}
 	query, args = applyMessageFilters(query, args, p)
 	query += " ORDER BY bm25(messages_fts) LIMIT ?"

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -56,6 +56,7 @@ type Message struct {
 	DisplayText string
 	MediaType   string
 	Snippet     string
+	Revoked     bool
 }
 
 type MessageInfo struct {

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -197,6 +197,33 @@ func (c *Client) SendProtoMessage(ctx context.Context, to types.JID, msg *waProt
 	return resp.ID, nil
 }
 
+func (c *Client) RevokeMessage(ctx context.Context, chat types.JID, msgID types.MessageID) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	_, err := cli.SendMessage(ctx, chat, cli.BuildRevoke(chat, types.EmptyJID, msgID))
+	return err
+}
+
+func (c *Client) EditMessage(ctx context.Context, chat types.JID, msgID types.MessageID, newText string) (types.MessageID, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return "", fmt.Errorf("not connected")
+	}
+	newContent := &waProto.Message{Conversation: &newText}
+	editMsg := cli.BuildEdit(chat, msgID, newContent)
+	resp, err := cli.SendMessage(ctx, chat, editMsg)
+	if err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
 func (c *Client) Upload(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error) {
 	c.mu.Lock()
 	cli := c.client

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 )
@@ -34,6 +35,71 @@ type ParsedMessage struct {
 	ReplyToDisplay string
 	ReactionToID   string
 	ReactionEmoji  string
+}
+
+// RevokeInfo returns the chat JID and message ID for a revoke (delete-for-everyone) event.
+// If the event is not a revoke, ok is false.
+func RevokeInfo(evt *events.Message) (chatJID, msgID string, ok bool) {
+	if evt == nil || evt.Message == nil {
+		return "", "", false
+	}
+	proto := evt.Message.GetProtocolMessage()
+	if proto == nil || proto.GetType() != waE2E.ProtocolMessage_REVOKE {
+		return "", "", false
+	}
+	key := proto.GetKey()
+	if key == nil {
+		return "", "", false
+	}
+	chatJID = strings.TrimSpace(key.GetRemoteJID())
+	msgID = strings.TrimSpace(key.GetID())
+	if chatJID == "" || msgID == "" {
+		return "", "", false
+	}
+	return chatJID, msgID, true
+}
+
+// ParseEditEvent parses an edit event and returns a ParsedMessage for the original message
+// with updated text, so the store can upsert by (chat_jid, msg_id). If the event is not
+// an edit, ok is false.
+func ParseEditEvent(evt *events.Message) (pm ParsedMessage, ok bool) {
+	if evt == nil || evt.Message == nil {
+		return ParsedMessage{}, false
+	}
+	editedWrap := evt.Message.GetEditedMessage()
+	if editedWrap == nil || editedWrap.GetMessage() == nil {
+		return ParsedMessage{}, false
+	}
+	inner := editedWrap.GetMessage()
+	proto := inner.GetProtocolMessage()
+	if proto == nil || proto.GetType() != waE2E.ProtocolMessage_MESSAGE_EDIT {
+		return ParsedMessage{}, false
+	}
+	key := proto.GetKey()
+	if key == nil {
+		return ParsedMessage{}, false
+	}
+	originalID := strings.TrimSpace(key.GetID())
+	if originalID == "" {
+		return ParsedMessage{}, false
+	}
+	editedContent := proto.GetEditedMessage()
+	if editedContent == nil {
+		return ParsedMessage{}, false
+	}
+
+	pm = ParsedMessage{
+		Chat:      evt.Info.Chat,
+		ID:        originalID,
+		Timestamp: evt.Info.Timestamp,
+		FromMe:    evt.Info.IsFromMe,
+		PushName:  evt.Info.PushName,
+	}
+	if s := evt.Info.Sender.String(); s != "" {
+		pm.SenderJID = s
+	}
+	extractWAProto(editedContent, &pm)
+	return pm, true
 }
 
 func ParseLiveMessage(evt *events.Message) ParsedMessage {


### PR DESCRIPTION
Adds the ability to edit and delete (revoke) messages you sent.

## Changes

- **Store:** New `revoked` column (migration 4), `MarkRevoked(chatJID, msgID)`, and exclusion of revoked messages from list/search.
- **WhatsApp layer (`internal/wa`):** `RevokeMessage()` and `EditMessage()` using whatsmeow `BuildRevoke` / `BuildEdit` + `SendMessage`.
- **App:** `WAClient` interface extended with revoke/edit; fake client stubs for tests.
- **Sync:** Handles incoming revoke and edit events via `RevokeInfo` / `ParseEditEvent` and updates the local store accordingly.
- **CLI:** New subcommands:
  - `wacli messages delete --chat <jid> --id <msgid>` — revoke (delete for everyone)
  - `wacli messages edit --chat <jid> --id <msgid> --message "<text>"` — edit within WhatsApp’s ~20 min window

Only own messages (`FromMe`) can be edited or revoked.

Made with [Cursor](https://cursor.com)