### PR TITLE
feat: add multi-account support

### DIFF
--- a/cmd/wacli/accounts.go
+++ b/cmd/wacli/accounts.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/steipete/wacli/internal/config"
+	"github.com/steipete/wacli/internal/out"
+)
+
+func newAccountsCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "accounts",
+		Aliases: []string{"account"},
+		Short:   "Manage WhatsApp accounts",
+	}
+
+	cmd.AddCommand(newAccountsListCmd(flags))
+	cmd.AddCommand(newAccountsDefaultCmd(flags))
+	cmd.AddCommand(newAccountsRemoveCmd(flags))
+
+	return cmd
+}
+
+func newAccountsListCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all accounts",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			baseDir := flags.storeDir
+			if baseDir == "" {
+				baseDir = config.DefaultStoreDir()
+			}
+			baseDir, _ = filepath.Abs(baseDir)
+
+			if err := config.MaybeMigrateLegacyStore(baseDir); err != nil {
+				return err
+			}
+
+			accounts, err := config.ListAccounts(baseDir)
+			if err != nil {
+				return fmt.Errorf("list accounts: %w", err)
+			}
+
+			defaultAccount := config.ReadDefaultAccount(baseDir)
+
+			if flags.asJSON {
+				type entry struct {
+					Name    string `json:"name"`
+					Default bool   `json:"default"`
+				}
+				var entries []entry
+				for _, name := range accounts {
+					entries = append(entries, entry{Name: name, Default: name == defaultAccount})
+				}
+				return out.WriteJSON(os.Stdout, entries)
+			}
+
+			if len(accounts) == 0 {
+				fmt.Fprintln(os.Stdout, "No accounts found. Run `wacli auth` to set one up.")
+				return nil
+			}
+
+			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+			for _, name := range accounts {
+				marker := ""
+				if name == defaultAccount {
+					marker = " (default)"
+				}
+				fmt.Fprintf(w, "%s%s\n", name, marker)
+			}
+			return w.Flush()
+		},
+	}
+}
+
+func newAccountsDefaultCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "default [name]",
+		Short: "Get or set the default account",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			baseDir := flags.storeDir
+			if baseDir == "" {
+				baseDir = config.DefaultStoreDir()
+			}
+			baseDir, _ = filepath.Abs(baseDir)
+
+			if len(args) == 0 {
+				name := config.ReadDefaultAccount(baseDir)
+				if flags.asJSON {
+					return out.WriteJSON(os.Stdout, map[string]string{"default": name})
+				}
+				fmt.Fprintln(os.Stdout, name)
+				return nil
+			}
+
+			name := args[0]
+			if err := config.ValidateAccountName(name); err != nil {
+				return err
+			}
+
+			// Verify account exists
+			acctDir := config.AccountDir(baseDir, name)
+			if _, err := os.Stat(acctDir); os.IsNotExist(err) {
+				return fmt.Errorf("account %q does not exist", name)
+			}
+
+			if err := config.WriteDefaultAccount(baseDir, name); err != nil {
+				return fmt.Errorf("set default account: %w", err)
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]string{"default": name})
+			}
+			fmt.Fprintf(os.Stdout, "Default account set to %q.\n", name)
+			return nil
+		},
+	}
+}
+
+func newAccountsRemoveCmd(flags *rootFlags) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "remove <name>",
+		Short: "Remove an account and its data",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			if err := config.ValidateAccountName(name); err != nil {
+				return err
+			}
+
+			baseDir := flags.storeDir
+			if baseDir == "" {
+				baseDir = config.DefaultStoreDir()
+			}
+			baseDir, _ = filepath.Abs(baseDir)
+
+			acctDir := config.AccountDir(baseDir, name)
+			if _, err := os.Stat(acctDir); os.IsNotExist(err) {
+				return fmt.Errorf("account %q does not exist", name)
+			}
+
+			if !force {
+				return fmt.Errorf("refusing to remove account %q without --force (this deletes all local data for this account)", name)
+			}
+
+			if err := os.RemoveAll(acctDir); err != nil {
+				return fmt.Errorf("remove account: %w", err)
+			}
+
+			// If we removed the default, clear the default file
+			if config.ReadDefaultAccount(baseDir) == name {
+				_ = os.Remove(filepath.Join(baseDir, "default_account"))
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{"removed": name})
+			}
+			fmt.Fprintf(os.Stdout, "Account %q removed.\n", name)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "confirm deletion of account data")
+	return cmd
+}

--- a/cmd/wacli/auth.go
+++ b/cmd/wacli/auth.go
@@ -37,7 +37,10 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 				mode = appPkg.SyncModeFollow
 			}
 
-			fmt.Fprintln(os.Stderr, "Starting authentication…")
+			// Show which account we're authenticating (resolveStoreDir is idempotent).
+			if _, _, acctName, err := resolveStoreDir(flags); err == nil {
+				fmt.Fprintf(os.Stderr, "Starting authentication for account %q…\n", acctName)
+			}
 			res, err := a.Sync(ctx, appPkg.SyncOptions{
 				Mode:            mode,
 				AllowQR:         true,

--- a/cmd/wacli/doctor.go
+++ b/cmd/wacli/doctor.go
@@ -9,7 +9,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
-	"github.com/steipete/wacli/internal/config"
 	"github.com/steipete/wacli/internal/lock"
 	"github.com/steipete/wacli/internal/out"
 )
@@ -24,18 +23,17 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			ctx, cancel := withTimeout(context.Background(), flags)
 			defer cancel()
 
-			storeDir := flags.storeDir
-			if storeDir == "" {
-				storeDir = config.DefaultStoreDir()
+			_, accountDir, accountName, err := resolveStoreDir(flags)
+			if err != nil {
+				return err
 			}
-			storeDir, _ = filepath.Abs(storeDir)
 
 			var lockHeld bool
 			var lockInfo string
-			if b, err := os.ReadFile(filepath.Join(storeDir, "LOCK")); err == nil {
+			if b, err := os.ReadFile(filepath.Join(accountDir, "LOCK")); err == nil {
 				lockInfo = strings.TrimSpace(string(b))
 			}
-			if lk, err := lock.Acquire(storeDir); err == nil {
+			if lk, err := lock.Acquire(accountDir); err == nil {
 				_ = lk.Release()
 			} else {
 				lockHeld = true
@@ -59,6 +57,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			type report struct {
+				Account    string `json:"account"`
 				StoreDir   string `json:"store_dir"`
 				LockHeld   bool   `json:"lock_held"`
 				LockInfo   string `json:"lock_info,omitempty"`
@@ -68,7 +67,8 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			rep := report{
-				StoreDir:   storeDir,
+				Account:    accountName,
+				StoreDir:   accountDir,
 				LockHeld:   lockHeld,
 				LockInfo:   lockInfo,
 				Authed:     authed,
@@ -81,6 +81,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+			fmt.Fprintf(w, "ACCOUNT\t%s\n", rep.Account)
 			fmt.Fprintf(w, "STORE\t%s\n", rep.StoreDir)
 			fmt.Fprintf(w, "LOCKED\t%v\n", rep.LockHeld)
 			if rep.LockHeld && rep.LockInfo != "" {

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -19,6 +19,7 @@ var version = "0.5.0"
 
 type rootFlags struct {
 	storeDir string
+	account  string
 	asJSON   bool
 	timeout  time.Duration
 }
@@ -35,6 +36,7 @@ func execute(args []string) error {
 	rootCmd.SetVersionTemplate("wacli {{.Version}}\n")
 
 	rootCmd.PersistentFlags().StringVar(&flags.storeDir, "store", "", "store directory (default: ~/.wacli)")
+	rootCmd.PersistentFlags().StringVarP(&flags.account, "account", "a", "", "account name (default: from ~/.wacli/default_account or \"default\")")
 	rootCmd.PersistentFlags().BoolVar(&flags.asJSON, "json", false, "output JSON instead of human-readable text")
 	rootCmd.PersistentFlags().DurationVar(&flags.timeout, "timeout", 5*time.Minute, "command timeout (non-sync commands)")
 
@@ -49,6 +51,7 @@ func execute(args []string) error {
 	rootCmd.AddCommand(newChatsCmd(&flags))
 	rootCmd.AddCommand(newGroupsCmd(&flags))
 	rootCmd.AddCommand(newHistoryCmd(&flags))
+	rootCmd.AddCommand(newAccountsCmd(&flags))
 
 	rootCmd.SetArgs(args)
 	if err := rootCmd.Execute(); err != nil {
@@ -58,24 +61,43 @@ func execute(args []string) error {
 	return nil
 }
 
-func newApp(ctx context.Context, flags *rootFlags, needLock bool, allowUnauthed bool) (*app.App, *lock.Lock, error) {
-	storeDir := flags.storeDir
-	if storeDir == "" {
-		storeDir = config.DefaultStoreDir()
+// resolveStoreDir returns the base store dir and the account-specific store dir.
+func resolveStoreDir(flags *rootFlags) (baseDir string, accountDir string, accountName string, err error) {
+	baseDir = flags.storeDir
+	if baseDir == "" {
+		baseDir = config.DefaultStoreDir()
 	}
-	storeDir, _ = filepath.Abs(storeDir)
+	baseDir, _ = filepath.Abs(baseDir)
+
+	if err := config.MaybeMigrateLegacyStore(baseDir); err != nil {
+		return "", "", "", err
+	}
+
+	accountName, err = config.ResolveAccount(baseDir, flags.account)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	accountDir = config.AccountDir(baseDir, accountName)
+	return baseDir, accountDir, accountName, nil
+}
+
+func newApp(ctx context.Context, flags *rootFlags, needLock bool, allowUnauthed bool) (*app.App, *lock.Lock, error) {
+	_, accountDir, _, err := resolveStoreDir(flags)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	var lk *lock.Lock
 	if needLock {
-		var err error
-		lk, err = lock.Acquire(storeDir)
+		lk, err = lock.Acquire(accountDir)
 		if err != nil {
 			return nil, nil, err
 		}
 	}
 
 	a, err := app.New(app.Options{
-		StoreDir:      storeDir,
+		StoreDir:      accountDir,
 		Version:       version,
 		JSON:          flags.asJSON,
 		AllowUnauthed: allowUnauthed,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,9 +1,14 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 )
+
+var validAccountName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
 func DefaultStoreDir() string {
 	home, err := os.UserHomeDir()
@@ -11,4 +16,130 @@ func DefaultStoreDir() string {
 		return ".wacli"
 	}
 	return filepath.Join(home, ".wacli")
+}
+
+// ValidateAccountName checks that name is safe for use as a directory name.
+func ValidateAccountName(name string) error {
+	if name == "" {
+		return fmt.Errorf("account name cannot be empty")
+	}
+	if len(name) > 64 {
+		return fmt.Errorf("account name too long (max 64 characters)")
+	}
+	if !validAccountName.MatchString(name) {
+		return fmt.Errorf("invalid account name %q: must start with alphanumeric and contain only [a-zA-Z0-9._-]", name)
+	}
+	return nil
+}
+
+// AccountDir returns the store directory for a named account.
+func AccountDir(baseDir, account string) string {
+	return filepath.Join(baseDir, "accounts", account)
+}
+
+// ResolveAccount determines which account to use based on flag, env var, or default file.
+func ResolveAccount(baseDir, flagValue string) (string, error) {
+	if flagValue != "" {
+		if err := ValidateAccountName(flagValue); err != nil {
+			return "", err
+		}
+		return flagValue, nil
+	}
+
+	if env := os.Getenv("WACLI_ACCOUNT"); env != "" {
+		if err := ValidateAccountName(env); err != nil {
+			return "", fmt.Errorf("WACLI_ACCOUNT: %w", err)
+		}
+		return env, nil
+	}
+
+	return ReadDefaultAccount(baseDir), nil
+}
+
+// ReadDefaultAccount reads the default account name from the base dir.
+// Returns "default" if not set.
+func ReadDefaultAccount(baseDir string) string {
+	b, err := os.ReadFile(filepath.Join(baseDir, "default_account"))
+	if err != nil {
+		return "default"
+	}
+	name := strings.TrimSpace(string(b))
+	if name == "" {
+		return "default"
+	}
+	return name
+}
+
+// WriteDefaultAccount persists the default account name.
+func WriteDefaultAccount(baseDir, name string) error {
+	if err := ValidateAccountName(name); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(baseDir, "default_account"), []byte(name+"\n"), 0600)
+}
+
+// ListAccounts returns all account names found in baseDir/accounts/.
+func ListAccounts(baseDir string) ([]string, error) {
+	accountsDir := filepath.Join(baseDir, "accounts")
+	entries, err := os.ReadDir(accountsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() && ValidateAccountName(e.Name()) == nil {
+			names = append(names, e.Name())
+		}
+	}
+	return names, nil
+}
+
+// MaybeMigrateLegacyStore moves a legacy single-account store layout into
+// accounts/default/ so existing users get a seamless upgrade.
+func MaybeMigrateLegacyStore(baseDir string) error {
+	sessionDB := filepath.Join(baseDir, "session.db")
+	if _, err := os.Stat(sessionDB); err != nil {
+		return nil // no legacy layout
+	}
+
+	// Already migrated?
+	accountsDir := filepath.Join(baseDir, "accounts")
+	if _, err := os.Stat(accountsDir); err == nil {
+		return nil // accounts dir already exists, don't touch
+	}
+
+	targetDir := AccountDir(baseDir, "default")
+	if err := os.MkdirAll(targetDir, 0700); err != nil {
+		return fmt.Errorf("migrate legacy store: create dir: %w", err)
+	}
+
+	filesToMove := []string{"session.db", "session.db-wal", "session.db-shm", "wacli.db", "wacli.db-wal", "wacli.db-shm"}
+	for _, name := range filesToMove {
+		src := filepath.Join(baseDir, name)
+		if _, err := os.Stat(src); err != nil {
+			continue
+		}
+		dst := filepath.Join(targetDir, name)
+		if err := os.Rename(src, dst); err != nil {
+			return fmt.Errorf("migrate legacy store: move %s: %w", name, err)
+		}
+	}
+
+	// Move media dir if present
+	mediaSrc := filepath.Join(baseDir, "media")
+	if info, err := os.Stat(mediaSrc); err == nil && info.IsDir() {
+		mediaDst := filepath.Join(targetDir, "media")
+		if err := os.Rename(mediaSrc, mediaDst); err != nil {
+			return fmt.Errorf("migrate legacy store: move media: %w", err)
+		}
+	}
+
+	// Remove old LOCK file (it will be recreated per-account)
+	_ = os.Remove(filepath.Join(baseDir, "LOCK"))
+
+	fmt.Fprintf(os.Stderr, "Migrated legacy store to account \"default\".\n")
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateAccountName(t *testing.T) {
+	valid := []string{"default", "work", "personal", "my-account", "account.2", "Account_1"}
+	for _, name := range valid {
+		if err := ValidateAccountName(name); err != nil {
+			t.Errorf("ValidateAccountName(%q) = %v, want nil", name, err)
+		}
+	}
+
+	invalid := []string{"", "-starts-with-dash", ".dot", "../traversal", "has space", "has/slash", "a\x00b"}
+	for _, name := range invalid {
+		if err := ValidateAccountName(name); err == nil {
+			t.Errorf("ValidateAccountName(%q) = nil, want error", name)
+		}
+	}
+
+	// 65 chars
+	long := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	if err := ValidateAccountName(long); err == nil {
+		t.Error("ValidateAccountName(65 chars) = nil, want error")
+	}
+}
+
+func TestResolveAccount(t *testing.T) {
+	dir := t.TempDir()
+
+	// No flag, no env, no file → "default"
+	name, err := ResolveAccount(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "default" {
+		t.Errorf("got %q, want %q", name, "default")
+	}
+
+	// Write default_account file
+	if err := WriteDefaultAccount(dir, "work"); err != nil {
+		t.Fatal(err)
+	}
+	name, err = ResolveAccount(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "work" {
+		t.Errorf("got %q, want %q", name, "work")
+	}
+
+	// Flag overrides file
+	name, err = ResolveAccount(dir, "personal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "personal" {
+		t.Errorf("got %q, want %q", name, "personal")
+	}
+
+	// Env overrides file (when no flag)
+	t.Setenv("WACLI_ACCOUNT", "env-acct")
+	name, err = ResolveAccount(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "env-acct" {
+		t.Errorf("got %q, want %q", name, "env-acct")
+	}
+}
+
+func TestListAccounts(t *testing.T) {
+	dir := t.TempDir()
+
+	// No accounts dir → empty
+	accounts, err := ListAccounts(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(accounts) != 0 {
+		t.Errorf("got %v, want empty", accounts)
+	}
+
+	// Create some accounts
+	for _, name := range []string{"default", "work", "personal"} {
+		if err := os.MkdirAll(filepath.Join(dir, "accounts", name), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	accounts, err = ListAccounts(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(accounts) != 3 {
+		t.Errorf("got %d accounts, want 3", len(accounts))
+	}
+}
+
+func TestMaybeMigrateLegacyStore(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create legacy layout
+	os.WriteFile(filepath.Join(dir, "session.db"), []byte("session"), 0600)
+	os.WriteFile(filepath.Join(dir, "wacli.db"), []byte("index"), 0600)
+	os.MkdirAll(filepath.Join(dir, "media"), 0700)
+	os.WriteFile(filepath.Join(dir, "media", "test.jpg"), []byte("img"), 0600)
+
+	if err := MaybeMigrateLegacyStore(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify files moved
+	target := AccountDir(dir, "default")
+	if b, err := os.ReadFile(filepath.Join(target, "session.db")); err != nil || string(b) != "session" {
+		t.Error("session.db not migrated correctly")
+	}
+	if b, err := os.ReadFile(filepath.Join(target, "wacli.db")); err != nil || string(b) != "index" {
+		t.Error("wacli.db not migrated correctly")
+	}
+	if b, err := os.ReadFile(filepath.Join(target, "media", "test.jpg")); err != nil || string(b) != "img" {
+		t.Error("media not migrated correctly")
+	}
+
+	// Old files should be gone
+	if _, err := os.Stat(filepath.Join(dir, "session.db")); !os.IsNotExist(err) {
+		t.Error("old session.db still exists")
+	}
+
+	// Second call should be a no-op
+	if err := MaybeMigrateLegacyStore(dir); err != nil {
+		t.Fatal("second migration should be no-op:", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `--account` / `-a` global flag and `WACLI_ACCOUNT` env var to select which WhatsApp account to use
- Each account stored in `~/.wacli/accounts/<name>/` with isolated session, database, lock, and media
- New `wacli accounts` command: `list`, `default [name]`, `remove <name> --force`
- Auto-migrate legacy single-account layout to `accounts/default/` on first run
- Account name validation to prevent path traversal
- Per-account file locking enables concurrent use of different accounts

## Usage

```bash
# Auth a second account
wacli -a work auth

# All commands work with -a
wacli -a work messages search "hello"

# Manage accounts
wacli accounts list
wacli accounts default work
```

## Backward compatibility

Existing users are seamlessly migrated: on first run, if `session.db` is found in the root store dir, all files are moved to `accounts/default/`. Everything works as before without `-a`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Unit tests for account name validation, resolution, listing, and legacy migration
- [x] Manual testing: authenticated two accounts on a separate machine via `-a`