### PR TITLE
fix: normalize phone numbers with leading plus

### DIFF
--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -255,6 +255,7 @@ func ParseUserOrJID(s string) (types.JID, error) {
 	if strings.Contains(s, "@") {
 		return types.ParseJID(s)
 	}
+	s = strings.TrimPrefix(s, "+")
 	return types.JID{User: s, Server: types.DefaultUserServer}, nil
 }
 

--- a/internal/wa/client_test.go
+++ b/internal/wa/client_test.go
@@ -15,6 +15,14 @@ func TestParseUserOrJID(t *testing.T) {
 		t.Fatalf("unexpected jid: %+v", j)
 	}
 
+	j, err = ParseUserOrJID(" +1234567890 ")
+	if err != nil {
+		t.Fatalf("ParseUserOrJID plus: %v", err)
+	}
+	if j.Server != types.DefaultUserServer || j.User != "1234567890" {
+		t.Fatalf("unexpected normalized jid: %+v", j)
+	}
+
 	j, err = ParseUserOrJID("123@g.us")
 	if err != nil {
 		t.Fatalf("ParseUserOrJID group: %v", err)


### PR DESCRIPTION
## Summary
- strip a leading `+` from phone-number inputs before building a user JID
- preserve existing behavior for explicit JIDs containing `@`
- add a regression test covering whitespace + `+` normalization

## Why
Several reports show `wacli send text --to "+49123456789" ...` timing out while `49123456789` works.
The malformed lookup path builds `+49123456789@s.whatsapp.net`, which leads to `info query timed out` / user-info lookup failures.

This is a small, low-risk fix that addresses the phone-number parsing bug independently of the larger IPC/send-delegation work in #92.

## Testing
- `go test ./internal/wa ./cmd/wacli`

## Related
- Fixes/addresses #28
- Likely improves symptoms reported in #9 and #91
- Separate from #92 (IPC delegation while `sync --follow` is running)
