### PR TITLE
fix: bound reconnect duration to prevent indefinite lock holding

### DIFF
--- a/cmd/wacli/sync.go
+++ b/cmd/wacli/sync.go
@@ -17,6 +17,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var once bool
 	var follow bool
 	var idleExit time.Duration
+	var maxReconnect time.Duration
 	var downloadMedia bool
 	var refreshContacts bool
 	var refreshGroups bool
@@ -54,6 +55,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 				RefreshContacts: refreshContacts,
 				RefreshGroups:   refreshGroups,
 				IdleExit:        idleExit,
+				MaxReconnect:    maxReconnect,
 			})
 			if err != nil {
 				return err
@@ -73,6 +75,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().BoolVar(&once, "once", false, "sync until idle and exit")
 	cmd.Flags().BoolVar(&follow, "follow", true, "keep syncing until Ctrl+C")
 	cmd.Flags().DurationVar(&idleExit, "idle-exit", 30*time.Second, "exit after being idle (once mode)")
+	cmd.Flags().DurationVar(&maxReconnect, "max-reconnect", 5*time.Minute, "give up reconnecting after this duration (0 = unlimited)")
 	cmd.Flags().BoolVar(&downloadMedia, "download-media", false, "download media in the background during sync")
 	cmd.Flags().BoolVar(&refreshContacts, "refresh-contacts", false, "refresh contacts from session store into local DB")
 	cmd.Flags().BoolVar(&refreshGroups, "refresh-groups", false, "refresh joined groups (live) into local DB")

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -31,6 +31,7 @@ type SyncOptions struct {
 	RefreshContacts bool
 	RefreshGroups   bool
 	IdleExit        time.Duration // only used for bootstrap/once
+	MaxReconnect    time.Duration // max time to attempt reconnection before giving up (0 = unlimited)
 	Verbosity       int           // future
 }
 
@@ -176,7 +177,7 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 				return SyncResult{MessagesStored: messagesStored.Load()}, nil
 			case <-disconnected:
 				fmt.Fprintln(os.Stderr, "Reconnecting...")
-				if err := a.wa.ReconnectWithBackoff(ctx, 2*time.Second, 30*time.Second); err != nil {
+				if err := a.reconnect(ctx, opts.MaxReconnect); err != nil {
 					return SyncResult{MessagesStored: messagesStored.Load()}, err
 				}
 			}
@@ -197,7 +198,7 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 			return SyncResult{MessagesStored: messagesStored.Load()}, nil
 		case <-disconnected:
 			fmt.Fprintln(os.Stderr, "Reconnecting...")
-			if err := a.wa.ReconnectWithBackoff(ctx, 2*time.Second, 30*time.Second); err != nil {
+			if err := a.reconnect(ctx, opts.MaxReconnect); err != nil {
 				return SyncResult{MessagesStored: messagesStored.Load()}, err
 			}
 		case <-ticker.C:
@@ -208,6 +209,24 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 			}
 		}
 	}
+}
+
+// reconnect wraps ReconnectWithBackoff with an optional deadline.
+// If maxDuration is positive, reconnection gives up after that long.
+// A zero or negative value means retry indefinitely (until ctx is cancelled).
+func (a *App) reconnect(ctx context.Context, maxDuration time.Duration) error {
+	rctx := ctx
+	var cancel context.CancelFunc
+	if maxDuration > 0 {
+		rctx, cancel = context.WithTimeout(ctx, maxDuration)
+		defer cancel()
+	}
+	err := a.wa.ReconnectWithBackoff(rctx, 2*time.Second, 30*time.Second)
+	if err != nil && ctx.Err() == nil {
+		// Deadline hit but parent context is still alive — we gave up, not the user.
+		return fmt.Errorf("could not reconnect after %s: %w", maxDuration, err)
+	}
+	return err
 }
 
 func chatKind(chat types.JID) string {


### PR DESCRIPTION
Fixes #88.

## Problem

`sync --follow` calls `ReconnectWithBackoff` on disconnect, which retries forever (exponential backoff from 2s up to 30s). If the connection can't recover — protocol version blocked, network permanently down, session invalidated — the process sits retrying indefinitely while holding the store lock. Every other wacli command fails with "store is locked".

The user in #88 had to manually find and kill the PID to get their terminal back.

## Fix

New `reconnect()` wrapper in `internal/app/sync.go` that applies a `context.WithTimeout` around `ReconnectWithBackoff`. When the deadline fires, sync exits with a clear error:

```
could not reconnect after 5m0s: context deadline exceeded
```

New `--max-reconnect` flag on `sync` (default `5m`). Pass `--max-reconnect 0` for unbounded retries (the old behavior).

The timeout resets on each disconnect — it bounds a single reconnection attempt, not the total runtime. A sync that connects, runs for days, disconnects, reconnects within 5m, then runs for more days is fine.

## Testing

- `go build -tags sqlite_fts5 ./cmd/wacli/` passes
- `go test -tags sqlite_fts5 ./...` — all existing tests pass