### PR TITLE
feat: JSON-RPC daemon with full messaging support + LID routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md — wacli Go Production Code Standards
+
+This file is loaded by Claude Code on every session. These rules are MANDATORY.
+
+## Build & Test
+```bash
+go vet ./...
+go test ./...
+go build ./cmd/wacli/
+```
+
+## Seven Iron Rules (Strictly Enforced)
+
+1. **NO panic-capable shortcuts** — `log.Fatal()`, `panic()`, and bare `os.Exit()` are BANNED in library code. Use error returns. Only allowed in `main()` for startup failures.
+2. **NO dead code** — No unused variables, parameters, imports, or functions. Code must compile with zero warnings.
+3. **NO incomplete implementations** — No `// TODO` stubs that leave broken code paths. Every function must be fully implemented.
+4. **Business logic must be verifiable** — All code must pass `go vet`. No speculative interfaces or pseudo-implementations.
+5. **Validate with `go vet` and `go test`** — Check correctness before building.
+6. **Explicit API and error handling** — Check every error return. Never use `_` to discard errors silently without justification. Wrap errors with `fmt.Errorf("context: %w", err)`.
+7. **Minimize allocations** — Prefer slices over maps when order matters. Use `strings.Builder` for concatenation. Pass pointers for large structs. Avoid unnecessary copies.
+
+## Go Error Handling Rules
+
+```go
+// ❌ BANNED:
+result, _ := riskyOperation()     // silently discarding error
+if err != nil { panic(err) }       // panic instead of return
+
+// ✅ REQUIRED:
+result, err := riskyOperation()
+if err != nil {
+    return fmt.Errorf("operation context: %w", err)
+}
+```
+
+## Logging
+- NEVER log tokens, API keys, passwords
+- Use structured logging (slog preferred)
+
+## Commit Style
+```
+feat(scope): description
+fix(scope): description
+```
+English only in commits and code comments.

--- a/cmd/wacli/daemon.go
+++ b/cmd/wacli/daemon.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steipete/wacli/internal/rpc"
 	"github.com/steipete/wacli/internal/wa"
+	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 )
 
@@ -104,19 +105,38 @@ func runDaemon(ctx context.Context, flags *rootFlags, opts daemonOptions) error 
 	}
 
 	// Bridge whatsmeow events → EventHub.
+	resolveChatJIDForSend := func(chat types.JID) string {
+		base := chat.ToNonAD()
+		if !wa.IsLIDJID(base) {
+			return base.String()
+		}
+		resolveCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+		resolved, err := a.WA().ResolveRecipientJID(resolveCtx, base)
+		if err != nil || resolved.IsEmpty() {
+			return base.String()
+		}
+		return resolved.ToNonAD().String()
+	}
+
 	handlerID := a.WA().AddEventHandler(func(rawEvt interface{}) {
 		switch v := rawEvt.(type) {
 		case *events.Message:
 			pm := wa.ParseLiveMessage(v)
 			chatJID := pm.Chat.String()
+			resolvedJID := chatJID
+			if !wa.IsGroupJID(pm.Chat) && !pm.Chat.IsBroadcastList() {
+				resolvedJID = resolveChatJIDForSend(pm.Chat)
+			}
 			payload := map[string]any{
-				"id":        pm.ID,
-				"chatJid":   chatJID,
-				"senderJid": pm.SenderJID,
-				"selfJid":   selfJid,
-				"fromMe":    pm.FromMe,
-				"text":      pm.Text,
-				"timestamp": pm.Timestamp.UTC().Format(time.RFC3339Nano),
+				"id":          pm.ID,
+				"chatJid":     chatJID,
+				"resolvedJid": resolvedJID,
+				"senderJid":   pm.SenderJID,
+				"selfJid":     selfJid,
+				"fromMe":      pm.FromMe,
+				"text":        pm.Text,
+				"timestamp":   pm.Timestamp.UTC().Format(time.RFC3339Nano),
 			}
 			if strings.Contains(chatJID, "@g.us") {
 				if name, ok := groupNameCache[chatJID]; ok {

--- a/cmd/wacli/daemon.go
+++ b/cmd/wacli/daemon.go
@@ -81,6 +81,9 @@ func runDaemon(ctx context.Context, flags *rootFlags, opts daemonOptions) error 
 	hub := rpc.NewHub(opts.eventBuffer)
 	defer hub.Close()
 
+	// Resolve own JID for self-identification in events.
+	selfJid := a.WA().SelfJID()
+
 	// Bridge whatsmeow events → EventHub.
 	handlerID := a.WA().AddEventHandler(func(rawEvt interface{}) {
 		switch v := rawEvt.(type) {
@@ -91,6 +94,7 @@ func runDaemon(ctx context.Context, flags *rootFlags, opts daemonOptions) error 
 				"id":        pm.ID,
 				"chatJid":   chatJID,
 				"senderJid": pm.SenderJID,
+				"selfJid":   selfJid,
 				"fromMe":    pm.FromMe,
 				"text":      pm.Text,
 				"timestamp": pm.Timestamp.UTC().Format(time.RFC3339Nano),

--- a/cmd/wacli/daemon.go
+++ b/cmd/wacli/daemon.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -21,6 +22,7 @@ type daemonOptions struct {
 	listen      string
 	eventBuffer int
 	allowQR     bool
+	lockWait    time.Duration
 }
 
 func newDaemonCmd(flags *rootFlags) *cobra.Command {
@@ -60,12 +62,13 @@ Transport:
 	cmd.Flags().StringVar(&opts.listen, "listen", "127.0.0.1:8686", "TCP listen address (only used with --transport=tcp)")
 	cmd.Flags().IntVar(&opts.eventBuffer, "event-buffer", 256, "per-subscriber event channel buffer size")
 	cmd.Flags().BoolVar(&opts.allowQR, "allow-qr", false, "allow QR code authentication on first run")
+	cmd.Flags().DurationVar(&opts.lockWait, "lock-wait", 45*time.Second, "how long to wait for store lock before failing")
 
 	return cmd
 }
 
 func runDaemon(ctx context.Context, flags *rootFlags, opts daemonOptions) error {
-	a, lk, err := newApp(ctx, flags, true, opts.allowQR)
+	a, lk, err := newAppWithLockWait(ctx, flags, true, opts.allowQR, opts.lockWait)
 	if err != nil {
 		return fmt.Errorf("init app: %w", err)
 	}
@@ -81,6 +84,62 @@ func runDaemon(ctx context.Context, flags *rootFlags, opts daemonOptions) error 
 	// Event hub.
 	hub := rpc.NewHub(opts.eventBuffer)
 	defer hub.Close()
+
+	reconnectRequested := make(chan string, 1)
+	var reconnecting atomic.Bool
+	requestReconnect := func(reason string) {
+		if ctx.Err() != nil {
+			return
+		}
+		select {
+		case reconnectRequested <- reason:
+		default:
+		}
+	}
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case reason := <-reconnectRequested:
+				if !reconnecting.CompareAndSwap(false, true) {
+					continue
+				}
+				fmt.Fprintf(os.Stderr, "wacli: reconnecting to WhatsApp (%s)\n", reason)
+				if err := a.WA().ReconnectWithBackoff(ctx, 2*time.Second, 30*time.Second); err != nil {
+					if ctx.Err() == nil {
+						fmt.Fprintf(os.Stderr, "wacli: reconnect failed: %v\n", err)
+					}
+				} else {
+					fmt.Fprintln(os.Stderr, "wacli: WhatsApp reconnected")
+					hub.Publish(rpc.Event{
+						Type: "connection",
+						Payload: map[string]any{
+							"state": "connected",
+						},
+					})
+				}
+				reconnecting.Store(false)
+			}
+		}
+	}()
+
+	// Defensive watchdog in case the disconnect event is missed.
+	go func() {
+		tick := time.NewTicker(30 * time.Second)
+		defer tick.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick.C:
+				if !a.WA().IsConnected() {
+					requestReconnect("connection watchdog")
+				}
+			}
+		}
+	}()
 
 	// Resolve own JID for self-identification in events.
 	selfJid := a.WA().SelfJID()
@@ -144,6 +203,18 @@ func runDaemon(ctx context.Context, flags *rootFlags, opts daemonOptions) error 
 				} else if chat, err := a.DB().GetChat(chatJID); err == nil && strings.TrimSpace(chat.Name) != "" {
 					payload["groupName"] = chat.Name
 					groupNameCache[chatJID] = chat.Name
+				} else {
+					// Fallback: fetch from WA server.
+					groupJID, parseErr := types.ParseJID(chatJID)
+					if parseErr == nil {
+						groupInfo, infoErr := a.WA().GetGroupInfo(ctx, groupJID)
+						if infoErr == nil && groupInfo != nil && groupInfo.GroupName.Name != "" {
+							payload["groupName"] = groupInfo.GroupName.Name
+							groupNameCache[chatJID] = groupInfo.GroupName.Name
+							// Persist to DB for future lookups.
+							_ = a.DB().UpsertChat(chatJID, "group", groupInfo.GroupName.Name, time.Time{})
+						}
+					}
 				}
 			}
 			if pm.PushName != "" {
@@ -206,6 +277,23 @@ func runDaemon(ctx context.Context, flags *rootFlags, opts daemonOptions) error 
 				Type:    "presence",
 				Payload: payload,
 			})
+
+		case *events.Connected:
+			hub.Publish(rpc.Event{
+				Type: "connection",
+				Payload: map[string]any{
+					"state": "connected",
+				},
+			})
+
+		case *events.Disconnected:
+			hub.Publish(rpc.Event{
+				Type: "connection",
+				Payload: map[string]any{
+					"state": "disconnected",
+				},
+			})
+			requestReconnect("disconnected event")
 		}
 	})
 	defer a.WA().RemoveEventHandler(handlerID)

--- a/cmd/wacli/daemon.go
+++ b/cmd/wacli/daemon.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steipete/wacli/internal/rpc"
+	"github.com/steipete/wacli/internal/wa"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+type daemonOptions struct {
+	transport   string
+	listen      string
+	eventBuffer int
+	allowQR     bool
+}
+
+func newDaemonCmd(flags *rootFlags) *cobra.Command {
+	var opts daemonOptions
+
+	cmd := &cobra.Command{
+		Use:   "daemon",
+		Short: "Start a JSON-RPC 2.0 daemon (stdio or TCP transport)",
+		Long: `Run wacli as a persistent JSON-RPC 2.0 daemon.
+
+The daemon acquires an exclusive store lock so that it is the single WhatsApp
+session owner.  Clients communicate via JSON-RPC 2.0 requests/responses.
+Server-initiated event notifications (e.g. message.received) are pushed to
+clients that have called the "subscribe" method.
+
+Supported RPC methods:
+  send         – send a text message
+  listChats    – list chats from local store
+  getMessages  – retrieve message history for a chat
+  subscribe    – subscribe to real-time events (push notifications)
+
+Transport:
+  stdio  (default) – JSON-RPC on stdin/stdout; ideal for sub-process integration
+  tcp              – listen on --listen address`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return runDaemon(ctx, flags, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.transport, "transport", "stdio", "transport type: stdio or tcp")
+	cmd.Flags().StringVar(&opts.listen, "listen", "127.0.0.1:8686", "TCP listen address (only used with --transport=tcp)")
+	cmd.Flags().IntVar(&opts.eventBuffer, "event-buffer", 256, "per-subscriber event channel buffer size")
+	cmd.Flags().BoolVar(&opts.allowQR, "allow-qr", false, "allow QR code authentication on first run")
+
+	return cmd
+}
+
+func runDaemon(ctx context.Context, flags *rootFlags, opts daemonOptions) error {
+	a, lk, err := newApp(ctx, flags, true, opts.allowQR)
+	if err != nil {
+		return fmt.Errorf("init app: %w", err)
+	}
+	defer closeApp(a, lk)
+
+	// Connect to WhatsApp.
+	if err := a.Connect(ctx, opts.allowQR, func(qr string) {
+		fmt.Fprintf(os.Stderr, "Scan QR code: %s\n", qr)
+	}); err != nil {
+		return fmt.Errorf("connect to WhatsApp: %w", err)
+	}
+
+	// Event hub.
+	hub := rpc.NewHub(opts.eventBuffer)
+	defer hub.Close()
+
+	// Bridge whatsmeow events → EventHub.
+	handlerID := a.WA().AddEventHandler(func(rawEvt interface{}) {
+		switch v := rawEvt.(type) {
+		case *events.Message:
+			pm := wa.ParseLiveMessage(v)
+			payload := map[string]any{
+				"id":        pm.ID,
+				"chatJid":   pm.Chat.String(),
+				"senderJid": pm.SenderJID,
+				"fromMe":    pm.FromMe,
+				"text":      pm.Text,
+				"timestamp": pm.Timestamp.UTC().Format(time.RFC3339Nano),
+			}
+			if pm.PushName != "" {
+				payload["pushName"] = pm.PushName
+			}
+			hub.Publish(rpc.Event{
+				Type:    "message.received",
+				Payload: payload,
+			})
+
+		case *events.Receipt:
+			hub.Publish(rpc.Event{
+				Type: "message.sent",
+				Payload: map[string]any{
+					"ids":     v.MessageIDs,
+					"chatJid": v.MessageSource.Chat.String(),
+				},
+			})
+		}
+	})
+	defer a.WA().RemoveEventHandler(handlerID)
+
+	// Start RPC server.
+	srv := rpc.NewServer(a, hub)
+	fmt.Fprintf(os.Stderr, "wacli: daemon started (transport=%s)\n", opts.transport)
+
+	return srv.Serve(ctx, rpc.ServeOptions{
+		Transport: opts.transport,
+		Listen:    opts.listen,
+	})
+}

--- a/cmd/wacli/daemon.go
+++ b/cmd/wacli/daemon.go
@@ -153,6 +153,9 @@ func runDaemon(ctx context.Context, flags *rootFlags, opts daemonOptions) error 
 				payload["reactionEmoji"] = pm.ReactionEmoji
 				payload["reactionToId"] = pm.ReactionToID
 			}
+			if len(pm.MentionedJids) > 0 {
+				payload["mentionedJids"] = pm.MentionedJids
+			}
 			if pm.Media != nil {
 				payload["media"] = map[string]any{
 					"type":       pm.Media.Type,

--- a/cmd/wacli/daemon.go
+++ b/cmd/wacli/daemon.go
@@ -35,10 +35,14 @@ Server-initiated event notifications (e.g. message.received) are pushed to
 clients that have called the "subscribe" method.
 
 Supported RPC methods:
-  send         – send a text message
-  listChats    – list chats from local store
-  getMessages  – retrieve message history for a chat
-  subscribe    – subscribe to real-time events (push notifications)
+  send           – send a text message
+  listChats      – list chats from local store
+  getMessages    – retrieve message history for a chat
+  sendReaction   – send a reaction to a message
+  remoteDelete   – revoke/delete a message
+  sendFile       – upload and send a file attachment
+  searchMessages – full-text search across messages
+  subscribe      – subscribe to real-time events (push notifications)
 
 Transport:
   stdio  (default) – JSON-RPC on stdin/stdout; ideal for sub-process integration
@@ -92,6 +96,19 @@ func runDaemon(ctx context.Context, flags *rootFlags, opts daemonOptions) error 
 			if pm.PushName != "" {
 				payload["pushName"] = pm.PushName
 			}
+			if pm.ReactionEmoji != "" {
+				payload["reactionEmoji"] = pm.ReactionEmoji
+				payload["reactionToId"] = pm.ReactionToID
+			}
+			if pm.Media != nil {
+				payload["media"] = map[string]any{
+					"type":       pm.Media.Type,
+					"mimeType":   pm.Media.MimeType,
+					"caption":    pm.Media.Caption,
+					"directPath": pm.Media.DirectPath,
+					"fileLength": pm.Media.FileLength,
+				}
+			}
 			hub.Publish(rpc.Event{
 				Type:    "message.received",
 				Payload: payload,
@@ -104,6 +121,34 @@ func runDaemon(ctx context.Context, flags *rootFlags, opts daemonOptions) error 
 					"ids":     v.MessageIDs,
 					"chatJid": v.MessageSource.Chat.String(),
 				},
+			})
+
+		case *events.ChatPresence:
+			hub.Publish(rpc.Event{
+				Type: "typing",
+				Payload: map[string]any{
+					"chatJid":   v.MessageSource.Chat.String(),
+					"senderJid": v.MessageSource.Sender.String(),
+					"state":     string(v.State),
+					"media":     string(v.Media),
+				},
+			})
+
+		case *events.Presence:
+			status := "available"
+			if v.Unavailable {
+				status = "unavailable"
+			}
+			payload := map[string]any{
+				"from":   v.From.String(),
+				"status": status,
+			}
+			if !v.LastSeen.IsZero() {
+				payload["lastSeen"] = v.LastSeen.UTC().Format(time.RFC3339Nano)
+			}
+			hub.Publish(rpc.Event{
+				Type:    "presence",
+				Payload: payload,
 			})
 		}
 	})

--- a/cmd/wacli/daemon.go
+++ b/cmd/wacli/daemon.go
@@ -96,7 +96,9 @@ func runDaemon(ctx context.Context, flags *rootFlags, opts daemonOptions) error 
 				"timestamp": pm.Timestamp.UTC().Format(time.RFC3339Nano),
 			}
 			if strings.Contains(chatJID, "@g.us") {
-				if groups, err := a.DB().ListGroups(chatJID, 1); err == nil {
+				if chat, err := a.DB().GetChat(chatJID); err == nil && strings.TrimSpace(chat.Name) != "" {
+					payload["groupName"] = chat.Name
+				} else if groups, err := a.DB().ListGroups(chatJID, 1); err == nil {
 					for _, g := range groups {
 						if g.JID == chatJID && strings.TrimSpace(g.Name) != "" {
 							payload["groupName"] = g.Name

--- a/cmd/wacli/daemon.go
+++ b/cmd/wacli/daemon.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -85,13 +86,24 @@ func runDaemon(ctx context.Context, flags *rootFlags, opts daemonOptions) error 
 		switch v := rawEvt.(type) {
 		case *events.Message:
 			pm := wa.ParseLiveMessage(v)
+			chatJID := pm.Chat.String()
 			payload := map[string]any{
 				"id":        pm.ID,
-				"chatJid":   pm.Chat.String(),
+				"chatJid":   chatJID,
 				"senderJid": pm.SenderJID,
 				"fromMe":    pm.FromMe,
 				"text":      pm.Text,
 				"timestamp": pm.Timestamp.UTC().Format(time.RFC3339Nano),
+			}
+			if strings.Contains(chatJID, "@g.us") {
+				if groups, err := a.DB().ListGroups(chatJID, 1); err == nil {
+					for _, g := range groups {
+						if g.JID == chatJID && strings.TrimSpace(g.Name) != "" {
+							payload["groupName"] = g.Name
+							break
+						}
+					}
+				}
 			}
 			if pm.PushName != "" {
 				payload["pushName"] = pm.PushName

--- a/cmd/wacli/daemon.go
+++ b/cmd/wacli/daemon.go
@@ -84,6 +84,25 @@ func runDaemon(ctx context.Context, flags *rootFlags, opts daemonOptions) error 
 	// Resolve own JID for self-identification in events.
 	selfJid := a.WA().SelfJID()
 
+	// Pre-populate group names into local DB so event handler can look them up.
+	if groups, err := a.WA().GetJoinedGroups(ctx); err == nil {
+		for _, g := range groups {
+			_ = a.DB().UpsertGroup(g.JID.String(), g.GroupName.Name, g.OwnerJID.String(), g.GroupCreated)
+			_ = a.DB().UpsertChat(g.JID.String(), "group", g.GroupName.Name, time.Time{})
+		}
+		fmt.Fprintf(os.Stderr, "Synced %d group(s) to local DB\n", len(groups))
+	}
+
+	// In-memory group name cache for fast lookup in event handler.
+	groupNameCache := make(map[string]string)
+	if chats, err := a.DB().ListChats("", 200); err == nil {
+		for _, c := range chats {
+			if strings.Contains(c.JID, "@g.us") && c.Name != "" {
+				groupNameCache[c.JID] = c.Name
+			}
+		}
+	}
+
 	// Bridge whatsmeow events → EventHub.
 	handlerID := a.WA().AddEventHandler(func(rawEvt interface{}) {
 		switch v := rawEvt.(type) {
@@ -100,15 +119,11 @@ func runDaemon(ctx context.Context, flags *rootFlags, opts daemonOptions) error 
 				"timestamp": pm.Timestamp.UTC().Format(time.RFC3339Nano),
 			}
 			if strings.Contains(chatJID, "@g.us") {
-				if chat, err := a.DB().GetChat(chatJID); err == nil && strings.TrimSpace(chat.Name) != "" {
+				if name, ok := groupNameCache[chatJID]; ok {
+					payload["groupName"] = name
+				} else if chat, err := a.DB().GetChat(chatJID); err == nil && strings.TrimSpace(chat.Name) != "" {
 					payload["groupName"] = chat.Name
-				} else if groups, err := a.DB().ListGroups(chatJID, 1); err == nil {
-					for _, g := range groups {
-						if g.JID == chatJID && strings.TrimSpace(g.Name) != "" {
-							payload["groupName"] = g.Name
-							break
-						}
-					}
+					groupNameCache[chatJID] = chat.Name
 				}
 			}
 			if pm.PushName != "" {

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -60,6 +62,10 @@ func execute(args []string) error {
 }
 
 func newApp(ctx context.Context, flags *rootFlags, needLock bool, allowUnauthed bool) (*app.App, *lock.Lock, error) {
+	return newAppWithLockWait(ctx, flags, needLock, allowUnauthed, 0)
+}
+
+func newAppWithLockWait(ctx context.Context, flags *rootFlags, needLock bool, allowUnauthed bool, lockWait time.Duration) (*app.App, *lock.Lock, error) {
 	storeDir := flags.storeDir
 	if storeDir == "" {
 		storeDir = config.DefaultStoreDir()
@@ -68,9 +74,30 @@ func newApp(ctx context.Context, flags *rootFlags, needLock bool, allowUnauthed 
 
 	var lk *lock.Lock
 	if needLock {
+		acquire := func() (*lock.Lock, error) {
+			deadline := time.Now().Add(lockWait)
+			for {
+				cur, err := lock.Acquire(storeDir)
+				if err == nil {
+					return cur, nil
+				}
+				if lockWait <= 0 || !isStoreLockContention(err) || time.Now().After(deadline) {
+					return nil, err
+				}
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(500 * time.Millisecond):
+				}
+			}
+		}
+
 		var err error
-		lk, err = lock.Acquire(storeDir)
+		lk, err = acquire()
 		if err != nil {
+			if lockWait > 0 && isStoreLockContention(err) {
+				return nil, nil, fmt.Errorf("timed out waiting for store lock after %s: %w", lockWait, err)
+			}
 			return nil, nil, err
 		}
 	}
@@ -89,6 +116,12 @@ func newApp(ctx context.Context, flags *rootFlags, needLock bool, allowUnauthed 
 	}
 
 	return a, lk, nil
+}
+
+func isStoreLockContention(err error) bool {
+	return errors.Is(err, syscall.EWOULDBLOCK) ||
+		errors.Is(err, syscall.EAGAIN) ||
+		strings.Contains(err.Error(), "store is locked")
 }
 
 func withTimeout(ctx context.Context, flags *rootFlags) (context.Context, context.CancelFunc) {

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -49,6 +49,7 @@ func execute(args []string) error {
 	rootCmd.AddCommand(newChatsCmd(&flags))
 	rootCmd.AddCommand(newGroupsCmd(&flags))
 	rootCmd.AddCommand(newHistoryCmd(&flags))
+	rootCmd.AddCommand(newDaemonCmd(&flags))
 
 	rootCmd.SetArgs(args)
 	if err := rootCmd.Execute(); err != nil {

--- a/codex.md
+++ b/codex.md
@@ -1,0 +1,15 @@
+# codex.md — wacli Go Production Standards
+
+## Build
+```bash
+go vet ./... && go test ./... && go build ./cmd/wacli/
+```
+
+## Seven Iron Rules
+1. NO panic/log.Fatal in library code — use error returns
+2. NO dead code — zero unused vars/imports/functions
+3. NO incomplete implementations — no TODO stubs leaving broken paths
+4. All code must pass go vet
+5. Validate with go vet + go test
+6. Check EVERY error return — never discard with _ silently
+7. Minimize allocations — strings.Builder, pointer receivers for large structs

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,8 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/beeper/argo-go v1.1.2 // indirect
 	github.com/coder/websocket v1.8.14 // indirect
+	github.com/creachadair/jrpc2 v1.3.4 // indirect
+	github.com/creachadair/mds v0.25.13 // indirect
 	github.com/elliotchance/orderedmap/v3 v3.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -29,6 +31,7 @@ require (
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/exp v0.0.0-20260212183809-81e46e3db34a // indirect
 	golang.org/x/net v0.50.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	rsc.io/qr v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,10 @@ github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/creachadair/jrpc2 v1.3.4 h1:3bDFDlRORVAVuzBSpi4b81seIYZPSgdfZQQgGbGCbAA=
+github.com/creachadair/jrpc2 v1.3.4/go.mod h1:Rp2wYJ0fmAt66JlyLe+1zdM/a2DN5XmqffqDxANan+I=
+github.com/creachadair/mds v0.25.13 h1:PsSUHV6zsfPd29k4kvm1rMoee1YFia7JyNGeMPmDcPM=
+github.com/creachadair/mds v0.25.13/go.mod h1:4hatI3hRM+qhzuAmqPRFvaBM8mONkS7nsLxkcuTYUIs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elliotchance/orderedmap/v3 v3.1.0 h1:j4DJ5ObEmMBt/lcwIecKcoRxIQUEnw0L804lXYDt/pg=
@@ -67,6 +71,8 @@ golang.org/x/exp v0.0.0-20260212183809-81e46e3db34a h1:ovFr6Z0MNmU7nH8VaX5xqw+05
 golang.org/x/exp v0.0.0-20260212183809-81e46e3db34a/go.mod h1:K79w1Vqn7PoiZn+TkNpx3BUWUQksGO3JcVX6qIjytmA=
 golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
 golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -42,6 +42,10 @@ type WAClient interface {
 	Upload(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error)
 	DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error)
 
+	SendReaction(ctx context.Context, chat types.JID, targetMsgID types.MessageID, emoji string) (types.MessageID, error)
+	RemoteDelete(ctx context.Context, chat types.JID, targetMsgID types.MessageID) (types.MessageID, error)
+	SendFile(ctx context.Context, to types.JID, filePath, caption, mimeOverride string) (wa.SendFileResult, error)
+
 	DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error)
 	RequestHistorySyncOnDemand(ctx context.Context, lastKnown types.MessageInfo, count int) (types.MessageID, error)
 	Logout(ctx context.Context) error

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -36,6 +36,7 @@ type WAClient interface {
 	GetGroupInviteLink(ctx context.Context, group types.JID, reset bool) (string, error)
 	JoinGroupWithLink(ctx context.Context, code string) (types.JID, error)
 	LeaveGroup(ctx context.Context, group types.JID) error
+	SelfJID() string
 
 	SendText(ctx context.Context, to types.JID, text string) (types.MessageID, error)
 	SendProtoMessage(ctx context.Context, to types.JID, msg *waProto.Message) (types.MessageID, error)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -28,6 +28,8 @@ type WAClient interface {
 	ResolveChatName(ctx context.Context, chat types.JID, pushName string) string
 	GetContact(ctx context.Context, jid types.JID) (types.ContactInfo, error)
 	GetAllContacts(ctx context.Context) (map[types.JID]types.ContactInfo, error)
+	GetUserInfo(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error)
+	ResolveRecipientJID(ctx context.Context, jid types.JID) (types.JID, error)
 
 	GetJoinedGroups(ctx context.Context) ([]*types.GroupInfo, error)
 	GetGroupInfo(ctx context.Context, jid types.JID) (*types.GroupInfo, error)

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -135,6 +135,14 @@ func (f *fakeWA) GetAllContacts(ctx context.Context) (map[types.JID]types.Contac
 	return out, nil
 }
 
+func (f *fakeWA) GetUserInfo(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error) {
+	return map[types.JID]types.UserInfo{}, nil
+}
+
+func (f *fakeWA) ResolveRecipientJID(ctx context.Context, jid types.JID) (types.JID, error) {
+	return jid.ToNonAD(), nil
+}
+
 func (f *fakeWA) GetJoinedGroups(ctx context.Context) ([]*types.GroupInfo, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -262,3 +262,5 @@ func (f *fakeWA) RemoteDelete(ctx context.Context, chat types.JID, targetMsgID t
 func (f *fakeWA) SendFile(ctx context.Context, to types.JID, filePath, caption, mimeOverride string) (wa.SendFileResult, error) {
 	return wa.SendFileResult{MsgID: "fileid", MimeType: "application/octet-stream", MediaType: "document", Filename: "test.bin"}, nil
 }
+
+func (f *fakeWA) SelfJID() string { return "test@s.whatsapp.net" }

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -250,3 +250,15 @@ func (f *fakeWA) Logout(ctx context.Context) error {
 	f.authed = false
 	return nil
 }
+
+func (f *fakeWA) SendReaction(ctx context.Context, chat types.JID, targetMsgID types.MessageID, emoji string) (types.MessageID, error) {
+	return types.MessageID("reactionid"), nil
+}
+
+func (f *fakeWA) RemoteDelete(ctx context.Context, chat types.JID, targetMsgID types.MessageID) (types.MessageID, error) {
+	return types.MessageID("deleteid"), nil
+}
+
+func (f *fakeWA) SendFile(ctx context.Context, to types.JID, filePath, caption, mimeOverride string) (wa.SendFileResult, error) {
+	return wa.SendFileResult{MsgID: "fileid", MimeType: "application/octet-stream", MediaType: "document", Filename: "test.bin"}, nil
+}

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/steipete/wacli/internal/store"
+	"github.com/steipete/wacli/internal/wa"
 	"go.mau.fi/whatsmeow/types"
 )
 
@@ -13,6 +14,23 @@ import (
 // It avoids direct dependency on CLI helpers from the cmd package.
 type Service struct {
 	app *App
+}
+
+type GroupParticipantInfo struct {
+	JID  string
+	Name string
+}
+
+type GroupInfo struct {
+	JID          string
+	Name         string
+	Participants []GroupParticipantInfo
+}
+
+type ContactName struct {
+	JID      string
+	Name     string
+	PushName string
 }
 
 // NewService wraps an App in a Service.
@@ -104,6 +122,66 @@ func (s *Service) SearchMessages(ctx context.Context, query string, limit int) (
 		Query: query,
 		Limit: limit,
 	})
+}
+
+// GetGroupInfo fetches live group info and resolves participant display names.
+func (s *Service) GetGroupInfo(ctx context.Context, groupJID string) (GroupInfo, error) {
+	if err := s.app.EnsureAuthed(); err != nil {
+		return GroupInfo{}, err
+	}
+	jid, err := types.ParseJID(groupJID)
+	if err != nil {
+		return GroupInfo{}, fmt.Errorf("invalid group JID: %w", err)
+	}
+	info, err := s.app.WA().GetGroupInfo(ctx, jid)
+	if err != nil {
+		return GroupInfo{}, err
+	}
+	if info == nil {
+		return GroupInfo{}, fmt.Errorf("group not found")
+	}
+	out := GroupInfo{
+		JID:  info.JID.String(),
+		Name: info.GroupName.Name,
+	}
+	if out.Name == "" {
+		out.Name = out.JID
+	}
+	out.Participants = make([]GroupParticipantInfo, 0, len(info.Participants))
+	for _, p := range info.Participants {
+		name := ""
+		if c, err := s.app.WA().GetContact(ctx, p.JID.ToNonAD()); err == nil {
+			name = wa.BestContactName(c)
+		}
+		if name == "" {
+			name = p.JID.String()
+		}
+		out.Participants = append(out.Participants, GroupParticipantInfo{
+			JID:  p.JID.String(),
+			Name: name,
+		})
+	}
+	return out, nil
+}
+
+// GetContactName fetches a contact's display name from the whatsmeow contact store.
+func (s *Service) GetContactName(ctx context.Context, jidStr string) (ContactName, error) {
+	if err := s.app.EnsureAuthed(); err != nil {
+		return ContactName{}, err
+	}
+	jid, err := types.ParseJID(jidStr)
+	if err != nil {
+		return ContactName{}, fmt.Errorf("invalid JID: %w", err)
+	}
+	info, err := s.app.WA().GetContact(ctx, jid.ToNonAD())
+	if err != nil {
+		return ContactName{}, err
+	}
+	return ContactName{
+		JID:      jid.String(),
+		Name:     wa.BestContactName(info),
+		PushName: info.PushName,
+	}, nil
 }
 
 // chatKindFromJID returns the kind string for a JID.

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"context"
+
+	"github.com/steipete/wacli/internal/store"
+	"go.mau.fi/whatsmeow/types"
+)
+
+// Service is a facade over App that provides a clean API for the RPC layer.
+// It avoids direct dependency on CLI helpers from the cmd package.
+type Service struct {
+	app *App
+}
+
+// NewService wraps an App in a Service.
+func NewService(a *App) *Service {
+	return &Service{app: a}
+}
+
+// SendText sends a plain-text message to the given JID and returns the message ID.
+func (s *Service) SendText(ctx context.Context, to types.JID, message string) (types.MessageID, error) {
+	if err := s.app.EnsureAuthed(); err != nil {
+		return "", err
+	}
+	return s.app.WA().SendText(ctx, to, message)
+}
+
+// ListChats returns a list of chats ordered by most-recent message.
+// query is an optional substring filter; limit ≤ 0 uses the store default (50).
+func (s *Service) ListChats(ctx context.Context, query string, limit int) ([]store.Chat, error) {
+	return s.app.DB().ListChats(query, limit)
+}
+
+// GetMessages returns messages in a given chat ordered by newest first.
+// limit ≤ 0 uses the store default (50).
+func (s *Service) GetMessages(ctx context.Context, chatJID string, limit int) ([]store.Message, error) {
+	return s.app.DB().ListMessages(store.ListMessagesParams{
+		ChatJID: chatJID,
+		Limit:   limit,
+	})
+}

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/steipete/wacli/internal/store"
 	"go.mau.fi/whatsmeow/types"
@@ -27,16 +29,93 @@ func (s *Service) SendText(ctx context.Context, to types.JID, message string) (t
 }
 
 // ListChats returns a list of chats ordered by most-recent message.
-// query is an optional substring filter; limit ≤ 0 uses the store default (50).
+// query is an optional substring filter; limit <= 0 uses the store default (50).
 func (s *Service) ListChats(ctx context.Context, query string, limit int) ([]store.Chat, error) {
 	return s.app.DB().ListChats(query, limit)
 }
 
 // GetMessages returns messages in a given chat ordered by newest first.
-// limit ≤ 0 uses the store default (50).
+// limit <= 0 uses the store default (50).
 func (s *Service) GetMessages(ctx context.Context, chatJID string, limit int) ([]store.Message, error) {
 	return s.app.DB().ListMessages(store.ListMessagesParams{
 		ChatJID: chatJID,
 		Limit:   limit,
 	})
+}
+
+// SendReaction sends a reaction to a message.
+// emoji is the reaction string; pass "" to remove an existing reaction.
+func (s *Service) SendReaction(ctx context.Context, to types.JID, targetMsgID types.MessageID, emoji string) (types.MessageID, error) {
+	if err := s.app.EnsureAuthed(); err != nil {
+		return "", err
+	}
+	return s.app.WA().SendReaction(ctx, to, targetMsgID, emoji)
+}
+
+// RemoteDelete revokes/deletes a sent message.
+func (s *Service) RemoteDelete(ctx context.Context, to types.JID, targetMsgID types.MessageID) (types.MessageID, error) {
+	if err := s.app.EnsureAuthed(); err != nil {
+		return "", err
+	}
+	return s.app.WA().RemoteDelete(ctx, to, targetMsgID)
+}
+
+// SendFile uploads and sends a file attachment, persisting it to the local DB.
+func (s *Service) SendFile(ctx context.Context, to types.JID, filePath, caption string) (types.MessageID, string, error) {
+	if err := s.app.EnsureAuthed(); err != nil {
+		return "", "", err
+	}
+	result, err := s.app.WA().SendFile(ctx, to, filePath, caption, "")
+	if err != nil {
+		return "", "", fmt.Errorf("sendFile: %w", err)
+	}
+
+	now := time.Now().UTC()
+	chatName := s.app.WA().ResolveChatName(ctx, to, "")
+	kind := chatKindFromJID(to)
+	_ = s.app.DB().UpsertChat(to.String(), kind, chatName, now)
+	_ = s.app.DB().UpsertMessage(store.UpsertMessageParams{
+		ChatJID:       to.String(),
+		ChatName:      chatName,
+		MsgID:         string(result.MsgID),
+		SenderJID:     "",
+		SenderName:    "me",
+		Timestamp:     now,
+		FromMe:        true,
+		Text:          caption,
+		MediaType:     result.MediaType,
+		MediaCaption:  caption,
+		Filename:      result.Filename,
+		MimeType:      result.MimeType,
+		DirectPath:    result.DirectPath,
+		MediaKey:      result.MediaKey,
+		FileSHA256:    result.FileSHA256,
+		FileEncSHA256: result.FileEncSHA256,
+		FileLength:    result.FileLength,
+	})
+
+	return result.MsgID, result.MimeType, nil
+}
+
+// SearchMessages searches messages by full-text query.
+// limit <= 0 defaults to 50.
+func (s *Service) SearchMessages(ctx context.Context, query string, limit int) ([]store.Message, error) {
+	return s.app.DB().SearchMessages(store.SearchMessagesParams{
+		Query: query,
+		Limit: limit,
+	})
+}
+
+// chatKindFromJID returns the kind string for a JID.
+func chatKindFromJID(j types.JID) string {
+	if j.Server == types.GroupServer {
+		return "group"
+	}
+	if j.IsBroadcastList() {
+		return "broadcast"
+	}
+	if j.Server == types.DefaultUserServer {
+		return "dm"
+	}
+	return "unknown"
 }

--- a/internal/rpc/events.go
+++ b/internal/rpc/events.go
@@ -1,0 +1,92 @@
+package rpc
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Event is a server-initiated notification sent to subscribed clients.
+type Event struct {
+	Type      string         `json:"type"`
+	Timestamp string         `json:"timestamp"`
+	Payload   map[string]any `json:"payload"`
+}
+
+type subscriber struct {
+	id string
+	ch chan Event
+}
+
+// Hub is the internal event bus that bridges whatsmeow events to RPC clients.
+type Hub struct {
+	mu         sync.RWMutex
+	subs       map[string]*subscriber
+	bufferSize int
+	closed     bool
+}
+
+// NewHub creates a new Hub with the given per-subscriber channel buffer size.
+func NewHub(bufferSize int) *Hub {
+	if bufferSize <= 0 {
+		bufferSize = 256
+	}
+	return &Hub{
+		subs:       make(map[string]*subscriber),
+		bufferSize: bufferSize,
+	}
+}
+
+// Subscribe registers a new subscriber and returns its ID, a read-only event
+// channel, and a cancel function to remove the subscription.
+func (h *Hub) Subscribe() (id string, ch <-chan Event, cancel func()) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	id = uuid.New().String()
+	evCh := make(chan Event, h.bufferSize)
+	sub := &subscriber{id: id, ch: evCh}
+	h.subs[id] = sub
+
+	cancel = func() {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		if s, ok := h.subs[id]; ok {
+			close(s.ch)
+			delete(h.subs, id)
+		}
+	}
+	return id, evCh, cancel
+}
+
+// Publish broadcasts an event to all subscribers.  It is non-blocking: if a
+// subscriber's buffer is full the event is dropped for that subscriber only.
+func (h *Hub) Publish(evt Event) {
+	if evt.Timestamp == "" {
+		evt.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for _, sub := range h.subs {
+		select {
+		case sub.ch <- evt:
+		default:
+			// Slow subscriber – drop the event rather than block WA handler.
+		}
+	}
+}
+
+// Close closes all subscriber channels and removes them.
+func (h *Hub) Close() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
+	h.closed = true
+	for id, sub := range h.subs {
+		close(sub.ch)
+		delete(h.subs, id)
+	}
+}

--- a/internal/rpc/events.go
+++ b/internal/rpc/events.go
@@ -61,6 +61,11 @@ func NewHub(bufferSize int) *Hub {
 func (h *Hub) Subscribe() (id string, ch <-chan Event, cancel func()) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if h.closed {
+		closedCh := make(chan Event)
+		close(closedCh)
+		return "", closedCh, func() {}
+	}
 
 	id = uuid.New().String()
 	evCh := make(chan Event, h.bufferSize)

--- a/internal/rpc/events.go
+++ b/internal/rpc/events.go
@@ -1,3 +1,21 @@
+// Package rpc implements the JSON-RPC 2.0 server and the event hub used to
+// push real-time notifications to subscribed clients.
+//
+// Event types pushed via the "event" notification:
+//
+//	message.received  – an incoming or outgoing message was received
+//	  payload: {id, chatJid, senderJid, fromMe, text, timestamp,
+//	            pushName?, reactionEmoji?, reactionToId?,
+//	            media?:{type, mimeType, caption, directPath, fileLength}}
+//
+//	message.sent      – a read receipt was received confirming delivery
+//	  payload: {ids, chatJid}
+//
+//	typing            – a chat presence (typing) notification
+//	  payload: {chatJid, senderJid, state ("composing"|"paused"), media}
+//
+//	presence          – an online/offline presence update
+//	  payload: {from, status ("available"|"unavailable"), lastSeen?}
 package rpc
 
 import (

--- a/internal/rpc/methods.go
+++ b/internal/rpc/methods.go
@@ -16,6 +16,18 @@ func newService(a *app.App) *app.Service {
 	return app.NewService(a)
 }
 
+func (s *Server) ensureConnected(ctx context.Context) error {
+	if s.app.WA().IsConnected() {
+		return nil
+	}
+	reconnectCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	if err := s.app.WA().ReconnectWithBackoff(reconnectCtx, 500*time.Millisecond, 5*time.Second); err != nil {
+		return fmt.Errorf("not connected and reconnect failed: %w", err)
+	}
+	return nil
+}
+
 // ---- send ---------------------------------------------------------------
 
 // SendRequest holds parameters for the "send" RPC method.
@@ -37,6 +49,10 @@ func (s *Server) rpcSend(ctx context.Context, req SendRequest) (SendResponse, er
 	}
 	if req.Message == "" {
 		return SendResponse{}, &jrpc2.Error{Code: -32602, Message: "message is required"}
+	}
+
+	if err := s.ensureConnected(ctx); err != nil {
+		return SendResponse{}, &jrpc2.Error{Code: -32011, Message: err.Error()}
 	}
 
 	jid, err := types.ParseJID(req.Recipient)
@@ -164,14 +180,38 @@ type SubscribeResponse struct {
 // Events are pushed as server-side notifications with method "event".
 func (s *Server) rpcSubscribe(ctx context.Context) (SubscribeResponse, error) {
 	srv := jrpc2.ServerFromContext(ctx)
+	if srv == nil {
+		return SubscribeResponse{}, &jrpc2.Error{Code: -32603, Message: "internal error: server context unavailable"}
+	}
 	id, evCh, cancel := s.hub.Subscribe()
+	if id == "" {
+		return SubscribeResponse{}, &jrpc2.Error{Code: -32000, Message: "event hub is closed"}
+	}
+
+	connDone := make(chan struct{})
+	go func() {
+		_ = srv.Wait()
+		close(connDone)
+	}()
 
 	go func() {
 		defer cancel()
-		for evt := range evCh {
-			if err := srv.Notify(context.Background(), "event", evt); err != nil {
-				// Client disconnected or server stopped.
+		for {
+			select {
+			case <-connDone:
+				// TCP connection is gone; unsubscribe immediately.
 				return
+			case evt, ok := <-evCh:
+				if !ok {
+					return
+				}
+				notifyCtx, done := context.WithTimeout(context.Background(), 5*time.Second)
+				err := srv.Notify(notifyCtx, "event", evt)
+				done()
+				if err != nil {
+					// Client disconnected or server stopped.
+					return
+				}
 			}
 		}
 	}()
@@ -200,6 +240,10 @@ func (s *Server) rpcSendReaction(ctx context.Context, req SendReactionRequest) (
 	if req.TargetMessageID == "" {
 		return SendReactionResponse{}, &jrpc2.Error{Code: -32602, Message: "targetMessageId is required"}
 	}
+	if err := s.ensureConnected(ctx); err != nil {
+		return SendReactionResponse{}, &jrpc2.Error{Code: -32011, Message: err.Error()}
+	}
+
 	jid, err := types.ParseJID(req.Recipient)
 	if err != nil {
 		return SendReactionResponse{}, &jrpc2.Error{Code: -32602, Message: fmt.Sprintf("invalid recipient JID: %v", err)}
@@ -232,6 +276,10 @@ func (s *Server) rpcRemoteDelete(ctx context.Context, req RemoteDeleteRequest) (
 	if req.TargetMessageID == "" {
 		return RemoteDeleteResponse{}, &jrpc2.Error{Code: -32602, Message: "targetMessageId is required"}
 	}
+	if err := s.ensureConnected(ctx); err != nil {
+		return RemoteDeleteResponse{}, &jrpc2.Error{Code: -32011, Message: err.Error()}
+	}
+
 	jid, err := types.ParseJID(req.Recipient)
 	if err != nil {
 		return RemoteDeleteResponse{}, &jrpc2.Error{Code: -32602, Message: fmt.Sprintf("invalid recipient JID: %v", err)}
@@ -268,6 +316,10 @@ func (s *Server) rpcSendFile(ctx context.Context, req SendFileRequest) (SendFile
 	if req.FilePath == "" {
 		return SendFileResponse{}, &jrpc2.Error{Code: -32602, Message: "filePath is required"}
 	}
+	if err := s.ensureConnected(ctx); err != nil {
+		return SendFileResponse{}, &jrpc2.Error{Code: -32011, Message: err.Error()}
+	}
+
 	jid, err := types.ParseJID(req.Recipient)
 	if err != nil {
 		return SendFileResponse{}, &jrpc2.Error{Code: -32602, Message: fmt.Sprintf("invalid recipient JID: %v", err)}
@@ -366,6 +418,10 @@ func (s *Server) rpcGetGroupInfo(ctx context.Context, req GetGroupInfoRequest) (
 		return GetGroupInfoResponse{}, &jrpc2.Error{Code: -32602, Message: fmt.Sprintf("invalid jid: %v", err)}
 	}
 
+	if err := s.ensureConnected(ctx); err != nil {
+		return GetGroupInfoResponse{}, &jrpc2.Error{Code: -32011, Message: err.Error()}
+	}
+
 	svc := newService(s.app)
 	info, err := svc.GetGroupInfo(ctx, req.JID)
 	if err != nil {
@@ -406,6 +462,10 @@ func (s *Server) rpcGetContactName(ctx context.Context, req GetContactNameReques
 	}
 	if _, err := types.ParseJID(req.JID); err != nil {
 		return GetContactNameResponse{}, &jrpc2.Error{Code: -32602, Message: fmt.Sprintf("invalid jid: %v", err)}
+	}
+
+	if err := s.ensureConnected(ctx); err != nil {
+		return GetContactNameResponse{}, &jrpc2.Error{Code: -32011, Message: err.Error()}
 	}
 
 	svc := newService(s.app)

--- a/internal/rpc/methods.go
+++ b/internal/rpc/methods.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/creachadair/jrpc2"
 	"github.com/steipete/wacli/internal/app"
+	"github.com/steipete/wacli/internal/wa"
 	"go.mau.fi/whatsmeow/types"
 )
 
@@ -41,6 +42,12 @@ func (s *Server) rpcSend(ctx context.Context, req SendRequest) (SendResponse, er
 	jid, err := types.ParseJID(req.Recipient)
 	if err != nil {
 		return SendResponse{}, &jrpc2.Error{Code: -32602, Message: fmt.Sprintf("invalid recipient JID: %v", err)}
+	}
+	jid = jid.ToNonAD()
+	if wa.IsLIDJID(jid) {
+		if resolved, resolveErr := s.app.WA().ResolveRecipientJID(ctx, jid); resolveErr == nil && !resolved.IsEmpty() {
+			jid = resolved.ToNonAD()
+		}
 	}
 
 	svc := newService(s.app)

--- a/internal/rpc/methods.go
+++ b/internal/rpc/methods.go
@@ -172,4 +172,161 @@ func (s *Server) rpcSubscribe(ctx context.Context) (SubscribeResponse, error) {
 	return SubscribeResponse{ID: id}, nil
 }
 
-// (no additional helpers needed)
+// ---- sendReaction -------------------------------------------------------
+
+// SendReactionRequest holds parameters for the "sendReaction" RPC method.
+type SendReactionRequest struct {
+	Recipient       string `json:"recipient"`
+	TargetMessageID string `json:"targetMessageId"`
+	Emoji           string `json:"emoji"`
+}
+
+// SendReactionResponse is returned by the "sendReaction" method.
+type SendReactionResponse struct {
+	OK bool `json:"ok"`
+}
+
+func (s *Server) rpcSendReaction(ctx context.Context, req SendReactionRequest) (SendReactionResponse, error) {
+	if req.Recipient == "" {
+		return SendReactionResponse{}, &jrpc2.Error{Code: -32602, Message: "recipient is required"}
+	}
+	if req.TargetMessageID == "" {
+		return SendReactionResponse{}, &jrpc2.Error{Code: -32602, Message: "targetMessageId is required"}
+	}
+	jid, err := types.ParseJID(req.Recipient)
+	if err != nil {
+		return SendReactionResponse{}, &jrpc2.Error{Code: -32602, Message: fmt.Sprintf("invalid recipient JID: %v", err)}
+	}
+	svc := newService(s.app)
+	_, err = svc.SendReaction(ctx, jid, types.MessageID(req.TargetMessageID), req.Emoji)
+	if err != nil {
+		return SendReactionResponse{}, &jrpc2.Error{Code: -32011, Message: fmt.Sprintf("sendReaction failed: %v", err)}
+	}
+	return SendReactionResponse{OK: true}, nil
+}
+
+// ---- remoteDelete -------------------------------------------------------
+
+// RemoteDeleteRequest holds parameters for the "remoteDelete" RPC method.
+type RemoteDeleteRequest struct {
+	Recipient       string `json:"recipient"`
+	TargetMessageID string `json:"targetMessageId"`
+}
+
+// RemoteDeleteResponse is returned by the "remoteDelete" method.
+type RemoteDeleteResponse struct {
+	OK bool `json:"ok"`
+}
+
+func (s *Server) rpcRemoteDelete(ctx context.Context, req RemoteDeleteRequest) (RemoteDeleteResponse, error) {
+	if req.Recipient == "" {
+		return RemoteDeleteResponse{}, &jrpc2.Error{Code: -32602, Message: "recipient is required"}
+	}
+	if req.TargetMessageID == "" {
+		return RemoteDeleteResponse{}, &jrpc2.Error{Code: -32602, Message: "targetMessageId is required"}
+	}
+	jid, err := types.ParseJID(req.Recipient)
+	if err != nil {
+		return RemoteDeleteResponse{}, &jrpc2.Error{Code: -32602, Message: fmt.Sprintf("invalid recipient JID: %v", err)}
+	}
+	svc := newService(s.app)
+	_, err = svc.RemoteDelete(ctx, jid, types.MessageID(req.TargetMessageID))
+	if err != nil {
+		return RemoteDeleteResponse{}, &jrpc2.Error{Code: -32011, Message: fmt.Sprintf("remoteDelete failed: %v", err)}
+	}
+	return RemoteDeleteResponse{OK: true}, nil
+}
+
+// ---- sendFile -----------------------------------------------------------
+
+// SendFileRequest holds parameters for the "sendFile" RPC method.
+type SendFileRequest struct {
+	Recipient string `json:"recipient"`
+	FilePath  string `json:"filePath"`
+	Caption   string `json:"caption,omitempty"`
+	MimeType  string `json:"mimeType,omitempty"`
+}
+
+// SendFileResponse is returned by the "sendFile" method.
+type SendFileResponse struct {
+	ID        string `json:"id"`
+	Timestamp string `json:"timestamp"`
+	MimeType  string `json:"mimeType"`
+}
+
+func (s *Server) rpcSendFile(ctx context.Context, req SendFileRequest) (SendFileResponse, error) {
+	if req.Recipient == "" {
+		return SendFileResponse{}, &jrpc2.Error{Code: -32602, Message: "recipient is required"}
+	}
+	if req.FilePath == "" {
+		return SendFileResponse{}, &jrpc2.Error{Code: -32602, Message: "filePath is required"}
+	}
+	jid, err := types.ParseJID(req.Recipient)
+	if err != nil {
+		return SendFileResponse{}, &jrpc2.Error{Code: -32602, Message: fmt.Sprintf("invalid recipient JID: %v", err)}
+	}
+	svc := newService(s.app)
+	msgID, mimeType, err := svc.SendFile(ctx, jid, req.FilePath, req.Caption)
+	if err != nil {
+		return SendFileResponse{}, &jrpc2.Error{Code: -32011, Message: fmt.Sprintf("sendFile failed: %v", err)}
+	}
+	return SendFileResponse{
+		ID:        string(msgID),
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		MimeType:  mimeType,
+	}, nil
+}
+
+// ---- searchMessages -----------------------------------------------------
+
+// SearchMessagesRequest holds parameters for the "searchMessages" RPC method.
+type SearchMessagesRequest struct {
+	Query string `json:"query"`
+	Limit int    `json:"limit,omitempty"`
+}
+
+// SearchMessageItem represents a single search result message.
+type SearchMessageItem struct {
+	ID          string `json:"id"`
+	ChatJID     string `json:"chatJid"`
+	ChatName    string `json:"chatName,omitempty"`
+	SenderJID   string `json:"senderJid,omitempty"`
+	Timestamp   string `json:"timestamp"`
+	FromMe      bool   `json:"fromMe"`
+	Text        string `json:"text,omitempty"`
+	DisplayText string `json:"displayText,omitempty"`
+	MediaType   string `json:"mediaType,omitempty"`
+	Snippet     string `json:"snippet,omitempty"`
+}
+
+// SearchMessagesResponse is the result of "searchMessages".
+type SearchMessagesResponse struct {
+	Messages []SearchMessageItem `json:"messages"`
+}
+
+func (s *Server) rpcSearchMessages(ctx context.Context, req SearchMessagesRequest) (SearchMessagesResponse, error) {
+	if req.Query == "" {
+		return SearchMessagesResponse{}, &jrpc2.Error{Code: -32602, Message: "query is required"}
+	}
+	svc := newService(s.app)
+	msgs, err := svc.SearchMessages(ctx, req.Query, req.Limit)
+	if err != nil {
+		return SearchMessagesResponse{}, &jrpc2.Error{Code: -32603, Message: fmt.Sprintf("searchMessages: %v", err)}
+	}
+	items := make([]SearchMessageItem, 0, len(msgs))
+	for _, m := range msgs {
+		items = append(items, SearchMessageItem{
+			ID:          m.MsgID,
+			ChatJID:     m.ChatJID,
+			ChatName:    m.ChatName,
+			SenderJID:   m.SenderJID,
+			Timestamp:   m.Timestamp.UTC().Format(time.RFC3339Nano),
+			FromMe:      m.FromMe,
+			Text:        m.Text,
+			DisplayText: m.DisplayText,
+			MediaType:   m.MediaType,
+			Snippet:     m.Snippet,
+		})
+	}
+	return SearchMessagesResponse{Messages: items}, nil
+}

--- a/internal/rpc/methods.go
+++ b/internal/rpc/methods.go
@@ -1,0 +1,175 @@
+package rpc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/steipete/wacli/internal/app"
+	"go.mau.fi/whatsmeow/types"
+)
+
+// newService is a thin helper to reduce boilerplate in handlers.
+func newService(a *app.App) *app.Service {
+	return app.NewService(a)
+}
+
+// ---- send ---------------------------------------------------------------
+
+// SendRequest holds parameters for the "send" RPC method.
+type SendRequest struct {
+	Recipient string `json:"recipient"`
+	Message   string `json:"message"`
+}
+
+// SendResponse is returned by the "send" method.
+type SendResponse struct {
+	ID        string `json:"id"`
+	ChatJID   string `json:"chatJid"`
+	Timestamp string `json:"timestamp"`
+}
+
+func (s *Server) rpcSend(ctx context.Context, req SendRequest) (SendResponse, error) {
+	if req.Recipient == "" {
+		return SendResponse{}, &jrpc2.Error{Code: -32602, Message: "recipient is required"}
+	}
+	if req.Message == "" {
+		return SendResponse{}, &jrpc2.Error{Code: -32602, Message: "message is required"}
+	}
+
+	jid, err := types.ParseJID(req.Recipient)
+	if err != nil {
+		return SendResponse{}, &jrpc2.Error{Code: -32602, Message: fmt.Sprintf("invalid recipient JID: %v", err)}
+	}
+
+	svc := newService(s.app)
+	msgID, err := svc.SendText(ctx, jid, req.Message)
+	if err != nil {
+		return SendResponse{}, &jrpc2.Error{Code: -32011, Message: fmt.Sprintf("send failed: %v", err)}
+	}
+
+	return SendResponse{
+		ID:        msgID,
+		ChatJID:   jid.String(),
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+	}, nil
+}
+
+// ---- listChats ----------------------------------------------------------
+
+// ListChatsRequest holds parameters for the "listChats" method.
+type ListChatsRequest struct {
+	Query string `json:"query,omitempty"`
+	Limit int    `json:"limit,omitempty"`
+}
+
+// ChatItem is a single chat entry.
+type ChatItem struct {
+	JID           string `json:"jid"`
+	Kind          string `json:"kind"`
+	Name          string `json:"name"`
+	LastMessageTS string `json:"lastMessageTs,omitempty"`
+}
+
+// ListChatsResponse is the result of "listChats".
+type ListChatsResponse struct {
+	Chats []ChatItem `json:"chats"`
+}
+
+func (s *Server) rpcListChats(ctx context.Context, req ListChatsRequest) (ListChatsResponse, error) {
+	svc := newService(s.app)
+	chats, err := svc.ListChats(ctx, req.Query, req.Limit)
+	if err != nil {
+		return ListChatsResponse{}, &jrpc2.Error{Code: -32603, Message: fmt.Sprintf("listChats: %v", err)}
+	}
+
+	items := make([]ChatItem, 0, len(chats))
+	for _, c := range chats {
+		item := ChatItem{JID: c.JID, Kind: c.Kind, Name: c.Name}
+		if !c.LastMessageTS.IsZero() {
+			item.LastMessageTS = c.LastMessageTS.UTC().Format(time.RFC3339Nano)
+		}
+		items = append(items, item)
+	}
+	return ListChatsResponse{Chats: items}, nil
+}
+
+// ---- getMessages --------------------------------------------------------
+
+// GetMessagesRequest holds parameters for the "getMessages" method.
+type GetMessagesRequest struct {
+	ChatJID string `json:"chatJid"`
+	Limit   int    `json:"limit,omitempty"`
+}
+
+// MessageItem represents a single message.
+type MessageItem struct {
+	ID          string `json:"id"`
+	ChatJID     string `json:"chatJid"`
+	SenderJID   string `json:"senderJid,omitempty"`
+	Timestamp   string `json:"timestamp"`
+	FromMe      bool   `json:"fromMe"`
+	Text        string `json:"text,omitempty"`
+	DisplayText string `json:"displayText,omitempty"`
+	MediaType   string `json:"mediaType,omitempty"`
+}
+
+// GetMessagesResponse is the result of "getMessages".
+type GetMessagesResponse struct {
+	Messages []MessageItem `json:"messages"`
+}
+
+func (s *Server) rpcGetMessages(ctx context.Context, req GetMessagesRequest) (GetMessagesResponse, error) {
+	if req.ChatJID == "" {
+		return GetMessagesResponse{}, &jrpc2.Error{Code: -32602, Message: "chatJid is required"}
+	}
+	svc := newService(s.app)
+	msgs, err := svc.GetMessages(ctx, req.ChatJID, req.Limit)
+	if err != nil {
+		return GetMessagesResponse{}, &jrpc2.Error{Code: -32603, Message: fmt.Sprintf("getMessages: %v", err)}
+	}
+
+	items := make([]MessageItem, 0, len(msgs))
+	for _, m := range msgs {
+		items = append(items, MessageItem{
+			ID:          m.MsgID,
+			ChatJID:     m.ChatJID,
+			SenderJID:   m.SenderJID,
+			Timestamp:   m.Timestamp.UTC().Format(time.RFC3339Nano),
+			FromMe:      m.FromMe,
+			Text:        m.Text,
+			DisplayText: m.DisplayText,
+			MediaType:   m.MediaType,
+		})
+	}
+	return GetMessagesResponse{Messages: items}, nil
+}
+
+// ---- subscribe ----------------------------------------------------------
+
+// SubscribeResponse is returned by the "subscribe" method.
+type SubscribeResponse struct {
+	ID string `json:"id"`
+}
+
+// rpcSubscribe registers the calling client to receive event notifications.
+// Events are pushed as server-side notifications with method "event".
+func (s *Server) rpcSubscribe(ctx context.Context) (SubscribeResponse, error) {
+	srv := jrpc2.ServerFromContext(ctx)
+	id, evCh, cancel := s.hub.Subscribe()
+
+	go func() {
+		defer cancel()
+		for evt := range evCh {
+			if err := srv.Notify(context.Background(), "event", evt); err != nil {
+				// Client disconnected or server stopped.
+				return
+			}
+		}
+	}()
+
+	return SubscribeResponse{ID: id}, nil
+}
+
+// (no additional helpers needed)

--- a/internal/rpc/methods.go
+++ b/internal/rpc/methods.go
@@ -330,3 +330,85 @@ func (s *Server) rpcSearchMessages(ctx context.Context, req SearchMessagesReques
 	}
 	return SearchMessagesResponse{Messages: items}, nil
 }
+
+// ---- getGroupInfo ------------------------------------------------------
+
+// GetGroupInfoRequest holds parameters for the "getGroupInfo" RPC method.
+type GetGroupInfoRequest struct {
+	JID string `json:"jid"`
+}
+
+// GroupParticipantItem is a single group participant entry.
+type GroupParticipantItem struct {
+	JID  string `json:"jid"`
+	Name string `json:"name"`
+}
+
+// GetGroupInfoResponse is the result of "getGroupInfo".
+type GetGroupInfoResponse struct {
+	JID          string                 `json:"jid"`
+	Name         string                 `json:"name"`
+	Participants []GroupParticipantItem `json:"participants"`
+}
+
+func (s *Server) rpcGetGroupInfo(ctx context.Context, req GetGroupInfoRequest) (GetGroupInfoResponse, error) {
+	if req.JID == "" {
+		return GetGroupInfoResponse{}, &jrpc2.Error{Code: -32602, Message: "jid is required"}
+	}
+	if _, err := types.ParseJID(req.JID); err != nil {
+		return GetGroupInfoResponse{}, &jrpc2.Error{Code: -32602, Message: fmt.Sprintf("invalid jid: %v", err)}
+	}
+
+	svc := newService(s.app)
+	info, err := svc.GetGroupInfo(ctx, req.JID)
+	if err != nil {
+		return GetGroupInfoResponse{}, &jrpc2.Error{Code: -32011, Message: fmt.Sprintf("getGroupInfo failed: %v", err)}
+	}
+
+	resp := GetGroupInfoResponse{
+		JID:          info.JID,
+		Name:         info.Name,
+		Participants: make([]GroupParticipantItem, 0, len(info.Participants)),
+	}
+	for _, p := range info.Participants {
+		resp.Participants = append(resp.Participants, GroupParticipantItem{
+			JID:  p.JID,
+			Name: p.Name,
+		})
+	}
+	return resp, nil
+}
+
+// ---- getContactName ----------------------------------------------------
+
+// GetContactNameRequest holds parameters for the "getContactName" RPC method.
+type GetContactNameRequest struct {
+	JID string `json:"jid"`
+}
+
+// GetContactNameResponse is the result of "getContactName".
+type GetContactNameResponse struct {
+	JID      string `json:"jid"`
+	Name     string `json:"name"`
+	PushName string `json:"pushName"`
+}
+
+func (s *Server) rpcGetContactName(ctx context.Context, req GetContactNameRequest) (GetContactNameResponse, error) {
+	if req.JID == "" {
+		return GetContactNameResponse{}, &jrpc2.Error{Code: -32602, Message: "jid is required"}
+	}
+	if _, err := types.ParseJID(req.JID); err != nil {
+		return GetContactNameResponse{}, &jrpc2.Error{Code: -32602, Message: fmt.Sprintf("invalid jid: %v", err)}
+	}
+
+	svc := newService(s.app)
+	contact, err := svc.GetContactName(ctx, req.JID)
+	if err != nil {
+		return GetContactNameResponse{}, &jrpc2.Error{Code: -32011, Message: fmt.Sprintf("getContactName failed: %v", err)}
+	}
+	return GetContactNameResponse{
+		JID:      contact.JID,
+		Name:     contact.Name,
+		PushName: contact.PushName,
+	}, nil
+}

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -1,0 +1,91 @@
+package rpc
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/channel"
+	"github.com/creachadair/jrpc2/handler"
+	jserver "github.com/creachadair/jrpc2/server"
+	"github.com/steipete/wacli/internal/app"
+)
+
+// Server wraps an App and an EventHub and implements JSON-RPC 2.0 service.
+type Server struct {
+	app *app.App
+	hub *Hub
+}
+
+// ServeOptions controls how the server listens for connections.
+type ServeOptions struct {
+	// Transport is "stdio" (default) or "tcp".
+	Transport string
+	// Listen is the address used when Transport=="tcp" (default 127.0.0.1:8686).
+	Listen string
+}
+
+// NewServer creates an RPC server backed by the given App and EventHub.
+func NewServer(a *app.App, hub *Hub) *Server {
+	return &Server{app: a, hub: hub}
+}
+
+func (s *Server) buildAssigner() jrpc2.Assigner {
+	return handler.Map{
+		"send":        handler.New(s.rpcSend),
+		"listChats":   handler.New(s.rpcListChats),
+		"getMessages": handler.New(s.rpcGetMessages),
+		"subscribe":   handler.New(s.rpcSubscribe),
+	}
+}
+
+func (s *Server) serverOpts() *jrpc2.ServerOptions {
+	return &jrpc2.ServerOptions{
+		AllowPush: true,
+	}
+}
+
+// Serve starts the JSON-RPC server using the transport specified in opts and
+// blocks until ctx is cancelled or an unrecoverable error occurs.
+func (s *Server) Serve(ctx context.Context, opts ServeOptions) error {
+	switch opts.Transport {
+	case "tcp":
+		return s.serveTCP(ctx, opts.Listen)
+	default: // "stdio" or empty
+		return s.serveStdio(ctx)
+	}
+}
+
+func (s *Server) serveStdio(ctx context.Context) error {
+	ch := channel.Line(os.Stdin, os.Stdout)
+	srv := jrpc2.NewServer(s.buildAssigner(), s.serverOpts()).Start(ch)
+	go func() {
+		<-ctx.Done()
+		srv.Stop()
+	}()
+	return srv.Wait()
+}
+
+func (s *Server) serveTCP(ctx context.Context, addr string) error {
+	if addr == "" {
+		addr = "127.0.0.1:8686"
+	}
+	lst, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", addr, err)
+	}
+	fmt.Fprintf(os.Stderr, "wacli: JSON-RPC daemon listening on %s\n", addr)
+
+	// Close listener when context is cancelled.
+	go func() {
+		<-ctx.Done()
+		_ = lst.Close()
+	}()
+
+	acc := jserver.NetAccepter(lst, channel.Line)
+	return jserver.Loop(ctx, acc, jserver.Static(s.buildAssigner()), &jserver.LoopOptions{
+		ServerOptions: s.serverOpts(),
+	})
+}

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -34,10 +34,14 @@ func NewServer(a *app.App, hub *Hub) *Server {
 
 func (s *Server) buildAssigner() jrpc2.Assigner {
 	return handler.Map{
-		"send":        handler.New(s.rpcSend),
-		"listChats":   handler.New(s.rpcListChats),
-		"getMessages": handler.New(s.rpcGetMessages),
-		"subscribe":   handler.New(s.rpcSubscribe),
+		"send":           handler.New(s.rpcSend),
+		"listChats":      handler.New(s.rpcListChats),
+		"getMessages":    handler.New(s.rpcGetMessages),
+		"subscribe":      handler.New(s.rpcSubscribe),
+		"sendReaction":   handler.New(s.rpcSendReaction),
+		"remoteDelete":   handler.New(s.rpcRemoteDelete),
+		"sendFile":       handler.New(s.rpcSendFile),
+		"searchMessages": handler.New(s.rpcSearchMessages),
 	}
 }
 

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -2,9 +2,11 @@ package rpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
+	"time"
 
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/channel"
@@ -90,8 +92,45 @@ func (s *Server) serveTCP(ctx context.Context, addr string) error {
 		_ = lst.Close()
 	}()
 
-	acc := jserver.NetAccepter(lst, channel.Line)
-	return jserver.Loop(ctx, acc, jserver.Static(s.buildAssigner()), &jserver.LoopOptions{
-		ServerOptions: s.serverOpts(),
-	})
+	if tcp, ok := lst.(*net.TCPListener); ok {
+		lst = tcpKeepAliveListener{TCPListener: tcp}
+	}
+
+	for {
+		acc := jserver.NetAccepter(lst, channel.Line)
+		err := jserver.Loop(ctx, acc, jserver.Static(s.buildAssigner()), &jserver.LoopOptions{
+			ServerOptions: s.serverOpts(),
+		})
+		if err == nil {
+			return nil
+		}
+		if ctx.Err() != nil || errors.Is(err, net.ErrClosed) {
+			return nil
+		}
+		var ne net.Error
+		if errors.As(err, &ne) && ne.Temporary() {
+			fmt.Fprintf(os.Stderr, "wacli: temporary TCP accept error: %v (retrying)\n", err)
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(500 * time.Millisecond):
+			}
+			continue
+		}
+		return err
+	}
+}
+
+type tcpKeepAliveListener struct {
+	*net.TCPListener
+}
+
+func (ln tcpKeepAliveListener) Accept() (net.Conn, error) {
+	conn, err := ln.AcceptTCP()
+	if err != nil {
+		return nil, err
+	}
+	_ = conn.SetKeepAlive(true)
+	_ = conn.SetKeepAlivePeriod(45 * time.Second)
+	return conn, nil
 }

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -42,6 +42,8 @@ func (s *Server) buildAssigner() jrpc2.Assigner {
 		"remoteDelete":   handler.New(s.rpcRemoteDelete),
 		"sendFile":       handler.New(s.rpcSendFile),
 		"searchMessages": handler.New(s.rpcSearchMessages),
+		"getGroupInfo":   handler.New(s.rpcGetGroupInfo),
+		"getContactName": handler.New(s.rpcGetContactName),
 	}
 }
 

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -535,3 +535,11 @@ func (c *Client) SendFile(ctx context.Context, to types.JID, filePath, caption, 
 		FileLength:    up.FileLength,
 	}, nil
 }
+
+// SelfJID returns the JID of this device (non-AD format), or empty string if not connected.
+func (c *Client) SelfJID() string {
+	if c.client != nil && c.client.Store != nil && c.client.Store.ID != nil {
+		return c.client.Store.ID.ToNonAD().String()
+	}
+	return ""
+}

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -266,6 +266,73 @@ func IsGroupJID(jid types.JID) bool {
 	return jid.Server == types.GroupServer
 }
 
+func IsLIDJID(jid types.JID) bool {
+	return jid.Server == types.HiddenUserServer || jid.Server == types.HostedLIDServer
+}
+
+func (c *Client) GetUserInfo(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return nil, fmt.Errorf("not connected")
+	}
+	if len(jids) == 0 {
+		return map[types.JID]types.UserInfo{}, nil
+	}
+	return cli.GetUserInfo(ctx, jids)
+}
+
+// ResolveRecipientJID resolves a LID user JID to a sendable phone-number JID when possible.
+// If no mapping is currently known, the original JID is returned.
+func (c *Client) ResolveRecipientJID(ctx context.Context, jid types.JID) (types.JID, error) {
+	jid = jid.ToNonAD()
+	if jid.IsEmpty() {
+		return types.JID{}, fmt.Errorf("jid is required")
+	}
+	if !IsLIDJID(jid) {
+		return jid, nil
+	}
+
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || cli.Store == nil {
+		return types.JID{}, fmt.Errorf("client store not available")
+	}
+
+	// Fast path: use persisted LID<->PN mappings in the local device store.
+	if alt, err := cli.Store.GetAltJID(ctx, jid); err == nil && !alt.IsEmpty() {
+		return alt.ToNonAD(), nil
+	}
+
+	if !cli.IsConnected() {
+		return jid, nil
+	}
+
+	// Best-effort refresh: query user info with PN candidate to populate LID mapping cache.
+	pnCandidate := types.NewJID(jid.User, types.DefaultUserServer)
+	if _, err := cli.GetUserInfo(ctx, []types.JID{pnCandidate}); err == nil {
+		if alt, err := cli.Store.GetAltJID(ctx, jid); err == nil && !alt.IsEmpty() {
+			return alt.ToNonAD(), nil
+		}
+	}
+
+	// Fallback: some servers may respond with the queried JID key only.
+	if infos, err := cli.GetUserInfo(ctx, []types.JID{jid}); err == nil {
+		if alt, err := cli.Store.GetAltJID(ctx, jid); err == nil && !alt.IsEmpty() {
+			return alt.ToNonAD(), nil
+		}
+		for candidate, info := range infos {
+			if candidate.Server == types.DefaultUserServer && info.LID.ToNonAD() == jid {
+				return candidate.ToNonAD(), nil
+			}
+		}
+	}
+
+	return jid, nil
+}
+
 func (c *Client) GetContact(ctx context.Context, jid types.JID) (types.ContactInfo, error) {
 	c.mu.Lock()
 	cli := c.client
@@ -410,10 +477,10 @@ func (c *Client) RemoteDelete(ctx context.Context, chat types.JID, targetMsgID t
 
 // SendFileResult holds the result of a SendFile call.
 type SendFileResult struct {
-	MsgID     types.MessageID
-	MimeType  string
-	MediaType string // "image", "video", "audio", or "document"
-	Filename  string
+	MsgID         types.MessageID
+	MimeType      string
+	MediaType     string // "image", "video", "audio", or "document"
+	Filename      string
 	DirectPath    string
 	MediaKey      []byte
 	FileSHA256    []byte

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"mime"
+	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +19,7 @@ import (
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	waLog "go.mau.fi/whatsmeow/util/log"
+	"google.golang.org/protobuf/proto"
 )
 
 type Options struct {
@@ -369,4 +373,165 @@ func (c *Client) ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay ti
 			delay = maxDelay
 		}
 	}
+}
+
+// SendReaction sends a reaction to a message in a chat.
+// Pass an empty emoji string to remove an existing reaction.
+func (c *Client) SendReaction(ctx context.Context, chat types.JID, targetMsgID types.MessageID, emoji string) (types.MessageID, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return "", fmt.Errorf("not connected")
+	}
+	msg := cli.BuildReaction(chat, types.EmptyJID, targetMsgID, emoji)
+	resp, err := cli.SendMessage(ctx, chat, msg)
+	if err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
+// RemoteDelete revokes/deletes a message in a chat.
+func (c *Client) RemoteDelete(ctx context.Context, chat types.JID, targetMsgID types.MessageID) (types.MessageID, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return "", fmt.Errorf("not connected")
+	}
+	msg := cli.BuildRevoke(chat, types.EmptyJID, targetMsgID)
+	resp, err := cli.SendMessage(ctx, chat, msg)
+	if err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
+// SendFileResult holds the result of a SendFile call.
+type SendFileResult struct {
+	MsgID     types.MessageID
+	MimeType  string
+	MediaType string // "image", "video", "audio", or "document"
+	Filename  string
+	DirectPath    string
+	MediaKey      []byte
+	FileSHA256    []byte
+	FileEncSHA256 []byte
+	FileLength    uint64
+}
+
+// SendFile uploads and sends a file to the given JID.
+// mimeOverride may be empty; if so the MIME type is detected from content.
+func (c *Client) SendFile(ctx context.Context, to types.JID, filePath, caption, mimeOverride string) (SendFileResult, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return SendFileResult{}, fmt.Errorf("not connected")
+	}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return SendFileResult{}, fmt.Errorf("read file: %w", err)
+	}
+
+	name := filepath.Base(filePath)
+	mimeType := strings.TrimSpace(mimeOverride)
+	if mimeType == "" {
+		mimeType = mime.TypeByExtension(strings.ToLower(filepath.Ext(filePath)))
+	}
+	if mimeType == "" {
+		sniff := data
+		if len(sniff) > 512 {
+			sniff = sniff[:512]
+		}
+		mimeType = http.DetectContentType(sniff)
+	}
+
+	mediaType := "document"
+	uploadType, _ := MediaTypeFromString("document")
+	switch {
+	case strings.HasPrefix(mimeType, "image/"):
+		mediaType = "image"
+		uploadType, _ = MediaTypeFromString("image")
+	case strings.HasPrefix(mimeType, "video/"):
+		mediaType = "video"
+		uploadType, _ = MediaTypeFromString("video")
+	case strings.HasPrefix(mimeType, "audio/"):
+		mediaType = "audio"
+		uploadType, _ = MediaTypeFromString("audio")
+	}
+
+	up, err := cli.Upload(ctx, data, uploadType)
+	if err != nil {
+		return SendFileResult{}, fmt.Errorf("upload: %w", err)
+	}
+
+	msg := &waProto.Message{}
+	switch mediaType {
+	case "image":
+		msg.ImageMessage = &waProto.ImageMessage{
+			URL:           proto.String(up.URL),
+			DirectPath:    proto.String(up.DirectPath),
+			MediaKey:      up.MediaKey,
+			FileEncSHA256: up.FileEncSHA256,
+			FileSHA256:    up.FileSHA256,
+			FileLength:    proto.Uint64(up.FileLength),
+			Mimetype:      proto.String(mimeType),
+			Caption:       proto.String(caption),
+		}
+	case "video":
+		msg.VideoMessage = &waProto.VideoMessage{
+			URL:           proto.String(up.URL),
+			DirectPath:    proto.String(up.DirectPath),
+			MediaKey:      up.MediaKey,
+			FileEncSHA256: up.FileEncSHA256,
+			FileSHA256:    up.FileSHA256,
+			FileLength:    proto.Uint64(up.FileLength),
+			Mimetype:      proto.String(mimeType),
+			Caption:       proto.String(caption),
+		}
+	case "audio":
+		msg.AudioMessage = &waProto.AudioMessage{
+			URL:           proto.String(up.URL),
+			DirectPath:    proto.String(up.DirectPath),
+			MediaKey:      up.MediaKey,
+			FileEncSHA256: up.FileEncSHA256,
+			FileSHA256:    up.FileSHA256,
+			FileLength:    proto.Uint64(up.FileLength),
+			Mimetype:      proto.String(mimeType),
+			PTT:           proto.Bool(false),
+		}
+	default:
+		msg.DocumentMessage = &waProto.DocumentMessage{
+			URL:           proto.String(up.URL),
+			DirectPath:    proto.String(up.DirectPath),
+			MediaKey:      up.MediaKey,
+			FileEncSHA256: up.FileEncSHA256,
+			FileSHA256:    up.FileSHA256,
+			FileLength:    proto.Uint64(up.FileLength),
+			Mimetype:      proto.String(mimeType),
+			FileName:      proto.String(name),
+			Caption:       proto.String(caption),
+			Title:         proto.String(name),
+		}
+	}
+
+	resp, err := cli.SendMessage(ctx, to, msg)
+	if err != nil {
+		return SendFileResult{}, fmt.Errorf("send: %w", err)
+	}
+
+	return SendFileResult{
+		MsgID:         resp.ID,
+		MimeType:      mimeType,
+		MediaType:     mediaType,
+		Filename:      name,
+		DirectPath:    up.DirectPath,
+		MediaKey:      up.MediaKey,
+		FileSHA256:    up.FileSHA256,
+		FileEncSHA256: up.FileEncSHA256,
+		FileLength:    up.FileLength,
+	}, nil
 }

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -34,6 +34,7 @@ type ParsedMessage struct {
 	ReplyToDisplay string
 	ReactionToID   string
 	ReactionEmoji  string
+	MentionedJids  []string
 }
 
 func ParseLiveMessage(evt *events.Message) ParsedMessage {
@@ -187,6 +188,9 @@ func extractWAProto(m *waProto.Message, pm *ParsedMessage) {
 		}
 		if quoted := ctx.GetQuotedMessage(); quoted != nil {
 			pm.ReplyToDisplay = strings.TrimSpace(displayTextForProto(quoted))
+		}
+		if jids := ctx.GetMentionedJID(); len(jids) > 0 {
+			pm.MentionedJids = jids
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Complete JSON-RPC 2.0 daemon implementation for wacli, enabling external applications (AI agents, bots) to interact with WhatsApp programmatically via TCP or stdio.

## Commits

1. **Phase 1** (`b05cd13`): Core JSON-RPC daemon — `send`, `subscribe`, `listChats`, `getMessages`
2. **Phase 2** (`0c03b27`): `sendReaction`, `remoteDelete`, `sendFile`, `searchMessages`, enhanced events
3. **Group support** (`e125b51`): `groupName` in events, `getGroupInfo`/`getContactName` RPC methods
4. (`1e0732b`): `GetChat` fallback for group name lookup
5. (`b829f05`): `selfJid` in message events for self-identification
6. (`8a7747c`): Pre-populate group names + in-memory cache for event handler
7. **LID→JID fix** (`9dd9687`): Resolve WhatsApp Linked IDs to traditional JIDs for reply routing

## Features

- **Transport**: TCP (`--transport tcp --listen addr`) or stdio (default)
- **RPC methods**: `send`, `sendFile`, `sendReaction`, `remoteDelete`, `listChats`, `getMessages`, `searchMessages`, `getGroupInfo`, `getContactName`, `subscribe`
- **Event streaming**: `subscribe` pushes real-time `message.received`, `message.sent`, `typing`, `presence` notifications
- **LID resolution**: Automatically resolves `@lid` JIDs to `@s.whatsapp.net` for reliable message delivery
- **Group awareness**: Group names, selfJid, and sender info in all events

## Testing

- `go build ./cmd/wacli/` passes
- Tested on live WhatsApp with DM + group messages, multi-platform AI agent integration