### PR TITLE
feat: add --events flag for machine-readable NDJSON lifecycle events on stderr

### DIFF
--- a/cmd/wacli/auth.go
+++ b/cmd/wacli/auth.go
@@ -37,7 +37,12 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 				mode = appPkg.SyncModeFollow
 			}
 
-			fmt.Fprintln(os.Stderr, "Starting authentication…")
+			ev := a.Events()
+			if ev.Enabled() {
+				ev.Emit("auth_starting", nil)
+			} else {
+				fmt.Fprintln(os.Stderr, "Starting authentication…")
+			}
 			res, err := a.Sync(ctx, appPkg.SyncOptions{
 				Mode:            mode,
 				AllowQR:         true,
@@ -46,9 +51,13 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 				RefreshGroups:   true,
 				IdleExit:        idleExit,
 				OnQRCode: func(code string) {
-					fmt.Fprintln(os.Stderr, "\nScan this QR code with WhatsApp (Linked Devices):")
-					qrterminal.GenerateHalfBlock(code, qrterminal.M, os.Stderr)
-					fmt.Fprintln(os.Stderr)
+					if ev.Enabled() {
+						ev.Emit("qr_code", map[string]interface{}{"code": code})
+					} else {
+						fmt.Fprintln(os.Stderr, "\nScan this QR code with WhatsApp (Linked Devices):")
+						qrterminal.GenerateHalfBlock(code, qrterminal.M, os.Stderr)
+						fmt.Fprintln(os.Stderr)
+					}
 				},
 			})
 			if err != nil {

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -20,6 +20,7 @@ var version = "0.5.0"
 type rootFlags struct {
 	storeDir string
 	asJSON   bool
+	asEvents bool
 	timeout  time.Duration
 }
 
@@ -36,6 +37,7 @@ func execute(args []string) error {
 
 	rootCmd.PersistentFlags().StringVar(&flags.storeDir, "store", "", "store directory (default: ~/.wacli)")
 	rootCmd.PersistentFlags().BoolVar(&flags.asJSON, "json", false, "output JSON instead of human-readable text")
+	rootCmd.PersistentFlags().BoolVar(&flags.asEvents, "events", false, "emit NDJSON lifecycle events to stderr (for scripting)")
 	rootCmd.PersistentFlags().DurationVar(&flags.timeout, "timeout", 5*time.Minute, "command timeout (non-sync commands)")
 
 	rootCmd.AddCommand(newVersionCmd())
@@ -78,6 +80,7 @@ func newApp(ctx context.Context, flags *rootFlags, needLock bool, allowUnauthed 
 		StoreDir:      storeDir,
 		Version:       version,
 		JSON:          flags.asJSON,
+		Events:        out.NewEventWriter(os.Stderr, flags.asEvents),
 		AllowUnauthed: allowUnauthed,
 	})
 	if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/steipete/wacli/internal/out"
 	"github.com/steipete/wacli/internal/store"
 	"github.com/steipete/wacli/internal/wa"
 	"go.mau.fi/whatsmeow"
@@ -51,13 +52,15 @@ type Options struct {
 	StoreDir      string
 	Version       string
 	JSON          bool
+	Events        *out.EventWriter
 	AllowUnauthed bool
 }
 
 type App struct {
-	opts Options
-	wa   WAClient
-	db   *store.DB
+	opts   Options
+	events *out.EventWriter
+	wa     WAClient
+	db     *store.DB
 }
 
 func New(opts Options) (*App, error) {
@@ -75,7 +78,12 @@ func New(opts Options) (*App, error) {
 		return nil, err
 	}
 
-	return &App{opts: opts, db: db}, nil
+	ev := opts.Events
+	if ev == nil {
+		ev = out.NewEventWriter(os.Stderr, false)
+	}
+
+	return &App{opts: opts, events: ev, db: db}, nil
 }
 
 func (a *App) OpenWA() error {
@@ -113,11 +121,12 @@ func (a *App) EnsureAuthed() error {
 	return fmt.Errorf("not authenticated; run `wacli auth`")
 }
 
-func (a *App) WA() WAClient        { return a.wa }
-func (a *App) DB() *store.DB       { return a.db }
-func (a *App) StoreDir() string    { return a.opts.StoreDir }
-func (a *App) Version() string     { return a.opts.Version }
-func (a *App) AllowUnauthed() bool { return a.opts.AllowUnauthed }
+func (a *App) WA() WAClient             { return a.wa }
+func (a *App) DB() *store.DB            { return a.db }
+func (a *App) Events() *out.EventWriter { return a.events }
+func (a *App) StoreDir() string         { return a.opts.StoreDir }
+func (a *App) Version() string          { return a.opts.Version }
+func (a *App) AllowUnauthed() bool      { return a.opts.AllowUnauthed }
 
 func (a *App) Connect(ctx context.Context, allowQR bool, qrWriter func(string)) error {
 	if err := a.OpenWA(); err != nil {

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -98,6 +98,42 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 			if err := a.storeParsedMessage(ctx, pm); err == nil {
 				messagesStored.Add(1)
 			}
+			if a.events.Enabled() {
+				data := map[string]interface{}{
+					"id":        pm.ID,
+					"chat":      pm.Chat.String(),
+					"sender":    pm.SenderJID,
+					"timestamp": pm.Timestamp.Unix(),
+					"from_me":   pm.FromMe,
+					"is_group":  pm.Chat.Server == types.GroupServer,
+				}
+				if pm.PushName != "" {
+					data["push_name"] = pm.PushName
+				}
+				if pm.Text != "" {
+					data["text"] = pm.Text
+				}
+				if pm.Media != nil {
+					data["media_type"] = pm.Media.Type
+					if pm.Media.Caption != "" {
+						data["caption"] = pm.Media.Caption
+					}
+					if pm.Media.MimeType != "" {
+						data["mime_type"] = pm.Media.MimeType
+					}
+					if pm.Media.Filename != "" {
+						data["filename"] = pm.Media.Filename
+					}
+				}
+				if pm.ReactionEmoji != "" {
+					data["reaction_emoji"] = pm.ReactionEmoji
+					data["reaction_to_id"] = pm.ReactionToID
+				}
+				if pm.ReplyToID != "" {
+					data["reply_to_id"] = pm.ReplyToID
+				}
+				a.events.Emit("new_message", data)
+			}
 			if opts.DownloadMedia && pm.Media != nil && pm.ID != "" {
 				enqueueMedia(pm.Chat.String(), pm.ID)
 			}

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -102,10 +102,20 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 				enqueueMedia(pm.Chat.String(), pm.ID)
 			}
 			if messagesStored.Load()%25 == 0 {
-				fmt.Fprintf(os.Stderr, "\rSynced %d messages...", messagesStored.Load())
+				n := messagesStored.Load()
+				if a.events.Enabled() {
+					a.events.Emit("progress", map[string]interface{}{"messages_synced": n})
+				} else {
+					fmt.Fprintf(os.Stderr, "\rSynced %d messages...", n)
+				}
 			}
 		case *events.HistorySync:
-			fmt.Fprintf(os.Stderr, "\nProcessing history sync (%d conversations)...\n", len(v.Data.Conversations))
+			nConv := len(v.Data.Conversations)
+			if a.events.Enabled() {
+				a.events.Emit("history_sync", map[string]interface{}{"conversations": nConv})
+			} else {
+				fmt.Fprintf(os.Stderr, "\nProcessing history sync (%d conversations)...\n", nConv)
+			}
 			for _, conv := range v.Data.Conversations {
 				lastEvent.Store(time.Now().UTC().UnixNano())
 				chatID := strings.TrimSpace(conv.GetID())
@@ -129,11 +139,24 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 					}
 				}
 			}
-			fmt.Fprintf(os.Stderr, "\rSynced %d messages...", messagesStored.Load())
+			n := messagesStored.Load()
+			if a.events.Enabled() {
+				a.events.Emit("progress", map[string]interface{}{"messages_synced": n})
+			} else {
+				fmt.Fprintf(os.Stderr, "\rSynced %d messages...", n)
+			}
 		case *events.Connected:
-			fmt.Fprintln(os.Stderr, "\nConnected.")
+			if a.events.Enabled() {
+				a.events.Emit("connected", nil)
+			} else {
+				fmt.Fprintln(os.Stderr, "\nConnected.")
+			}
 		case *events.Disconnected:
-			fmt.Fprintln(os.Stderr, "\nDisconnected.")
+			if a.events.Enabled() {
+				a.events.Emit("disconnected", nil)
+			} else {
+				fmt.Fprintln(os.Stderr, "\nDisconnected.")
+			}
 			select {
 			case disconnected <- struct{}{}:
 			default:
@@ -172,10 +195,18 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 		for {
 			select {
 			case <-ctx.Done():
-				fmt.Fprintln(os.Stderr, "\nStopping sync.")
+				if a.events.Enabled() {
+					a.events.Emit("stopping", map[string]interface{}{"messages_synced": messagesStored.Load()})
+				} else {
+					fmt.Fprintln(os.Stderr, "\nStopping sync.")
+				}
 				return SyncResult{MessagesStored: messagesStored.Load()}, nil
 			case <-disconnected:
-				fmt.Fprintln(os.Stderr, "Reconnecting...")
+				if a.events.Enabled() {
+					a.events.Emit("reconnecting", nil)
+				} else {
+					fmt.Fprintln(os.Stderr, "Reconnecting...")
+				}
 				if err := a.wa.ReconnectWithBackoff(ctx, 2*time.Second, 30*time.Second); err != nil {
 					return SyncResult{MessagesStored: messagesStored.Load()}, err
 				}
@@ -193,17 +224,32 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 	for {
 		select {
 		case <-ctx.Done():
-			fmt.Fprintln(os.Stderr, "\nStopping sync.")
+			if a.events.Enabled() {
+				a.events.Emit("stopping", map[string]interface{}{"messages_synced": messagesStored.Load()})
+			} else {
+				fmt.Fprintln(os.Stderr, "\nStopping sync.")
+			}
 			return SyncResult{MessagesStored: messagesStored.Load()}, nil
 		case <-disconnected:
-			fmt.Fprintln(os.Stderr, "Reconnecting...")
+			if a.events.Enabled() {
+				a.events.Emit("reconnecting", nil)
+			} else {
+				fmt.Fprintln(os.Stderr, "Reconnecting...")
+			}
 			if err := a.wa.ReconnectWithBackoff(ctx, 2*time.Second, 30*time.Second); err != nil {
 				return SyncResult{MessagesStored: messagesStored.Load()}, err
 			}
 		case <-ticker.C:
 			last := time.Unix(0, lastEvent.Load())
 			if time.Since(last) >= opts.IdleExit {
-				fmt.Fprintf(os.Stderr, "\nIdle for %s, exiting.\n", opts.IdleExit)
+				if a.events.Enabled() {
+					a.events.Emit("idle_exit", map[string]interface{}{
+						"idle_duration":  opts.IdleExit.String(),
+						"messages_synced": messagesStored.Load(),
+					})
+				} else {
+					fmt.Fprintf(os.Stderr, "\nIdle for %s, exiting.\n", opts.IdleExit)
+				}
 				return SyncResult{MessagesStored: messagesStored.Load()}, nil
 			}
 		}

--- a/internal/app/sync_events_test.go
+++ b/internal/app/sync_events_test.go
@@ -158,6 +158,202 @@ func TestSyncIdleExitEmitsEvent(t *testing.T) {
 	assertContains(t, eventNames, "idle_exit")
 }
 
+func TestSyncEmitsNewMessageEvent(t *testing.T) {
+	var buf bytes.Buffer
+	a := newTestApp(t)
+	a.events = out.NewEventWriter(&buf, true)
+
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "123", Server: types.DefaultUserServer}
+	sender := types.JID{User: "456", Server: types.DefaultUserServer}
+	f.contacts[chat.ToNonAD()] = types.ContactInfo{
+		Found:    true,
+		FullName: "Alice",
+		PushName: "Alice",
+	}
+
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// A live text message arriving after connect
+	liveMsg := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     chat,
+				Sender:   sender,
+				IsFromMe: false,
+			},
+			ID:        "msg-live-1",
+			Timestamp: base,
+			PushName:  "Bob",
+		},
+		Message: &waProto.Message{Conversation: proto.String("hey are you free?")},
+	}
+
+	f.connectEvents = []interface{}{liveMsg}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+	_, err := a.Sync(ctx, SyncOptions{
+		Mode:    SyncModeFollow,
+		AllowQR: false,
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	// Parse all emitted events, find new_message
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	var newMsgEvent *out.Event
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		var ev out.Event
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("unmarshal event line %q: %v", line, err)
+		}
+		if ev.Event == "new_message" {
+			newMsgEvent = &ev
+		}
+	}
+
+	if newMsgEvent == nil {
+		t.Fatalf("expected new_message event, got events: %s", buf.String())
+	}
+
+	// Verify data fields
+	data, ok := newMsgEvent.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected data to be map, got %T", newMsgEvent.Data)
+	}
+
+	if id, _ := data["id"].(string); id != "msg-live-1" {
+		t.Errorf("expected id=msg-live-1, got %q", id)
+	}
+	if chat, _ := data["chat"].(string); chat != "123@s.whatsapp.net" {
+		t.Errorf("expected chat=123@s.whatsapp.net, got %q", chat)
+	}
+	if text, _ := data["text"].(string); text != "hey are you free?" {
+		t.Errorf("expected text='hey are you free?', got %q", text)
+	}
+	if pushName, _ := data["push_name"].(string); pushName != "Bob" {
+		t.Errorf("expected push_name=Bob, got %q", pushName)
+	}
+	if fromMe, _ := data["from_me"].(bool); fromMe {
+		t.Error("expected from_me=false")
+	}
+	if isGroup, _ := data["is_group"].(bool); isGroup {
+		t.Error("expected is_group=false")
+	}
+}
+
+func TestSyncEmitsNewMessageEventForGroup(t *testing.T) {
+	var buf bytes.Buffer
+	a := newTestApp(t)
+	a.events = out.NewEventWriter(&buf, true)
+
+	f := newFakeWA()
+	a.wa = f
+
+	groupChat := types.JID{User: "999", Server: types.GroupServer}
+	sender := types.JID{User: "456", Server: types.DefaultUserServer}
+
+	liveMsg := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     groupChat,
+				Sender:   sender,
+				IsFromMe: false,
+			},
+			ID:        "msg-group-1",
+			Timestamp: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+			PushName:  "Charlie",
+		},
+		Message: &waProto.Message{Conversation: proto.String("group message")},
+	}
+
+	f.connectEvents = []interface{}{liveMsg}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+	_, err := a.Sync(ctx, SyncOptions{
+		Mode:    SyncModeFollow,
+		AllowQR: false,
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		var ev out.Event
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if ev.Event == "new_message" {
+			data, _ := ev.Data.(map[string]interface{})
+			if isGroup, _ := data["is_group"].(bool); !isGroup {
+				t.Error("expected is_group=true for group message")
+			}
+			if chat, _ := data["chat"].(string); chat != "999@g.us" {
+				t.Errorf("expected chat=999@g.us, got %q", chat)
+			}
+			return
+		}
+	}
+	t.Fatal("expected new_message event for group message")
+}
+
+func TestSyncNewMessageNotEmittedWhenEventsDisabled(t *testing.T) {
+	var buf bytes.Buffer
+	a := newTestApp(t)
+	a.events = out.NewEventWriter(&buf, false) // disabled
+
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "123", Server: types.DefaultUserServer}
+	f.contacts[chat.ToNonAD()] = types.ContactInfo{Found: true, PushName: "Alice"}
+
+	liveMsg := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     chat,
+				Sender:   chat,
+				IsFromMe: false,
+			},
+			ID:        "msg-no-event",
+			Timestamp: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+			PushName:  "Alice",
+		},
+		Message: &waProto.Message{Conversation: proto.String("should not emit")},
+	}
+
+	f.connectEvents = []interface{}{liveMsg}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	_, _ = a.Sync(ctx, SyncOptions{Mode: SyncModeFollow, AllowQR: false})
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected no event output when disabled, got %q", buf.String())
+	}
+}
+
 func assertContains(t *testing.T, slice []string, want string) {
 	t.Helper()
 	for _, s := range slice {

--- a/internal/app/sync_events_test.go
+++ b/internal/app/sync_events_test.go
@@ -1,0 +1,169 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steipete/wacli/internal/out"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/proto/waCommon"
+	"go.mau.fi/whatsmeow/proto/waHistorySync"
+	"go.mau.fi/whatsmeow/proto/waWeb"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestSyncEmitsJSONEvents(t *testing.T) {
+	var buf bytes.Buffer
+	a := newTestApp(t)
+	a.events = out.NewEventWriter(&buf, true)
+
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "123", Server: types.DefaultUserServer}
+	f.contacts[chat.ToNonAD()] = types.ContactInfo{
+		Found:    true,
+		FullName: "Alice",
+		PushName: "Alice",
+	}
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Create a history sync event with 2 conversations
+	histMsg1 := &waWeb.WebMessageInfo{
+		Key: &waCommon.MessageKey{
+			RemoteJID: proto.String(chat.String()),
+			FromMe:    proto.Bool(false),
+			ID:        proto.String("m-hist-1"),
+		},
+		MessageTimestamp: proto.Uint64(uint64(base.Unix())),
+		Message:          &waProto.Message{Conversation: proto.String("hello")},
+	}
+	history := &events.HistorySync{
+		Data: &waHistorySync.HistorySync{
+			SyncType: waHistorySync.HistorySync_FULL.Enum(),
+			Conversations: []*waHistorySync.Conversation{{
+				ID:       proto.String(chat.String()),
+				Messages: []*waHistorySync.HistorySyncMsg{{Message: histMsg1}},
+			}},
+		},
+	}
+
+	f.connectEvents = []interface{}{history}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+	_, err := a.Sync(ctx, SyncOptions{
+		Mode:    SyncModeFollow,
+		AllowQR: false,
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	// Parse all emitted events
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	eventNames := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		var ev out.Event
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("unmarshal event line %q: %v", line, err)
+		}
+		eventNames = append(eventNames, ev.Event)
+		if ev.TS <= 0 {
+			t.Fatalf("expected positive timestamp in event %q", ev.Event)
+		}
+	}
+
+	// Should contain: connected, history_sync, progress, stopping
+	assertContains(t, eventNames, "connected")
+	assertContains(t, eventNames, "history_sync")
+	assertContains(t, eventNames, "progress")
+	assertContains(t, eventNames, "stopping")
+}
+
+func TestSyncEventsDisabledNoJSON(t *testing.T) {
+	var buf bytes.Buffer
+	a := newTestApp(t)
+	// Events disabled (default)
+	a.events = out.NewEventWriter(&buf, false)
+
+	f := newFakeWA()
+	a.wa = f
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	_, err := a.Sync(ctx, SyncOptions{
+		Mode:    SyncModeFollow,
+		AllowQR: false,
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	// Should have no JSON output in our buffer
+	if buf.Len() != 0 {
+		t.Fatalf("expected no event output when disabled, got %q", buf.String())
+	}
+}
+
+func TestSyncIdleExitEmitsEvent(t *testing.T) {
+	var buf bytes.Buffer
+	a := newTestApp(t)
+	a.events = out.NewEventWriter(&buf, true)
+
+	f := newFakeWA()
+	a.wa = f
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := a.Sync(ctx, SyncOptions{
+		Mode:     SyncModeOnce,
+		AllowQR:  false,
+		IdleExit: 200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	eventNames := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		var ev out.Event
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("unmarshal event line %q: %v", line, err)
+		}
+		eventNames = append(eventNames, ev.Event)
+	}
+
+	assertContains(t, eventNames, "idle_exit")
+}
+
+func assertContains(t *testing.T, slice []string, want string) {
+	t.Helper()
+	for _, s := range slice {
+		if s == want {
+			return
+		}
+	}
+	t.Fatalf("expected %q in %v", want, slice)
+}

--- a/internal/out/events.go
+++ b/internal/out/events.go
@@ -1,0 +1,54 @@
+package out
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// Event is a single NDJSON line emitted to stderr when --events is set.
+type Event struct {
+	Event string      `json:"event"`
+	Data  interface{} `json:"data,omitempty"`
+	TS    int64       `json:"ts"`
+}
+
+// EventWriter emits structured NDJSON events to a writer.
+// When disabled, it is a no-op; callers should check Enabled() and fall back to
+// human-readable output.
+type EventWriter struct {
+	mu      sync.Mutex
+	w       io.Writer
+	enabled bool
+}
+
+// NewEventWriter returns an EventWriter. If enabled is false, Emit is a no-op.
+func NewEventWriter(w io.Writer, enabled bool) *EventWriter {
+	return &EventWriter{w: w, enabled: enabled}
+}
+
+// Enabled reports whether JSON events are active.
+func (ew *EventWriter) Enabled() bool {
+	return ew.enabled
+}
+
+// Emit writes a single NDJSON event line. Safe for concurrent use.
+func (ew *EventWriter) Emit(event string, data interface{}) {
+	if !ew.enabled {
+		return
+	}
+	e := Event{
+		Event: event,
+		Data:  data,
+		TS:    time.Now().UnixMilli(),
+	}
+	b, err := json.Marshal(e)
+	if err != nil {
+		return
+	}
+	ew.mu.Lock()
+	defer ew.mu.Unlock()
+	fmt.Fprintln(ew.w, string(b))
+}

--- a/internal/out/events_test.go
+++ b/internal/out/events_test.go
@@ -1,0 +1,105 @@
+package out
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestEventWriterEmitsNDJSON(t *testing.T) {
+	var buf bytes.Buffer
+	ew := NewEventWriter(&buf, true)
+
+	if !ew.Enabled() {
+		t.Fatal("expected Enabled() to be true")
+	}
+
+	ew.Emit("connected", nil)
+	ew.Emit("progress", map[string]interface{}{"messages_synced": 75})
+	ew.Emit("history_sync", map[string]interface{}{"conversations": 42})
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d: %q", len(lines), buf.String())
+	}
+
+	// Verify first event: connected
+	var ev1 Event
+	if err := json.Unmarshal([]byte(lines[0]), &ev1); err != nil {
+		t.Fatalf("unmarshal line 0: %v", err)
+	}
+	if ev1.Event != "connected" {
+		t.Fatalf("expected event=connected, got %q", ev1.Event)
+	}
+	if ev1.TS <= 0 {
+		t.Fatal("expected positive timestamp")
+	}
+
+	// Verify second event: progress with data
+	var ev2 struct {
+		Event string                 `json:"event"`
+		Data  map[string]interface{} `json:"data"`
+		TS    int64                  `json:"ts"`
+	}
+	if err := json.Unmarshal([]byte(lines[1]), &ev2); err != nil {
+		t.Fatalf("unmarshal line 1: %v", err)
+	}
+	if ev2.Event != "progress" {
+		t.Fatalf("expected event=progress, got %q", ev2.Event)
+	}
+	if ev2.Data["messages_synced"] != float64(75) {
+		t.Fatalf("expected messages_synced=75, got %v", ev2.Data["messages_synced"])
+	}
+
+	// Verify third event: history_sync
+	var ev3 struct {
+		Event string                 `json:"event"`
+		Data  map[string]interface{} `json:"data"`
+		TS    int64                  `json:"ts"`
+	}
+	if err := json.Unmarshal([]byte(lines[2]), &ev3); err != nil {
+		t.Fatalf("unmarshal line 2: %v", err)
+	}
+	if ev3.Event != "history_sync" {
+		t.Fatalf("expected event=history_sync, got %q", ev3.Event)
+	}
+	if ev3.Data["conversations"] != float64(42) {
+		t.Fatalf("expected conversations=42, got %v", ev3.Data["conversations"])
+	}
+}
+
+func TestEventWriterDisabledIsNoop(t *testing.T) {
+	var buf bytes.Buffer
+	ew := NewEventWriter(&buf, false)
+
+	if ew.Enabled() {
+		t.Fatal("expected Enabled() to be false")
+	}
+
+	ew.Emit("connected", nil)
+	ew.Emit("progress", map[string]interface{}{"messages_synced": 10})
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output when disabled, got %q", buf.String())
+	}
+}
+
+func TestEventWriterNilData(t *testing.T) {
+	var buf bytes.Buffer
+	ew := NewEventWriter(&buf, true)
+
+	ew.Emit("disconnected", nil)
+
+	var ev map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if ev["event"] != "disconnected" {
+		t.Fatalf("expected event=disconnected, got %v", ev["event"])
+	}
+	// data should be absent (omitempty)
+	if _, ok := ev["data"]; ok {
+		t.Fatalf("expected data to be omitted for nil, got %v", ev["data"])
+	}
+}


### PR DESCRIPTION
## Problem

`wacli` has `--json` for structured stdout output, but the auth/sync lifecycle — the most important part for programmatic consumers — only emits human-readable strings to stderr:

```
Starting authentication…
Connected.
Processing history sync (42 conversations)...
Synced 75 messages...
Idle for 30s, exiting.
```

Anyone building an application on top of `wacli` is forced to regex-parse English sentences to track what's happening. This is fragile: one wording change upstream silently breaks the consumer, and useful structured data (the `Progress` float from whatsmeow, conversation counts) gets thrown away in the string formatting.

This is a blind spot in an otherwise well-designed scripting interface — `--json` clearly signals intent for programmatic use, and issue #83 (JSON-RPC daemon) and issue #65 (Unix socket IPC) reinforce that vision.

## Solution

Add a `--events` persistent flag that emits **newline-delimited JSON** to stderr during auth and sync, one event per line:

```jsonc
{"event":"auth_starting","ts":1709042400000}
{"event":"qr_code","data":{"code":"2@abc123..."},"ts":1709042400001}
{"event":"connected","ts":1709042400002}
{"event":"history_sync","data":{"conversations":42},"ts":1709042400003}
{"event":"progress","data":{"messages_synced":75},"ts":1709042400004}
{"event":"idle_exit","data":{"idle_duration":"30s","messages_synced":150},"ts":1709042400005}
```

**Without `--events`, behavior is byte-for-byte identical to before.** This is purely additive.

## Events emitted

| Event | When | Data fields |
|---|---|---|
| `auth_starting` | `wacli auth` begins | — |
| `qr_code` | QR ready to scan | `code` (raw QR string, not terminal art) |
| `connected` | whatsmeow `events.Connected` | — |
| `disconnected` | whatsmeow `events.Disconnected` | — |
| `history_sync` | whatsmeow `events.HistorySync` | `conversations` (count) |
| `progress` | every 25 messages stored | `messages_synced` (count) |
| `reconnecting` | backoff reconnect starts | — |
| `stopping` | graceful shutdown (SIGINT/SIGTERM) | `messages_synced` |
| `idle_exit` | idle timer fires | `idle_duration`, `messages_synced` |

The `qr_code` event is particularly useful: instead of detecting Unicode block characters in a stream, consumers get the raw QR payload string and can render it however they want (web canvas, mobile SDK, PNG file).

## Changes

- **`internal/out/events.go`** — `EventWriter`: thread-safe NDJSON emitter, no-op when disabled
- **`cmd/wacli/root.go`** — `--events` persistent flag wired to `App.events`
- **`internal/app/app.go`** — `Events *out.EventWriter` in `Options`; `App.Events()` accessor
- **`internal/app/sync.go`** — every `fmt.Fprintf(os.Stderr, ...)` dual-pathed: JSON event or existing text
- **`cmd/wacli/auth.go`** — `auth_starting` and `qr_code` events
- **`internal/out/events_test.go`** — unit tests for EventWriter
- **`internal/app/sync_events_test.go`** — integration tests using the existing fakeWA harness

## Usage

```sh
# Machine-readable (new)
wacli auth --json --events --idle-exit 5s 2>events.ndjson

# Human-readable (unchanged)
wacli auth --json --idle-exit 5s
```

Combine with `jq` for easy scripting:
```sh
wacli sync --events 2>&1 | grep '^{' | jq 'select(.event == "progress") | .data.messages_synced'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)