### PR TITLE
fix(doctor): surface lock-owned paired sessions

### DIFF
--- a/cmd/wacli/doctor.go
+++ b/cmd/wacli/doctor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 
@@ -13,6 +14,20 @@ import (
 	"github.com/steipete/wacli/internal/lock"
 	"github.com/steipete/wacli/internal/out"
 )
+
+func parseLockOwnerPID(lockInfo string) int {
+	for _, line := range strings.Split(lockInfo, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "pid=") {
+			continue
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, "pid=")))
+		if err == nil && pid > 0 {
+			return pid
+		}
+	}
+	return 0
+}
 
 func newDoctorCmd(flags *rootFlags) *cobra.Command {
 	var connect bool
@@ -58,22 +73,34 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				}
 			}
 
+			connectionState := "disconnected"
+			lockOwnerPID := parseLockOwnerPID(lockInfo)
+			if connected {
+				connectionState = "connected"
+			} else if authed && lockHeld && !connect {
+				connectionState = "locked_by_other_process"
+			}
+
 			type report struct {
-				StoreDir   string `json:"store_dir"`
-				LockHeld   bool   `json:"lock_held"`
-				LockInfo   string `json:"lock_info,omitempty"`
-				Authed     bool   `json:"authenticated"`
-				Connected  bool   `json:"connected"`
-				FTSEnabled bool   `json:"fts_enabled"`
+				StoreDir        string `json:"store_dir"`
+				LockHeld        bool   `json:"lock_held"`
+				LockInfo        string `json:"lock_info,omitempty"`
+				LockOwnerPID    int    `json:"lock_owner_pid,omitempty"`
+				Authed          bool   `json:"authenticated"`
+				Connected       bool   `json:"connected"`
+				ConnectionState string `json:"connection_state"`
+				FTSEnabled      bool   `json:"fts_enabled"`
 			}
 
 			rep := report{
-				StoreDir:   storeDir,
-				LockHeld:   lockHeld,
-				LockInfo:   lockInfo,
-				Authed:     authed,
-				Connected:  connected,
-				FTSEnabled: a.DB().HasFTS(),
+				StoreDir:        storeDir,
+				LockHeld:        lockHeld,
+				LockInfo:        lockInfo,
+				LockOwnerPID:    lockOwnerPID,
+				Authed:          authed,
+				Connected:       connected,
+				ConnectionState: connectionState,
+				FTSEnabled:      a.DB().HasFTS(),
 			}
 
 			if flags.asJSON {
@@ -86,8 +113,12 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			if rep.LockHeld && rep.LockInfo != "" {
 				fmt.Fprintf(w, "LOCK_INFO\t%s\n", rep.LockInfo)
 			}
+			if rep.LockOwnerPID > 0 {
+				fmt.Fprintf(w, "LOCK_OWNER_PID\t%d\n", rep.LockOwnerPID)
+			}
 			fmt.Fprintf(w, "AUTHENTICATED\t%v\n", rep.Authed)
 			fmt.Fprintf(w, "CONNECTED\t%v\n", rep.Connected)
+			fmt.Fprintf(w, "CONNECTION_STATE\t%s\n", rep.ConnectionState)
 			fmt.Fprintf(w, "FTS5\t%v\n", rep.FTSEnabled)
 			_ = w.Flush()
 

--- a/cmd/wacli/doctor_test.go
+++ b/cmd/wacli/doctor_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+func TestParseLockOwnerPID(t *testing.T) {
+	t.Run("extracts pid line", func(t *testing.T) {
+		lockInfo := "pid=50394\nacquired_at=2026-04-05T12:30:11.568554+08:00"
+		if got := parseLockOwnerPID(lockInfo); got != 50394 {
+			t.Fatalf("parseLockOwnerPID() = %d, want 50394", got)
+		}
+	})
+
+	t.Run("ignores missing pid", func(t *testing.T) {
+		if got := parseLockOwnerPID("acquired_at=2026-04-05T12:30:11.568554+08:00"); got != 0 {
+			t.Fatalf("parseLockOwnerPID() = %d, want 0", got)
+		}
+	})
+
+	t.Run("ignores invalid pid", func(t *testing.T) {
+		if got := parseLockOwnerPID("pid=abc"); got != 0 {
+			t.Fatalf("parseLockOwnerPID() = %d, want 0", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`wacli doctor` currently reports `authenticated=true` and `connected=false` when another long-lived `wacli sync --follow` process already owns the store lock.

That makes the paired-but-owned state look like a plain disconnect, even though the real situation is “this process cannot verify connectivity because another process owns the session.”

This PR keeps `connected` backward-compatible and adds explicit lock-owner reporting:

- `lock_owner_pid`
- `connection_state`

When the store is paired and locked by another process, `connection_state` now reports `locked_by_other_process` instead of silently looking like an ordinary disconnected state.

## Why

A long-lived sync owner is the normal healthy shape for `wacli` live sync. In that state, `doctor` should at least surface that another process owns the paired session instead of only emitting `connected=false`.

## Validation

- `go test ./cmd/wacli/...`
