### PR TITLE
fix: security audit issues #60, #56, #62

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/steipete/wacli/internal/store"
@@ -55,9 +56,11 @@ type Options struct {
 }
 
 type App struct {
-	opts Options
-	wa   WAClient
-	db   *store.DB
+	opts     Options
+	wa       WAClient
+	db       *store.DB
+	waOnce   sync.Once
+	waErr    error
 }
 
 func New(opts Options) (*App, error) {
@@ -79,19 +82,18 @@ func New(opts Options) (*App, error) {
 }
 
 func (a *App) OpenWA() error {
-	if a.wa != nil {
-		return nil
-	}
-	sessionPath := filepath.Join(a.opts.StoreDir, "session.db")
-	cli, err := wa.New(wa.Options{
-		StorePath: sessionPath,
+	a.waOnce.Do(func() {
+		sessionPath := filepath.Join(a.opts.StoreDir, "session.db")
+		cli, err := wa.New(wa.Options{
+			StorePath: sessionPath,
+		})
+		if err != nil {
+			a.waErr = err
+			return
+		}
+		a.wa = cli
 	})
-	if err != nil {
-		return err
-	}
-
-	a.wa = cli
-	return nil
+	return a.waErr
 }
 
 func (a *App) Close() {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,8 +1,35 @@
 package app
 
 import (
+	"sync"
 	"testing"
 )
+
+func TestOpenWARaceCondition(t *testing.T) {
+	a := newTestApp(t)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 10)
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = a.OpenWA()
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: unexpected error: %v", i, err)
+		}
+	}
+
+	wa := a.WA()
+	if wa == nil {
+		t.Fatal("expected WA client to be initialized")
+	}
+}
 
 func newTestApp(t *testing.T) *App {
 	t.Helper()

--- a/internal/pathutil/sanitize.go
+++ b/internal/pathutil/sanitize.go
@@ -3,6 +3,7 @@ package pathutil
 import (
 	"path/filepath"
 	"strings"
+	"unicode"
 )
 
 var replacer = strings.NewReplacer(
@@ -23,9 +24,19 @@ func SanitizeSegment(seg string) string {
 		return "unknown"
 	}
 	seg = replacer.Replace(seg)
+	seg = stripControlChars(seg)
 	seg = strings.ReplaceAll(seg, "..", "_")
 	seg = strings.ReplaceAll(seg, string(filepath.Separator), "_")
 	return seg
+}
+
+func stripControlChars(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
 }
 
 func SanitizeFilename(name string) string {
@@ -34,6 +45,7 @@ func SanitizeFilename(name string) string {
 		return "file"
 	}
 	name = replacer.Replace(name)
+	name = stripControlChars(name)
 	name = strings.ReplaceAll(name, "..", "_")
 	name = strings.ReplaceAll(name, string(filepath.Separator), "_")
 	return name

--- a/internal/pathutil/sanitize_test.go
+++ b/internal/pathutil/sanitize_test.go
@@ -25,3 +25,28 @@ func TestSanitizeFilename(t *testing.T) {
 		t.Fatalf("expected a_b, got %q", got)
 	}
 }
+
+func TestSanitizeStripsNullByte(t *testing.T) {
+	if got := SanitizeSegment("foo" + string(rune(0)) + "bar"); got != "foobar" {
+		t.Fatalf("expected foobar, got %q", got)
+	}
+}
+
+func TestSanitizeStripsTab(t *testing.T) {
+	if got := SanitizeSegment("hello\tworld"); got != "helloworld" {
+		t.Fatalf("expected helloworld, got %q", got)
+	}
+}
+
+func TestSanitizeStripsControlChars(t *testing.T) {
+	input := "a" + string(rune(1)) + "b" + string(rune(31)) + "c" + string(rune(127)) + "d"
+	if got := SanitizeSegment(input); got != "abcd" {
+		t.Fatalf("expected abcd, got %q", got)
+	}
+}
+
+func TestSanitizeFilenameStripsControlChars(t *testing.T) {
+	if got := SanitizeFilename("file" + string(rune(0)) + "name"); got != "filename" {
+		t.Fatalf("expected filename, got %q", got)
+	}
+}

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -35,8 +35,8 @@ func (d *DB) searchLIKE(p SearchMessagesParams) ([]Message, error) {
 		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
-		WHERE (LOWER(m.text) LIKE LOWER(?) OR LOWER(m.display_text) LIKE LOWER(?) OR LOWER(m.media_caption) LIKE LOWER(?) OR LOWER(m.filename) LIKE LOWER(?) OR LOWER(COALESCE(m.chat_name,'')) LIKE LOWER(?) OR LOWER(COALESCE(m.sender_name,'')) LIKE LOWER(?) OR LOWER(COALESCE(c.name,'')) LIKE LOWER(?))`
-	needle := "%" + p.Query + "%"
+		WHERE (LOWER(m.text) LIKE LOWER(?) ESCAPE '\' OR LOWER(m.display_text) LIKE LOWER(?) ESCAPE '\' OR LOWER(m.media_caption) LIKE LOWER(?) ESCAPE '\' OR LOWER(m.filename) LIKE LOWER(?) ESCAPE '\' OR LOWER(COALESCE(m.chat_name,'')) LIKE LOWER(?) ESCAPE '\' OR LOWER(COALESCE(m.sender_name,'')) LIKE LOWER(?) ESCAPE '\' OR LOWER(COALESCE(c.name,'')) LIKE LOWER(?) ESCAPE '\')`
+	needle := "%" + escapeLike(p.Query) + "%"
 	args := []interface{}{needle, needle, needle, needle, needle, needle, needle}
 	query, args = applyMessageFilters(query, args, p)
 	query += " ORDER BY m.ts DESC LIMIT ?"
@@ -57,6 +57,13 @@ func (d *DB) searchFTS(p SearchMessagesParams) ([]Message, error) {
 	query += " ORDER BY bm25(messages_fts) LIMIT ?"
 	args = append(args, p.Limit)
 	return d.scanMessages(query, args...)
+}
+
+func escapeLike(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "%", "\\%")
+	s = strings.ReplaceAll(s, "_", "\\_")
+	return s
 }
 
 func applyMessageFilters(query string, args []interface{}, p SearchMessagesParams) (string, []interface{}) {

--- a/internal/store/search_nonfts_test.go
+++ b/internal/store/search_nonfts_test.go
@@ -7,6 +7,64 @@ import (
 	"time"
 )
 
+func TestEscapeLike(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"hello", "hello"},
+		{"100%", "100\\%"},
+		{"_foo", "\\_foo"},
+		{"a_b%", "a\\_b\\%"},
+		{"back\\slash", "back\\\\slash"},
+	}
+	for _, tt := range tests {
+		got := escapeLike(tt.in)
+		if got != tt.want {
+			t.Errorf("escapeLike(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestSearchLIKEEscapesWildcards(t *testing.T) {
+	db := openTestDB(t)
+
+	chat := "wild@s.whatsapp.net"
+	if err := db.UpsertChat(chat, "dm", "Bob", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+
+	msgs := []struct {
+		id, text string
+	}{
+		{"m1", "100% battery"},
+		{"m2", "100x battery"},
+		{"m3", "foo_bar"},
+		{"m4", "fooxbar"},
+	}
+	for _, m := range msgs {
+		if err := db.UpsertMessage(UpsertMessageParams{
+			ChatJID: chat, MsgID: m.id, Text: m.text,
+			Timestamp: time.Now(),
+		}); err != nil {
+			t.Fatalf("UpsertMessage %s: %v", m.id, err)
+		}
+	}
+
+	ms, err := db.SearchMessages(SearchMessagesParams{Query: "100%", Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchMessages: %v", err)
+	}
+	if len(ms) != 1 || ms[0].MsgID != "m1" {
+		t.Fatalf("expected exactly m1, got %d results: %+v", len(ms), ms)
+	}
+
+	ms, err = db.SearchMessages(SearchMessagesParams{Query: "foo_bar", Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchMessages: %v", err)
+	}
+	if len(ms) != 1 || ms[0].MsgID != "m3" {
+		t.Fatalf("expected exactly m3, got %d results: %+v", len(ms), ms)
+	}
+}
+
 func TestSearchMessagesUsesLIKEWhenFTSDisabled(t *testing.T) {
 	db := openTestDB(t)
 	if db.HasFTS() {


### PR DESCRIPTION
## Summary

Fixes 3 open issues from the security audit.

### #60 — Strip control characters in path sanitization
- Add `stripControlChars()` using `strings.Map` + `unicode.IsControl`
- Applied in both `SanitizeSegment` and `SanitizeFilename`
- Null bytes, tabs, and other control chars are now removed

### #56 — Escape LIKE wildcards in search queries
- Add `escapeLike()` helper that escapes backslash, percent, and underscore
- Add `ESCAPE` clause to all 7 LIKE predicates in searchLIKE
- Searching for `100%` or `foo_bar` now matches literally

### #62 — Fix race condition in OpenWA
- Replace check-then-set with `sync.Once`
- Add `waOnce` and `waErr` fields to `App`
- Concurrent calls to `OpenWA()` no longer race

## Testing

- All pathutil tests pass (4 new test cases)
- Store search tests pass (new LIKE escaping integration test)
- App race test passes with `-race` flag (concurrent OpenWA goroutines)
- Pre-existing auth/connect test failures are unrelated

Fixes #60
Fixes #56
Fixes #62
