### PR TITLE
Feature/history backfill cli

### DIFF
--- a/cmd/wacli/history.go
+++ b/cmd/wacli/history.go
@@ -5,20 +5,186 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
+	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/steipete/wacli/internal/app"
 	"github.com/steipete/wacli/internal/out"
+	"github.com/steipete/wacli/internal/store"
 )
 
 func newHistoryCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "history",
-		Short: "History backfill (best-effort; requires prior auth)",
+		Short: "Archive coverage and history backfill",
 	}
+	cmd.AddCommand(newHistoryCoverageCmd(flags))
+	cmd.AddCommand(newHistoryFillCmd(flags))
 	cmd.AddCommand(newHistoryBackfillCmd(flags))
+	return cmd
+}
+
+func newHistoryCoverageCmd(flags *rootFlags) *cobra.Command {
+	var query string
+	var kind string
+	var limit int
+	var includeBlocked bool
+	var onlyActionable bool
+
+	cmd := &cobra.Command{
+		Use:   "coverage",
+		Short: "Show local archive coverage and backfill state",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, false, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			coverage, err := a.ListBackfillCoverage(app.BackfillFillOptions{
+				Query:          query,
+				Kind:           kind,
+				LimitChats:     limit,
+				IncludeBlocked: includeBlocked || !onlyActionable,
+				OnlyActionable: onlyActionable,
+			})
+			if err != nil {
+				return err
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{"coverage": coverage})
+			}
+
+			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "CHAT\tKIND\tLAST\tMESSAGES\tOLDEST\tNEWEST\tSTATUS\tDETAIL")
+			for _, c := range coverage {
+				name := c.Name
+				if name == "" {
+					name = c.ChatJID
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\n",
+					truncate(name, 28),
+					c.Kind,
+					formatMaybeTime(c.LastMessageTS),
+					c.MessageCount,
+					formatMaybeTime(c.OldestTS),
+					formatMaybeTime(c.NewestTS),
+					c.Status,
+					truncate(historyCoverageDetail(c), 36),
+				)
+			}
+			_ = w.Flush()
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&query, "query", "", "filter chats by local name or JID")
+	cmd.Flags().StringVar(&kind, "kind", "", "chat kind filter (dm|group|broadcast|unknown)")
+	cmd.Flags().IntVar(&limit, "limit", 100, "limit rows")
+	cmd.Flags().BoolVar(&includeBlocked, "include-blocked", false, "include blocked chats in the output")
+	cmd.Flags().BoolVar(&onlyActionable, "only-actionable", false, "show only chats that can be worked on now")
+	return cmd
+}
+
+func newHistoryFillCmd(flags *rootFlags) *cobra.Command {
+	var chats []string
+	var query string
+	var kind string
+	var all bool
+	var resume bool
+	var dryRun bool
+	var retryStalled bool
+	var limitChats int
+	var requestsPerChat int
+	var count int
+	var wait time.Duration
+	var idleExit time.Duration
+
+	cmd := &cobra.Command{
+		Use:   "fill",
+		Short: "Backfill older history across many chats",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fillOpts := app.BackfillFillOptions{
+				ChatJIDs:        chats,
+				Query:           query,
+				Kind:            kind,
+				LimitChats:      limitChats,
+				RequestsPerChat: requestsPerChat,
+				Count:           count,
+				WaitPerRequest:  wait,
+				IdleExit:        idleExit,
+				RetryStalled:    retryStalled,
+				ResumeOnly:      resume,
+				ResetInProgress: true,
+			}
+
+			if dryRun {
+				ctx, cancel := withTimeout(context.Background(), flags)
+				defer cancel()
+
+				a, lk, err := newApp(ctx, flags, false, false)
+				if err != nil {
+					return err
+				}
+				defer closeApp(a, lk)
+
+				plan, err := a.PlanFillHistory(fillOpts)
+				if err != nil {
+					return err
+				}
+				if flags.asJSON {
+					return out.WriteJSON(os.Stdout, plan)
+				}
+
+				fmt.Fprintf(os.Stdout, "Selected %d chats for fill.\n", plan.Selected)
+				printHistoryFillChats(plan.Chats)
+				return nil
+			}
+
+			_ = all
+			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			res, err := a.FillHistory(ctx, fillOpts)
+			if err != nil {
+				return err
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, res)
+			}
+
+			fmt.Fprintf(os.Stdout, "Fill complete. Attempted %d chats, added %d messages.\n", res.Attempted, res.MessagesAdded)
+			printHistoryFillChats(res.Chats)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&chats, "chat", nil, "chat JID to fill (repeatable)")
+	cmd.Flags().StringVar(&query, "query", "", "filter chats by local name or JID")
+	cmd.Flags().StringVar(&kind, "kind", "", "chat kind filter (dm|group|broadcast|unknown)")
+	cmd.Flags().BoolVar(&all, "all", false, "consider all matching chats (default when no selectors are set)")
+	cmd.Flags().BoolVar(&resume, "resume", false, "resume a previous fill run using persisted state")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show which chats would be selected without connecting")
+	cmd.Flags().BoolVar(&retryStalled, "retry-stalled", false, "include chats currently marked stalled")
+	cmd.Flags().IntVar(&limitChats, "limit-chats", 100, "maximum chats to consider")
+	cmd.Flags().IntVar(&requestsPerChat, "requests-per-chat", 3, "max on-demand requests per chat")
+	cmd.Flags().IntVar(&count, "count", 50, "messages to request per on-demand sync")
+	cmd.Flags().DurationVar(&wait, "wait", 60*time.Second, "time to wait for each on-demand response")
+	cmd.Flags().DurationVar(&idleExit, "idle-exit", 5*time.Second, "exit after being idle once all requests finish")
 	return cmd
 }
 
@@ -31,7 +197,7 @@ func newHistoryBackfillCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "backfill",
-		Short: "Request older messages for a chat from your primary device (on-demand history sync)",
+		Short: "Request older messages for one chat from your primary device",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if chat == "" {
 				return fmt.Errorf("--chat is required")
@@ -78,4 +244,61 @@ func newHistoryBackfillCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().DurationVar(&wait, "wait", 60*time.Second, "time to wait for an on-demand response per request")
 	cmd.Flags().DurationVar(&idleExit, "idle-exit", 5*time.Second, "exit after being idle (after backfill requests)")
 	return cmd
+}
+
+func printHistoryFillChats(chats []app.BackfillFillChatResult) {
+	if len(chats) == 0 {
+		fmt.Fprintln(os.Stdout, "No chats selected.")
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "CHAT\tSTATUS\tREQUESTS\tADDED\tDETAIL")
+	for _, chat := range chats {
+		name := chat.Name
+		if name == "" {
+			name = chat.ChatJID
+		}
+		fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%s\n",
+			truncate(name, 28),
+			chat.Status,
+			chat.RequestsSent,
+			chat.MessagesAdded,
+			truncate(historyFillDetail(chat), 40),
+		)
+	}
+	_ = w.Flush()
+}
+
+func historyCoverageDetail(c store.ChatCoverage) string {
+	if c.BlockedReason != "" {
+		return c.BlockedReason
+	}
+	if c.LastError != "" {
+		return c.LastError
+	}
+	if !c.LastBackfillAt.IsZero() {
+		return "last backfill " + c.LastBackfillAt.Local().Format("2006-01-02")
+	}
+	return ""
+}
+
+func historyFillDetail(chat app.BackfillFillChatResult) string {
+	parts := make([]string, 0, 3)
+	if chat.BlockedReason != "" {
+		parts = append(parts, chat.BlockedReason)
+	}
+	if chat.LastError != "" {
+		parts = append(parts, chat.LastError)
+	}
+	if chat.ReachedStart {
+		parts = append(parts, "reached start")
+	}
+	return strings.Join(parts, "; ")
+}
+
+func formatMaybeTime(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return t.Local().Format("2006-01-02")
 }

--- a/internal/app/backfill.go
+++ b/internal/app/backfill.go
@@ -3,15 +3,22 @@ package app
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/steipete/wacli/internal/store"
 	"go.mau.fi/whatsmeow/proto/waHistorySync"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
+)
+
+var (
+	errNoLocalAnchor = errors.New("no local anchor")
+	errBackfillWait  = errors.New("timed out waiting for on-demand history sync response")
 )
 
 type BackfillOptions struct {
@@ -30,10 +37,67 @@ type BackfillResult struct {
 	MessagesSynced int64
 }
 
+type BackfillFillOptions struct {
+	ChatJIDs        []string
+	Query           string
+	Kind            string
+	LimitChats      int
+	RequestsPerChat int
+	Count           int
+	WaitPerRequest  time.Duration
+	IdleExit        time.Duration
+	RetryStalled    bool
+	IncludeBlocked  bool
+	OnlyActionable  bool
+	ResumeOnly      bool
+	ResetInProgress bool
+}
+
+type BackfillFillChatResult struct {
+	ChatJID       string `json:"chat_jid"`
+	Name          string `json:"name,omitempty"`
+	Kind          string `json:"kind,omitempty"`
+	Status        string `json:"status"`
+	BlockedReason string `json:"blocked_reason,omitempty"`
+	RequestsSent  int    `json:"requests_sent"`
+	ResponsesSeen int    `json:"responses_seen"`
+	MessagesAdded int64  `json:"messages_added"`
+	ReachedStart  bool   `json:"reached_start"`
+	LastError     string `json:"last_error,omitempty"`
+}
+
+type BackfillFillResult struct {
+	Selected       int                      `json:"selected"`
+	Attempted      int                      `json:"attempted"`
+	Blocked        int                      `json:"blocked"`
+	Completed      int                      `json:"completed"`
+	Stalled        int                      `json:"stalled"`
+	MessagesAdded  int64                    `json:"messages_added"`
+	Chats          []BackfillFillChatResult `json:"chats"`
+	Coverage       []store.ChatCoverage     `json:"coverage,omitempty"`
+	MessagesSynced int64                    `json:"messages_synced,omitempty"`
+}
+
 type onDemandResponse struct {
+	chatJID       string
 	conversations int
 	messages      int
 	endType       waHistorySync.Conversation_EndOfHistoryTransferType
+}
+
+type backfillAttempt struct {
+	response      onDemandResponse
+	progressed    bool
+	messagesAdded int64
+	reachedStart  bool
+}
+
+type backfillSession struct {
+	a *App
+
+	mu      sync.Mutex
+	waitFor string
+	waitCh  chan onDemandResponse
 }
 
 func (a *App) BackfillHistory(ctx context.Context, opts BackfillOptions) (BackfillResult, error) {
@@ -63,115 +127,37 @@ func (a *App) BackfillHistory(ctx context.Context, opts BackfillOptions) (Backfi
 	if err := a.EnsureAuthed(); err != nil {
 		return BackfillResult{}, err
 	}
-	if err := a.OpenWA(); err != nil {
-		return BackfillResult{}, err
-	}
 
 	beforeCount, _ := a.db.CountMessages()
+	session := &backfillSession{a: a}
+	var chatResult BackfillFillChatResult
+	var syncRes SyncResult
 
-	var mu sync.Mutex
-	var waitCh chan onDemandResponse
-	handlerID := a.wa.AddEventHandler(func(evt interface{}) {
-		hs, ok := evt.(*events.HistorySync)
-		if !ok || hs == nil || hs.Data == nil {
-			return
-		}
-		if hs.Data.GetSyncType() != waHistorySync.HistorySync_ON_DEMAND {
-			return
-		}
-
-		for _, conv := range hs.Data.GetConversations() {
-			if strings.TrimSpace(conv.GetID()) != chatStr {
-				continue
-			}
-			mu.Lock()
-			ch := waitCh
-			mu.Unlock()
-			if ch == nil {
-				return
-			}
-			resp := onDemandResponse{
-				conversations: len(hs.Data.GetConversations()),
-				messages:      len(conv.GetMessages()),
-				endType:       conv.GetEndOfHistoryTransferType(),
-			}
-			select {
-			case ch <- resp:
-			default:
-			}
-			return
-		}
-	})
+	handlerID := a.wa.AddEventHandler(session.handleEvent)
 	defer a.wa.RemoveEventHandler(handlerID)
 
-	var requestsSent int
-	var responsesSeen int
-
-	syncRes, err := a.Sync(ctx, SyncOptions{
+	syncRes, err = a.Sync(ctx, SyncOptions{
 		Mode:     SyncModeOnce,
 		AllowQR:  false,
 		IdleExit: opts.IdleExit,
 		AfterConnect: func(ctx context.Context) error {
-			for i := 0; i < opts.Requests; i++ {
-				oldest, err := a.db.GetOldestMessageInfo(chatStr)
-				if err != nil {
-					if err == sql.ErrNoRows {
-						return fmt.Errorf("no messages for %s in local DB; run `wacli sync` first", chatStr)
-					}
-					return err
-				}
-
-				reqInfo := types.MessageInfo{
-					MessageSource: types.MessageSource{
-						Chat:     chat,
-						IsFromMe: oldest.FromMe,
-					},
-					ID:        types.MessageID(oldest.MsgID),
-					Timestamp: oldest.Timestamp,
-				}
-
-				ch := make(chan onDemandResponse, 4)
-				mu.Lock()
-				waitCh = ch
-				mu.Unlock()
-
-				requestsSent++
-				fmt.Fprintf(os.Stderr, "Requesting %d older messages for %s...\n", opts.Count, chatStr)
-				if _, err := a.wa.RequestHistorySyncOnDemand(ctx, reqInfo, opts.Count); err != nil {
-					return err
-				}
-
-				var resp onDemandResponse
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case resp = <-ch:
-					responsesSeen++
-				case <-time.After(opts.WaitPerRequest):
-					return fmt.Errorf("timed out waiting for on-demand history sync response")
-				}
-
-				mu.Lock()
-				if waitCh == ch {
-					waitCh = nil
-				}
-				mu.Unlock()
-
-				fmt.Fprintf(os.Stderr, "On-demand history sync: %d conversations, %d messages.\n", resp.conversations, resp.messages)
-
-				newOldest, err := a.db.GetOldestMessageInfo(chatStr)
-				if err == nil && newOldest.MsgID == oldest.MsgID {
-					fmt.Fprintln(os.Stderr, "No older messages were added (stopping).")
-					return nil
-				}
-				if resp.messages <= 0 {
-					fmt.Fprintln(os.Stderr, "No messages returned (stopping).")
-					return nil
-				}
-				if resp.endType == waHistorySync.Conversation_COMPLETE_AND_NO_MORE_MESSAGE_REMAIN_ON_PRIMARY {
-					fmt.Fprintln(os.Stderr, "Reached start of chat history (stopping).")
-					return nil
-				}
+			coverage, err := a.lookupCoverage(chatStr)
+			if err != nil {
+				return err
+			}
+			chatResult, err = a.backfillChat(ctx, session, coverage, BackfillFillOptions{
+				RequestsPerChat: opts.Requests,
+				Count:           opts.Count,
+				WaitPerRequest:  opts.WaitPerRequest,
+			})
+			if err != nil {
+				return err
+			}
+			if chatResult.Status == store.BackfillStatusBlocked && chatResult.BlockedReason == store.BackfillBlockedNoLocalAnchor {
+				return fmt.Errorf("no messages for %s in local DB; run `wacli sync` first", chatStr)
+			}
+			if chatResult.Status == store.BackfillStatusStalled && chatResult.LastError != "" {
+				return fmt.Errorf("backfill stopped for %s: %s", chatStr, chatResult.LastError)
 			}
 			return nil
 		},
@@ -181,12 +167,451 @@ func (a *App) BackfillHistory(ctx context.Context, opts BackfillOptions) (Backfi
 	}
 
 	afterCount, _ := a.db.CountMessages()
-
 	return BackfillResult{
 		ChatJID:        chatStr,
-		RequestsSent:   requestsSent,
-		ResponsesSeen:  responsesSeen,
+		RequestsSent:   chatResult.RequestsSent,
+		ResponsesSeen:  chatResult.ResponsesSeen,
 		MessagesAdded:  afterCount - beforeCount,
 		MessagesSynced: syncRes.MessagesStored,
+	}, nil
+}
+
+func (a *App) ListBackfillCoverage(opts BackfillFillOptions) ([]store.ChatCoverage, error) {
+	params := store.ListChatCoverageParams{
+		Query:          opts.Query,
+		Kind:           opts.Kind,
+		ChatJIDs:       opts.ChatJIDs,
+		Limit:          opts.LimitChats,
+		IncludeBlocked: opts.IncludeBlocked,
+		OnlyActionable: opts.OnlyActionable,
+		OnlyTracked:    opts.ResumeOnly,
+	}
+	return a.db.ListChatCoverage(params)
+}
+
+func (a *App) FillHistory(ctx context.Context, opts BackfillFillOptions) (BackfillFillResult, error) {
+	if opts.Count <= 0 {
+		opts.Count = 50
+	}
+	if opts.RequestsPerChat <= 0 {
+		opts.RequestsPerChat = 3
+	}
+	if opts.WaitPerRequest <= 0 {
+		opts.WaitPerRequest = 60 * time.Second
+	}
+	if opts.IdleExit <= 0 {
+		opts.IdleExit = 5 * time.Second
+	}
+	if opts.LimitChats <= 0 {
+		opts.LimitChats = 1000
+	}
+
+	if err := a.EnsureAuthed(); err != nil {
+		return BackfillFillResult{}, err
+	}
+	if opts.ResetInProgress {
+		if err := a.db.ResetBackfillInProgress(time.Now().UTC()); err != nil {
+			return BackfillFillResult{}, err
+		}
+	}
+
+	coverage, err := a.ListBackfillCoverage(BackfillFillOptions{
+		ChatJIDs:       opts.ChatJIDs,
+		Query:          opts.Query,
+		Kind:           opts.Kind,
+		LimitChats:     opts.LimitChats,
+		IncludeBlocked: true,
+		ResumeOnly:     opts.ResumeOnly,
+	})
+	if err != nil {
+		return BackfillFillResult{}, err
+	}
+
+	selected, precomputed := selectBackfillCandidates(coverage, opts.RetryStalled)
+	for _, chat := range precomputed.Chats {
+		if chat.Status != store.BackfillStatusBlocked || chat.BlockedReason == "" {
+			continue
+		}
+		state, err := a.loadBackfillState(chat.ChatJID)
+		if err != nil {
+			return BackfillFillResult{}, err
+		}
+		state.ChatJID = chat.ChatJID
+		state.Status = store.BackfillStatusBlocked
+		state.BlockedReason = chat.BlockedReason
+		state.LastError = chat.LastError
+		state.UpdatedAt = time.Now().UTC()
+		if err := a.db.PutBackfillState(state); err != nil {
+			return BackfillFillResult{}, err
+		}
+	}
+	result := BackfillFillResult{
+		Selected: len(selected),
+		Blocked:  precomputed.Blocked,
+		Chats:    precomputed.Chats,
+	}
+	beforeCount, _ := a.db.CountMessages()
+
+	session := &backfillSession{a: a}
+	handlerID := a.wa.AddEventHandler(session.handleEvent)
+	defer a.wa.RemoveEventHandler(handlerID)
+
+	syncRes, err := a.Sync(ctx, SyncOptions{
+		Mode:     SyncModeOnce,
+		AllowQR:  false,
+		IdleExit: opts.IdleExit,
+		AfterConnect: func(ctx context.Context) error {
+			for _, candidate := range selected {
+				chatResult, err := a.backfillChat(ctx, session, candidate, opts)
+				if err != nil {
+					return err
+				}
+				result.Attempted++
+				result.MessagesAdded += chatResult.MessagesAdded
+				result.Chats = append(result.Chats, chatResult)
+				switch chatResult.Status {
+				case store.BackfillStatusBlocked:
+					result.Blocked++
+				case store.BackfillStatusComplete:
+					result.Completed++
+				case store.BackfillStatusStalled:
+					result.Stalled++
+				}
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		return BackfillFillResult{}, err
+	}
+	afterCount, _ := a.db.CountMessages()
+	result.MessagesAdded = afterCount - beforeCount
+	result.MessagesSynced = syncRes.MessagesStored
+	return result, nil
+}
+
+func (a *App) PlanFillHistory(opts BackfillFillOptions) (BackfillFillResult, error) {
+	if opts.LimitChats <= 0 {
+		opts.LimitChats = 1000
+	}
+	coverage, err := a.ListBackfillCoverage(BackfillFillOptions{
+		ChatJIDs:       opts.ChatJIDs,
+		Query:          opts.Query,
+		Kind:           opts.Kind,
+		LimitChats:     opts.LimitChats,
+		IncludeBlocked: true,
+		ResumeOnly:     opts.ResumeOnly,
+	})
+	if err != nil {
+		return BackfillFillResult{}, err
+	}
+	selected, result := selectBackfillCandidates(coverage, opts.RetryStalled)
+	result.Selected = len(selected)
+	result.Coverage = coverage
+	return result, nil
+}
+
+func selectBackfillCandidates(coverage []store.ChatCoverage, retryStalled bool) ([]store.ChatCoverage, BackfillFillResult) {
+	selected := make([]store.ChatCoverage, 0, len(coverage))
+	result := BackfillFillResult{Chats: make([]BackfillFillChatResult, 0)}
+	for _, c := range coverage {
+		switch c.Status {
+		case store.BackfillStatusReady, store.BackfillStatusInProgress:
+			selected = append(selected, c)
+		case store.BackfillStatusStalled:
+			if retryStalled {
+				selected = append(selected, c)
+			}
+		case store.BackfillStatusBlocked:
+			result.Blocked++
+			result.Chats = append(result.Chats, BackfillFillChatResult{
+				ChatJID:       c.ChatJID,
+				Name:          c.Name,
+				Kind:          c.Kind,
+				Status:        c.Status,
+				BlockedReason: c.BlockedReason,
+				LastError:     c.LastError,
+			})
+		}
+	}
+	return selected, result
+}
+
+func (a *App) backfillChat(ctx context.Context, session *backfillSession, coverage store.ChatCoverage, opts BackfillFillOptions) (BackfillFillChatResult, error) {
+	res := BackfillFillChatResult{
+		ChatJID: coverage.ChatJID,
+		Name:    coverage.Name,
+		Kind:    coverage.Kind,
+		Status:  coverage.Status,
+	}
+
+	if coverage.MessageCount <= 0 {
+		state, _ := a.loadBackfillState(coverage.ChatJID)
+		state.ChatJID = coverage.ChatJID
+		state.Status = store.BackfillStatusBlocked
+		state.BlockedReason = store.BackfillBlockedNoLocalAnchor
+		state.LastError = ""
+		state.UpdatedAt = time.Now().UTC()
+		if err := a.db.PutBackfillState(state); err != nil {
+			return res, err
+		}
+		res.Status = store.BackfillStatusBlocked
+		res.BlockedReason = store.BackfillBlockedNoLocalAnchor
+		return res, nil
+	}
+
+	state, err := a.loadBackfillState(coverage.ChatJID)
+	if err != nil {
+		return res, err
+	}
+	state.ChatJID = coverage.ChatJID
+	state.Status = store.BackfillStatusInProgress
+	state.BlockedReason = ""
+	state.LastError = ""
+	state.UpdatedAt = time.Now().UTC()
+	if err := a.db.PutBackfillState(state); err != nil {
+		return res, err
+	}
+
+	for i := 0; i < opts.RequestsPerChat; i++ {
+		attempt, err := session.requestChat(ctx, coverage.ChatJID, opts.Count, opts.WaitPerRequest)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return res, err
+			}
+			if errors.Is(err, errNoLocalAnchor) {
+				state.Status = store.BackfillStatusBlocked
+				state.BlockedReason = store.BackfillBlockedNoLocalAnchor
+				state.LastError = ""
+				state.UpdatedAt = time.Now().UTC()
+				if saveErr := a.db.PutBackfillState(state); saveErr != nil {
+					return res, saveErr
+				}
+				res.Status = state.Status
+				res.BlockedReason = state.BlockedReason
+				return res, nil
+			}
+			state.Status = store.BackfillStatusStalled
+			state.LastBackfillAt = time.Now().UTC()
+			state.LastError = err.Error()
+			state.UpdatedAt = state.LastBackfillAt
+			if saveErr := a.db.PutBackfillState(state); saveErr != nil {
+				return res, saveErr
+			}
+			res.Status = state.Status
+			res.LastError = state.LastError
+			return res, nil
+		}
+
+		now := time.Now().UTC()
+		state.LastBackfillAt = now
+		state.RequestsSentTotal++
+		res.RequestsSent++
+		if attempt.response.messages > 0 || attempt.response.endType != 0 || attempt.response.conversations > 0 {
+			state.ResponsesSeenTotal++
+			res.ResponsesSeen++
+		}
+
+		if attempt.progressed {
+			state.LastSuccessAt = now
+			state.ConsecutiveNoopRequests = 0
+			state.LastError = ""
+			res.MessagesAdded += attempt.messagesAdded
+		} else {
+			state.ConsecutiveNoopRequests++
+			if attempt.response.messages <= 0 {
+				state.LastError = "no messages returned"
+			} else {
+				state.LastError = "no older messages were added"
+			}
+		}
+
+		if attempt.reachedStart {
+			state.Status = store.BackfillStatusComplete
+			state.ReachedStart = true
+			state.BlockedReason = ""
+			state.LastError = ""
+			state.UpdatedAt = now
+			if err := a.db.PutBackfillState(state); err != nil {
+				return res, err
+			}
+			res.Status = state.Status
+			res.ReachedStart = true
+			return res, nil
+		}
+
+		if !attempt.progressed && state.ConsecutiveNoopRequests >= 2 {
+			state.Status = store.BackfillStatusStalled
+			state.UpdatedAt = now
+			if err := a.db.PutBackfillState(state); err != nil {
+				return res, err
+			}
+			res.Status = state.Status
+			res.LastError = state.LastError
+			return res, nil
+		}
+
+		state.UpdatedAt = now
+		if err := a.db.PutBackfillState(state); err != nil {
+			return res, err
+		}
+	}
+
+	state.Status = store.BackfillStatusReady
+	state.BlockedReason = ""
+	state.UpdatedAt = time.Now().UTC()
+	if err := a.db.PutBackfillState(state); err != nil {
+		return res, err
+	}
+	res.Status = state.Status
+	res.LastError = state.LastError
+	return res, nil
+}
+
+func (a *App) loadBackfillState(chatJID string) (store.BackfillState, error) {
+	state, err := a.db.GetBackfillState(chatJID)
+	if err == nil {
+		return state, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.BackfillState{ChatJID: chatJID, Status: store.BackfillStatusReady}, nil
+	}
+	return store.BackfillState{}, err
+}
+
+func (a *App) lookupCoverage(chatJID string) (store.ChatCoverage, error) {
+	coverage, err := a.db.GetChatCoverage(chatJID)
+	if err == nil {
+		return coverage, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.ChatCoverage{
+			ChatJID:       chatJID,
+			Status:        store.BackfillStatusBlocked,
+			BlockedReason: store.BackfillBlockedNoLocalAnchor,
+		}, nil
+	}
+	return store.ChatCoverage{}, err
+}
+
+func (s *backfillSession) handleEvent(evt interface{}) {
+	hs, ok := evt.(*events.HistorySync)
+	if !ok || hs == nil || hs.Data == nil {
+		return
+	}
+	if hs.Data.GetSyncType() != waHistorySync.HistorySync_ON_DEMAND {
+		return
+	}
+
+	s.mu.Lock()
+	waitFor := s.waitFor
+	ch := s.waitCh
+	s.mu.Unlock()
+	if ch == nil || waitFor == "" {
+		return
+	}
+
+	for _, conv := range hs.Data.GetConversations() {
+		chatJID := strings.TrimSpace(conv.GetID())
+		if chatJID == "" || chatJID != waitFor {
+			continue
+		}
+		resp := onDemandResponse{
+			chatJID:       chatJID,
+			conversations: len(hs.Data.GetConversations()),
+			messages:      len(conv.GetMessages()),
+			endType:       conv.GetEndOfHistoryTransferType(),
+		}
+		select {
+		case ch <- resp:
+		default:
+		}
+		return
+	}
+}
+
+func (s *backfillSession) requestChat(ctx context.Context, chatJID string, count int, wait time.Duration) (backfillAttempt, error) {
+	chatStr := strings.TrimSpace(chatJID)
+	if chatStr == "" {
+		return backfillAttempt{}, fmt.Errorf("chat JID is required")
+	}
+	chat, err := types.ParseJID(chatStr)
+	if err != nil {
+		return backfillAttempt{}, fmt.Errorf("parse chat JID: %w", err)
+	}
+
+	beforeCount, err := s.a.db.CountMessagesForChat(chatStr)
+	if err != nil {
+		return backfillAttempt{}, err
+	}
+	oldest, err := s.a.db.GetOldestMessageInfo(chatStr)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return backfillAttempt{}, errNoLocalAnchor
+		}
+		return backfillAttempt{}, err
+	}
+
+	ch := make(chan onDemandResponse, 1)
+	s.mu.Lock()
+	s.waitFor = chatStr
+	s.waitCh = ch
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		if s.waitCh == ch {
+			s.waitFor = ""
+			s.waitCh = nil
+		}
+		s.mu.Unlock()
+	}()
+
+	reqInfo := types.MessageInfo{
+		MessageSource: types.MessageSource{
+			Chat:     chat,
+			IsFromMe: oldest.FromMe,
+		},
+		ID:        types.MessageID(oldest.MsgID),
+		Timestamp: oldest.Timestamp,
+	}
+
+	fmt.Fprintf(os.Stderr, "Requesting %d older messages for %s...\n", count, chatStr)
+	if _, err := s.a.wa.RequestHistorySyncOnDemand(ctx, reqInfo, count); err != nil {
+		return backfillAttempt{}, err
+	}
+
+	var resp onDemandResponse
+	select {
+	case <-ctx.Done():
+		return backfillAttempt{}, ctx.Err()
+	case resp = <-ch:
+	case <-time.After(wait):
+		return backfillAttempt{}, errBackfillWait
+	}
+
+	fmt.Fprintf(os.Stderr, "On-demand history sync for %s: %d conversations, %d messages.\n", chatStr, resp.conversations, resp.messages)
+
+	afterCount, err := s.a.db.CountMessagesForChat(chatStr)
+	if err != nil {
+		return backfillAttempt{}, err
+	}
+	newOldest, err := s.a.db.GetOldestMessageInfo(chatStr)
+	if err != nil {
+		return backfillAttempt{}, err
+	}
+
+	progressed := afterCount > beforeCount || newOldest.MsgID != oldest.MsgID || newOldest.Timestamp.Before(oldest.Timestamp)
+	if !progressed {
+		fmt.Fprintf(os.Stderr, "No older messages were added for %s.\n", chatStr)
+	}
+	if resp.endType == waHistorySync.Conversation_COMPLETE_AND_NO_MORE_MESSAGE_REMAIN_ON_PRIMARY {
+		fmt.Fprintf(os.Stderr, "Reached start of chat history for %s.\n", chatStr)
+	}
+
+	return backfillAttempt{
+		response:      resp,
+		progressed:    progressed,
+		messagesAdded: afterCount - beforeCount,
+		reachedStart:  resp.endType == waHistorySync.Conversation_COMPLETE_AND_NO_MORE_MESSAGE_REMAIN_ON_PRIMARY,
 	}, nil
 }

--- a/internal/app/backfill_test.go
+++ b/internal/app/backfill_test.go
@@ -91,3 +91,189 @@ func storeUpsertMessage(chatJID, id string, ts time.Time, text string) store.Ups
 		Text:       text,
 	}
 }
+
+func TestFillHistoryMarksCompleteAndBlockedChats(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chatReady := types.JID{User: "123", Server: types.DefaultUserServer}
+	chatBlocked := types.JID{User: "456", Server: types.DefaultUserServer}
+	base := time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	if err := a.db.UpsertChat(chatReady.String(), "dm", "Ready", base.Add(2*time.Minute)); err != nil {
+		t.Fatalf("UpsertChat ready: %v", err)
+	}
+	if err := a.db.UpsertChat(chatBlocked.String(), "dm", "Blocked", base.Add(1*time.Minute)); err != nil {
+		t.Fatalf("UpsertChat blocked: %v", err)
+	}
+	if err := a.db.UpsertMessage(storeUpsertMessage(chatReady.String(), "m2", base.Add(2*time.Second), "newer")); err != nil {
+		t.Fatalf("UpsertMessage ready: %v", err)
+	}
+
+	f.onDemandHistory = func(lastKnown types.MessageInfo, count int) *events.HistorySync {
+		older := &waWeb.WebMessageInfo{
+			Key: &waCommon.MessageKey{
+				RemoteJID: proto.String(lastKnown.Chat.String()),
+				FromMe:    proto.Bool(false),
+				ID:        proto.String("m1"),
+			},
+			MessageTimestamp: proto.Uint64(uint64(base.Add(1 * time.Second).Unix())),
+			Message:          &waProto.Message{Conversation: proto.String("older")},
+		}
+		return &events.HistorySync{
+			Data: &waHistorySync.HistorySync{
+				SyncType: waHistorySync.HistorySync_ON_DEMAND.Enum(),
+				Conversations: []*waHistorySync.Conversation{{
+					ID:                       proto.String(lastKnown.Chat.String()),
+					EndOfHistoryTransfer:     proto.Bool(true),
+					EndOfHistoryTransferType: waHistorySync.Conversation_COMPLETE_AND_NO_MORE_MESSAGE_REMAIN_ON_PRIMARY.Enum(),
+					Messages:                 []*waHistorySync.HistorySyncMsg{{Message: older}},
+				}},
+			},
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	res, err := a.FillHistory(ctx, BackfillFillOptions{
+		LimitChats:      10,
+		RequestsPerChat: 1,
+		Count:           50,
+		WaitPerRequest:  time.Second,
+		IdleExit:        200 * time.Millisecond,
+		ResetInProgress: true,
+	})
+	if err != nil {
+		t.Fatalf("FillHistory: %v", err)
+	}
+	if res.Attempted != 1 {
+		t.Fatalf("expected 1 attempted chat, got %d", res.Attempted)
+	}
+	if res.Blocked != 1 {
+		t.Fatalf("expected 1 blocked chat, got %d", res.Blocked)
+	}
+	if res.Completed != 1 {
+		t.Fatalf("expected 1 completed chat, got %d", res.Completed)
+	}
+	if res.MessagesAdded <= 0 {
+		t.Fatalf("expected messages added, got %d", res.MessagesAdded)
+	}
+
+	readyState, err := a.db.GetBackfillState(chatReady.String())
+	if err != nil {
+		t.Fatalf("GetBackfillState ready: %v", err)
+	}
+	if readyState.Status != store.BackfillStatusComplete || !readyState.ReachedStart {
+		t.Fatalf("expected ready chat complete, got %+v", readyState)
+	}
+
+	blockedState, err := a.db.GetBackfillState(chatBlocked.String())
+	if err != nil {
+		t.Fatalf("GetBackfillState blocked: %v", err)
+	}
+	if blockedState.Status != store.BackfillStatusBlocked || blockedState.BlockedReason != store.BackfillBlockedNoLocalAnchor {
+		t.Fatalf("expected blocked chat no_local_anchor, got %+v", blockedState)
+	}
+}
+
+func TestFillHistoryMarksStalledAfterRepeatedNoProgress(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "999", Server: types.DefaultUserServer}
+	base := time.Date(2024, 5, 2, 0, 0, 0, 0, time.UTC)
+
+	if err := a.db.UpsertChat(chat.String(), "dm", "Stalled", base); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := a.db.UpsertMessage(storeUpsertMessage(chat.String(), "m2", base.Add(2*time.Second), "newer")); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	f.onDemandHistory = func(lastKnown types.MessageInfo, count int) *events.HistorySync {
+		return &events.HistorySync{
+			Data: &waHistorySync.HistorySync{
+				SyncType: waHistorySync.HistorySync_ON_DEMAND.Enum(),
+				Conversations: []*waHistorySync.Conversation{{
+					ID:       proto.String(lastKnown.Chat.String()),
+					Messages: nil,
+				}},
+			},
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	res, err := a.FillHistory(ctx, BackfillFillOptions{
+		ChatJIDs:        []string{chat.String()},
+		LimitChats:      10,
+		RequestsPerChat: 2,
+		Count:           50,
+		WaitPerRequest:  time.Second,
+		IdleExit:        200 * time.Millisecond,
+		ResetInProgress: true,
+	})
+	if err != nil {
+		t.Fatalf("FillHistory: %v", err)
+	}
+	if res.Attempted != 1 || res.Stalled != 1 {
+		t.Fatalf("expected one stalled chat, got %+v", res)
+	}
+
+	state, err := a.db.GetBackfillState(chat.String())
+	if err != nil {
+		t.Fatalf("GetBackfillState: %v", err)
+	}
+	if state.Status != store.BackfillStatusStalled {
+		t.Fatalf("expected stalled state, got %+v", state)
+	}
+	if state.ConsecutiveNoopRequests != 2 {
+		t.Fatalf("expected 2 noop requests, got %+v", state)
+	}
+}
+
+func TestPlanFillHistoryResumeOnlyUsesTrackedChats(t *testing.T) {
+	a := newTestApp(t)
+
+	base := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+	chatFresh := "111@s.whatsapp.net"
+	chatTracked := "222@s.whatsapp.net"
+
+	if err := a.db.UpsertChat(chatFresh, "dm", "Fresh", base.Add(2*time.Minute)); err != nil {
+		t.Fatalf("UpsertChat fresh: %v", err)
+	}
+	if err := a.db.UpsertChat(chatTracked, "dm", "Tracked", base.Add(1*time.Minute)); err != nil {
+		t.Fatalf("UpsertChat tracked: %v", err)
+	}
+	if err := a.db.UpsertMessage(storeUpsertMessage(chatFresh, "m1", base.Add(1*time.Second), "fresh")); err != nil {
+		t.Fatalf("UpsertMessage fresh: %v", err)
+	}
+	if err := a.db.UpsertMessage(storeUpsertMessage(chatTracked, "m2", base.Add(2*time.Second), "tracked")); err != nil {
+		t.Fatalf("UpsertMessage tracked: %v", err)
+	}
+	if err := a.db.PutBackfillState(store.BackfillState{
+		ChatJID:   chatTracked,
+		Status:    store.BackfillStatusReady,
+		UpdatedAt: base.Add(3 * time.Minute),
+	}); err != nil {
+		t.Fatalf("PutBackfillState: %v", err)
+	}
+
+	plan, err := a.PlanFillHistory(BackfillFillOptions{
+		LimitChats: 10,
+		ResumeOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("PlanFillHistory: %v", err)
+	}
+	if plan.Selected != 1 {
+		t.Fatalf("expected 1 selected tracked chat, got %+v", plan)
+	}
+	if len(plan.Coverage) != 1 || plan.Coverage[0].ChatJID != chatTracked {
+		t.Fatalf("expected only tracked coverage row, got %+v", plan.Coverage)
+	}
+}

--- a/internal/store/history.go
+++ b/internal/store/history.go
@@ -1,0 +1,348 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	BackfillStatusReady      = "ready"
+	BackfillStatusInProgress = "in_progress"
+	BackfillStatusStalled    = "stalled"
+	BackfillStatusBlocked    = "blocked"
+	BackfillStatusComplete   = "complete"
+
+	BackfillBlockedNoLocalAnchor = "no_local_anchor"
+)
+
+type BackfillState struct {
+	ChatJID                 string
+	Status                  string
+	LastBackfillAt          time.Time
+	LastSuccessAt           time.Time
+	RequestsSentTotal       int
+	ResponsesSeenTotal      int
+	ConsecutiveNoopRequests int
+	ReachedStart            bool
+	BlockedReason           string
+	LastError               string
+	UpdatedAt               time.Time
+}
+
+type ChatCoverage struct {
+	ChatJID        string
+	Kind           string
+	Name           string
+	LastMessageTS  time.Time
+	MessageCount   int64
+	OldestTS       time.Time
+	NewestTS       time.Time
+	HasState       bool
+	Status         string
+	BlockedReason  string
+	ReachedStart   bool
+	LastError      string
+	LastBackfillAt time.Time
+}
+
+type ListChatCoverageParams struct {
+	Query          string
+	Kind           string
+	ChatJIDs       []string
+	Limit          int
+	IncludeBlocked bool
+	OnlyActionable bool
+	OnlyTracked    bool
+}
+
+func (d *DB) PutBackfillState(state BackfillState) error {
+	state.ChatJID = strings.TrimSpace(state.ChatJID)
+	state.Status = strings.TrimSpace(state.Status)
+	state.BlockedReason = strings.TrimSpace(state.BlockedReason)
+	state.LastError = strings.TrimSpace(state.LastError)
+	if state.ChatJID == "" {
+		return fmt.Errorf("chat JID is required")
+	}
+	if state.Status == "" {
+		return fmt.Errorf("status is required")
+	}
+	if state.UpdatedAt.IsZero() {
+		state.UpdatedAt = time.Now().UTC()
+	}
+
+	_, err := d.sql.Exec(`
+		INSERT INTO history_backfill_state(
+			chat_jid,
+			status,
+			last_backfill_at,
+			last_success_at,
+			requests_sent_total,
+			responses_seen_total,
+			consecutive_noop_requests,
+			reached_start,
+			blocked_reason,
+			last_error,
+			updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(chat_jid) DO UPDATE SET
+			status=excluded.status,
+			last_backfill_at=excluded.last_backfill_at,
+			last_success_at=excluded.last_success_at,
+			requests_sent_total=excluded.requests_sent_total,
+			responses_seen_total=excluded.responses_seen_total,
+			consecutive_noop_requests=excluded.consecutive_noop_requests,
+			reached_start=excluded.reached_start,
+			blocked_reason=excluded.blocked_reason,
+			last_error=excluded.last_error,
+			updated_at=excluded.updated_at
+	`,
+		state.ChatJID,
+		state.Status,
+		nullIfZeroUnix(state.LastBackfillAt),
+		nullIfZeroUnix(state.LastSuccessAt),
+		state.RequestsSentTotal,
+		state.ResponsesSeenTotal,
+		state.ConsecutiveNoopRequests,
+		boolToInt(state.ReachedStart),
+		nullIfEmpty(state.BlockedReason),
+		nullIfEmpty(state.LastError),
+		unix(state.UpdatedAt),
+	)
+	return err
+}
+
+func (d *DB) GetBackfillState(chatJID string) (BackfillState, error) {
+	chatJID = strings.TrimSpace(chatJID)
+	if chatJID == "" {
+		return BackfillState{}, fmt.Errorf("chat JID is required")
+	}
+	row := d.sql.QueryRow(`
+		SELECT chat_jid,
+		       status,
+		       COALESCE(last_backfill_at, 0),
+		       COALESCE(last_success_at, 0),
+		       requests_sent_total,
+		       responses_seen_total,
+		       consecutive_noop_requests,
+		       reached_start,
+		       COALESCE(blocked_reason, ''),
+		       COALESCE(last_error, ''),
+		       updated_at
+		FROM history_backfill_state
+		WHERE chat_jid = ?
+	`, chatJID)
+	return scanBackfillState(row)
+}
+
+func (d *DB) ResetBackfillInProgress(now time.Time) error {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	_, err := d.sql.Exec(`
+		UPDATE history_backfill_state
+		SET status = ?,
+		    updated_at = ?
+		WHERE status = ?
+	`, BackfillStatusReady, unix(now), BackfillStatusInProgress)
+	return err
+}
+
+func (d *DB) ListChatCoverage(p ListChatCoverageParams) ([]ChatCoverage, error) {
+	if p.Limit <= 0 {
+		p.Limit = 100
+	}
+
+	query := `
+		SELECT c.jid,
+		       c.kind,
+		       COALESCE(c.name,''),
+		       COALESCE(c.last_message_ts, 0),
+		       COALESCE(ms.message_count, 0),
+		       COALESCE(ms.oldest_ts, 0),
+		       COALESCE(ms.newest_ts, 0),
+		       CASE WHEN h.chat_jid IS NULL THEN 0 ELSE 1 END,
+		       COALESCE(h.status, ''),
+		       COALESCE(h.blocked_reason, ''),
+		       COALESCE(h.reached_start, 0),
+		       COALESCE(h.last_error, ''),
+		       COALESCE(h.last_backfill_at, 0)
+		FROM chats c
+		LEFT JOIN (
+			SELECT chat_jid,
+			       COUNT(1) AS message_count,
+			       MIN(ts) AS oldest_ts,
+			       MAX(ts) AS newest_ts
+			FROM messages
+			GROUP BY chat_jid
+		) ms ON ms.chat_jid = c.jid
+		LEFT JOIN history_backfill_state h ON h.chat_jid = c.jid
+		WHERE 1=1`
+	args := make([]interface{}, 0, 8)
+
+	if q := strings.TrimSpace(p.Query); q != "" {
+		needle := "%" + q + "%"
+		query += ` AND (LOWER(COALESCE(c.name,'')) LIKE LOWER(?) OR LOWER(c.jid) LIKE LOWER(?))`
+		args = append(args, needle, needle)
+	}
+	if kind := strings.TrimSpace(p.Kind); kind != "" {
+		query += ` AND c.kind = ?`
+		args = append(args, kind)
+	}
+	if len(p.ChatJIDs) > 0 {
+		query += ` AND c.jid IN (` + placeholders(len(p.ChatJIDs)) + `)`
+		for _, jid := range p.ChatJIDs {
+			args = append(args, jid)
+		}
+	}
+
+	query += ` ORDER BY COALESCE(c.last_message_ts, 0) DESC, c.jid LIMIT ?`
+	args = append(args, p.Limit)
+
+	rows, err := d.sql.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]ChatCoverage, 0, p.Limit)
+	for rows.Next() {
+		var c ChatCoverage
+		var lastTS, oldestTS, newestTS, lastBackfill int64
+		var reachedStart, hasState int
+		if err := rows.Scan(
+			&c.ChatJID,
+			&c.Kind,
+			&c.Name,
+			&lastTS,
+			&c.MessageCount,
+			&oldestTS,
+			&newestTS,
+			&hasState,
+			&c.Status,
+			&c.BlockedReason,
+			&reachedStart,
+			&c.LastError,
+			&lastBackfill,
+		); err != nil {
+			return nil, err
+		}
+		c.LastMessageTS = fromUnix(lastTS)
+		c.OldestTS = fromUnix(oldestTS)
+		c.NewestTS = fromUnix(newestTS)
+		c.LastBackfillAt = fromUnix(lastBackfill)
+		c.HasState = hasState != 0
+		c.ReachedStart = reachedStart != 0
+		c = normalizeCoverage(c)
+		if p.OnlyTracked && !c.HasState {
+			continue
+		}
+		if !p.IncludeBlocked && c.Status == BackfillStatusBlocked {
+			continue
+		}
+		if p.OnlyActionable && !isActionableCoverage(c) {
+			continue
+		}
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (d *DB) GetChatCoverage(chatJID string) (ChatCoverage, error) {
+	rows, err := d.ListChatCoverage(ListChatCoverageParams{
+		ChatJIDs:       []string{strings.TrimSpace(chatJID)},
+		Limit:          1,
+		IncludeBlocked: true,
+	})
+	if err != nil {
+		return ChatCoverage{}, err
+	}
+	if len(rows) == 0 {
+		return ChatCoverage{}, sql.ErrNoRows
+	}
+	return rows[0], nil
+}
+
+func scanBackfillState(row *sql.Row) (BackfillState, error) {
+	var state BackfillState
+	var lastBackfillAt, lastSuccessAt, updatedAt int64
+	var reachedStart int
+	if err := row.Scan(
+		&state.ChatJID,
+		&state.Status,
+		&lastBackfillAt,
+		&lastSuccessAt,
+		&state.RequestsSentTotal,
+		&state.ResponsesSeenTotal,
+		&state.ConsecutiveNoopRequests,
+		&reachedStart,
+		&state.BlockedReason,
+		&state.LastError,
+		&updatedAt,
+	); err != nil {
+		return BackfillState{}, err
+	}
+	state.LastBackfillAt = fromUnix(lastBackfillAt)
+	state.LastSuccessAt = fromUnix(lastSuccessAt)
+	state.UpdatedAt = fromUnix(updatedAt)
+	state.ReachedStart = reachedStart != 0
+	return state, nil
+}
+
+func normalizeCoverage(c ChatCoverage) ChatCoverage {
+	c.Status = strings.TrimSpace(c.Status)
+	c.BlockedReason = strings.TrimSpace(c.BlockedReason)
+	c.LastError = strings.TrimSpace(c.LastError)
+
+	if c.ReachedStart {
+		c.Status = BackfillStatusComplete
+		c.BlockedReason = ""
+		return c
+	}
+	if c.MessageCount <= 0 {
+		c.Status = BackfillStatusBlocked
+		if c.BlockedReason == "" {
+			c.BlockedReason = BackfillBlockedNoLocalAnchor
+		}
+		return c
+	}
+	if c.Status == BackfillStatusBlocked && c.BlockedReason == BackfillBlockedNoLocalAnchor {
+		c.Status = BackfillStatusReady
+		c.BlockedReason = ""
+	}
+	if c.Status == "" {
+		c.Status = BackfillStatusReady
+	}
+	return c
+}
+
+func isActionableCoverage(c ChatCoverage) bool {
+	switch c.Status {
+	case BackfillStatusReady, BackfillStatusInProgress, BackfillStatusStalled:
+		return true
+	default:
+		return false
+	}
+}
+
+func placeholders(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	parts := make([]string, n)
+	for i := range parts {
+		parts[i] = "?"
+	}
+	return strings.Join(parts, ",")
+}
+
+func nullIfZeroUnix(t time.Time) interface{} {
+	if t.IsZero() {
+		return nil
+	}
+	return unix(t)
+}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -119,6 +119,15 @@ func (d *DB) CountMessages() (int64, error) {
 	return n, nil
 }
 
+func (d *DB) CountMessagesForChat(chatJID string) (int64, error) {
+	row := d.sql.QueryRow(`SELECT COUNT(1) FROM messages WHERE chat_jid = ?`, chatJID)
+	var n int64
+	if err := row.Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
 func (d *DB) GetOldestMessageInfo(chatJID string) (MessageInfo, error) {
 	chatJID = strings.TrimSpace(chatJID)
 	if chatJID == "" {

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -18,6 +18,7 @@ var schemaMigrations = []migration{
 	{version: 1, name: "core schema", up: migrateCoreSchema},
 	{version: 2, name: "messages display_text column", up: migrateMessagesDisplayText},
 	{version: 3, name: "messages fts", up: migrateMessagesFTS},
+	{version: 4, name: "history backfill state", up: migrateHistoryBackfillState},
 }
 
 func (d *DB) ensureSchema() error {
@@ -247,6 +248,30 @@ func migrateMessagesFTS(d *DB) error {
 	}
 
 	d.ftsEnabled = true
+	return nil
+}
+
+func migrateHistoryBackfillState(d *DB) error {
+	if _, err := d.sql.Exec(`
+		CREATE TABLE IF NOT EXISTS history_backfill_state (
+			chat_jid TEXT PRIMARY KEY,
+			status TEXT NOT NULL,
+			last_backfill_at INTEGER,
+			last_success_at INTEGER,
+			requests_sent_total INTEGER NOT NULL DEFAULT 0,
+			responses_seen_total INTEGER NOT NULL DEFAULT 0,
+			consecutive_noop_requests INTEGER NOT NULL DEFAULT 0,
+			reached_start INTEGER NOT NULL DEFAULT 0,
+			blocked_reason TEXT,
+			last_error TEXT,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (chat_jid) REFERENCES chats(jid) ON DELETE CASCADE
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_history_backfill_state_status ON history_backfill_state(status);
+	`); err != nil {
+		return fmt.Errorf("create history_backfill_state table: %w", err)
+	}
 	return nil
 }
 

--- a/internal/store/schema_test.go
+++ b/internal/store/schema_test.go
@@ -33,6 +33,28 @@ func TestOpenCreatesExpectedSchema(t *testing.T) {
 			t.Fatalf("expected messages column %q to exist", want)
 		}
 	}
+
+	backfillCols, err := tableColumns(db.sql, "history_backfill_state")
+	if err != nil {
+		t.Fatalf("tableColumns history_backfill_state: %v", err)
+	}
+	for _, want := range []string{
+		"chat_jid",
+		"status",
+		"last_backfill_at",
+		"last_success_at",
+		"requests_sent_total",
+		"responses_seen_total",
+		"consecutive_noop_requests",
+		"reached_start",
+		"blocked_reason",
+		"last_error",
+		"updated_at",
+	} {
+		if !backfillCols[want] {
+			t.Fatalf("expected history_backfill_state column %q to exist", want)
+		}
+	}
 }
 
 func tableColumns(db *sql.DB, table string) (map[string]bool, error) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -319,3 +319,113 @@ func TestGroupsUpsertListAndParticipantsReplace(t *testing.T) {
 		t.Fatalf("expected roles admin=1 member=1, got admin=%d member=%d", admins, members)
 	}
 }
+
+func TestBackfillStateCoverageAndReset(t *testing.T) {
+	db := openTestDB(t)
+
+	readyChat := "100@s.whatsapp.net"
+	blockedChat := "200@s.whatsapp.net"
+	trackedChat := "300@s.whatsapp.net"
+	base := time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	if err := db.UpsertChat(readyChat, "dm", "Ready", base.Add(10*time.Minute)); err != nil {
+		t.Fatalf("UpsertChat ready: %v", err)
+	}
+	if err := db.UpsertChat(blockedChat, "dm", "Blocked", base.Add(9*time.Minute)); err != nil {
+		t.Fatalf("UpsertChat blocked: %v", err)
+	}
+	if err := db.UpsertChat(trackedChat, "group", "Tracked", base.Add(8*time.Minute)); err != nil {
+		t.Fatalf("UpsertChat tracked: %v", err)
+	}
+
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:    readyChat,
+		ChatName:   "Ready",
+		MsgID:      "m2",
+		SenderJID:  readyChat,
+		SenderName: "Ready",
+		Timestamp:  base.Add(2 * time.Minute),
+		Text:       "hello",
+	}); err != nil {
+		t.Fatalf("UpsertMessage ready: %v", err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:    trackedChat,
+		ChatName:   "Tracked",
+		MsgID:      "m3",
+		SenderJID:  trackedChat,
+		SenderName: "Tracked",
+		Timestamp:  base.Add(3 * time.Minute),
+		Text:       "tracked",
+	}); err != nil {
+		t.Fatalf("UpsertMessage tracked: %v", err)
+	}
+
+	now := base.Add(20 * time.Minute)
+	if err := db.PutBackfillState(BackfillState{
+		ChatJID:                 trackedChat,
+		Status:                  BackfillStatusInProgress,
+		LastBackfillAt:          now,
+		RequestsSentTotal:       2,
+		ResponsesSeenTotal:      2,
+		ConsecutiveNoopRequests: 1,
+		UpdatedAt:               now,
+	}); err != nil {
+		t.Fatalf("PutBackfillState: %v", err)
+	}
+
+	if err := db.ResetBackfillInProgress(now.Add(time.Minute)); err != nil {
+		t.Fatalf("ResetBackfillInProgress: %v", err)
+	}
+	state, err := db.GetBackfillState(trackedChat)
+	if err != nil {
+		t.Fatalf("GetBackfillState: %v", err)
+	}
+	if state.Status != BackfillStatusReady {
+		t.Fatalf("expected reset state ready, got %q", state.Status)
+	}
+
+	if err := db.PutBackfillState(BackfillState{
+		ChatJID:                 trackedChat,
+		Status:                  BackfillStatusComplete,
+		LastBackfillAt:          now,
+		LastSuccessAt:           now,
+		RequestsSentTotal:       3,
+		ResponsesSeenTotal:      3,
+		ConsecutiveNoopRequests: 0,
+		ReachedStart:            true,
+		UpdatedAt:               now,
+	}); err != nil {
+		t.Fatalf("PutBackfillState complete: %v", err)
+	}
+
+	coverage, err := db.ListChatCoverage(ListChatCoverageParams{Limit: 10, IncludeBlocked: true})
+	if err != nil {
+		t.Fatalf("ListChatCoverage: %v", err)
+	}
+	if len(coverage) != 3 {
+		t.Fatalf("expected 3 coverage rows, got %d", len(coverage))
+	}
+
+	byChat := map[string]ChatCoverage{}
+	for _, c := range coverage {
+		byChat[c.ChatJID] = c
+	}
+	if byChat[readyChat].Status != BackfillStatusReady {
+		t.Fatalf("expected ready chat status ready, got %q", byChat[readyChat].Status)
+	}
+	if byChat[blockedChat].Status != BackfillStatusBlocked || byChat[blockedChat].BlockedReason != BackfillBlockedNoLocalAnchor {
+		t.Fatalf("expected blocked chat no_local_anchor, got %+v", byChat[blockedChat])
+	}
+	if byChat[trackedChat].Status != BackfillStatusComplete || !byChat[trackedChat].HasState || !byChat[trackedChat].ReachedStart {
+		t.Fatalf("expected tracked chat complete with state, got %+v", byChat[trackedChat])
+	}
+
+	trackedOnly, err := db.ListChatCoverage(ListChatCoverageParams{Limit: 10, IncludeBlocked: true, OnlyTracked: true})
+	if err != nil {
+		t.Fatalf("ListChatCoverage tracked: %v", err)
+	}
+	if len(trackedOnly) != 1 || trackedOnly[0].ChatJID != trackedChat {
+		t.Fatalf("expected only tracked chat, got %+v", trackedOnly)
+	}
+}


### PR DESCRIPTION
Expose archive coverage inspection and multi-chat fill commands so users can drive resumable history recovery from the CLI instead of shell loops. This gives the new backfill engine a clear human and JSON interface while preserving the existing single-chat backfill escape hatch.