### PR TITLE
fix: force exit on second SIGINT during long-running commands

### DIFF
--- a/cmd/wacli/auth.go
+++ b/cmd/wacli/auth.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	"github.com/mdp/qrterminal/v3"
@@ -23,7 +21,7 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 		Use:   "auth",
 		Short: "Authenticate with WhatsApp (QR) and bootstrap sync",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+			ctx, stop := signalContext()
 			defer stop()
 
 			a, lk, err := newApp(ctx, flags, true, true)

--- a/cmd/wacli/history.go
+++ b/cmd/wacli/history.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -37,7 +34,7 @@ func newHistoryBackfillCmd(flags *rootFlags) *cobra.Command {
 				return fmt.Errorf("--chat is required")
 			}
 
-			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+			ctx, stop := signalContext()
 			defer stop()
 
 			a, lk, err := newApp(ctx, flags, true, false)

--- a/cmd/wacli/signal.go
+++ b/cmd/wacli/signal.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// signalContext returns a context that is cancelled on the first SIGINT/SIGTERM.
+// A second signal force-kills the process so that a stuck cleanup never leaves
+// the user unable to get their terminal back.
+func signalContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sigCh := make(chan os.Signal, 2)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		<-sigCh
+		fmt.Fprintln(os.Stderr, "\nShutting down (interrupt again to force quit)...")
+		cancel()
+
+		<-sigCh
+		fmt.Fprintln(os.Stderr, "Force quit.")
+		os.Exit(1)
+	}()
+
+	return ctx, func() {
+		signal.Stop(sigCh)
+		cancel()
+	}
+}

--- a/cmd/wacli/sync.go
+++ b/cmd/wacli/sync.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -25,7 +22,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 		Use:   "sync",
 		Short: "Sync messages (requires prior auth; never shows QR)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+			ctx, stop := signalContext()
 			defer stop()
 
 			a, lk, err := newApp(ctx, flags, true, false)


### PR DESCRIPTION
Fixes #61.

## Problem

`sync --follow`, `auth`, and `history backfill` use `signal.NotifyContext` which catches the first SIGINT to cancel the context, then deregisters. If cleanup hangs (reconnect loop, media workers, etc.), a second Ctrl+C does nothing — the process is stuck and the store lock stays held.

## Fix

New `signalContext()` helper in `cmd/wacli/signal.go` that keeps listening after the first signal:

1. First SIGINT/SIGTERM → cancels the context, prints "Shutting down (interrupt again to force quit)..."
2. Second signal → `os.Exit(1)`

All three long-running commands (`sync`, `auth`, `history backfill`) now use this instead of `signal.NotifyContext`.

## Testing

- `go build -tags sqlite_fts5 ./cmd/wacli/` passes
- All existing tests pass (`go test -tags sqlite_fts5 ./...`)