### PR TITLE
feat: add NDJSON lifecycle events

### DIFF
--- a/cmd/wacli/auth.go
+++ b/cmd/wacli/auth.go
@@ -38,6 +38,7 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			fmt.Fprintln(os.Stderr, "Starting authentication…")
+			_ = a.Events().Emit("auth_starting", nil)
 			res, err := a.Sync(ctx, appPkg.SyncOptions{
 				Mode:            mode,
 				AllowQR:         true,
@@ -46,6 +47,7 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 				RefreshGroups:   true,
 				IdleExit:        idleExit,
 				OnQRCode: func(code string) {
+					_ = a.Events().Emit("qr_code", map[string]any{"code": code})
 					fmt.Fprintln(os.Stderr, "\nScan this QR code with WhatsApp (Linked Devices):")
 					qrterminal.GenerateHalfBlock(code, qrterminal.M, os.Stderr)
 					fmt.Fprintln(os.Stderr)

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -20,6 +20,7 @@ var version = "0.5.0"
 type rootFlags struct {
 	storeDir string
 	asJSON   bool
+	events   bool
 	timeout  time.Duration
 }
 
@@ -36,6 +37,7 @@ func execute(args []string) error {
 
 	rootCmd.PersistentFlags().StringVar(&flags.storeDir, "store", "", "store directory (default: ~/.wacli)")
 	rootCmd.PersistentFlags().BoolVar(&flags.asJSON, "json", false, "output JSON instead of human-readable text")
+	rootCmd.PersistentFlags().BoolVar(&flags.events, "events", false, "emit machine-readable NDJSON lifecycle events on stderr")
 	rootCmd.PersistentFlags().DurationVar(&flags.timeout, "timeout", 5*time.Minute, "command timeout (non-sync commands)")
 
 	rootCmd.AddCommand(newVersionCmd())
@@ -78,6 +80,7 @@ func newApp(ctx context.Context, flags *rootFlags, needLock bool, allowUnauthed 
 		StoreDir:      storeDir,
 		Version:       version,
 		JSON:          flags.asJSON,
+		Events:        out.NewEventWriter(os.Stderr, flags.events),
 		AllowUnauthed: allowUnauthed,
 	})
 	if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/steipete/wacli/internal/out"
 	"github.com/steipete/wacli/internal/store"
 	"github.com/steipete/wacli/internal/wa"
 	"go.mau.fi/whatsmeow"
@@ -51,6 +52,7 @@ type Options struct {
 	StoreDir      string
 	Version       string
 	JSON          bool
+	Events        *out.EventWriter
 	AllowUnauthed bool
 }
 
@@ -113,11 +115,12 @@ func (a *App) EnsureAuthed() error {
 	return fmt.Errorf("not authenticated; run `wacli auth`")
 }
 
-func (a *App) WA() WAClient        { return a.wa }
-func (a *App) DB() *store.DB       { return a.db }
-func (a *App) StoreDir() string    { return a.opts.StoreDir }
-func (a *App) Version() string     { return a.opts.Version }
-func (a *App) AllowUnauthed() bool { return a.opts.AllowUnauthed }
+func (a *App) WA() WAClient             { return a.wa }
+func (a *App) DB() *store.DB            { return a.db }
+func (a *App) Events() *out.EventWriter { return a.opts.Events }
+func (a *App) StoreDir() string         { return a.opts.StoreDir }
+func (a *App) Version() string          { return a.opts.Version }
+func (a *App) AllowUnauthed() bool      { return a.opts.AllowUnauthed }
 
 func (a *App) Connect(ctx context.Context, allowQR bool, qrWriter func(string)) error {
 	if err := a.OpenWA(); err != nil {

--- a/internal/app/backfill.go
+++ b/internal/app/backfill.go
@@ -68,6 +68,7 @@ func (a *App) BackfillHistory(ctx context.Context, opts BackfillOptions) (Backfi
 	}
 
 	beforeCount, _ := a.db.CountMessages()
+	eventWriter := a.Events()
 
 	var mu sync.Mutex
 	var waitCh chan onDemandResponse
@@ -136,6 +137,11 @@ func (a *App) BackfillHistory(ctx context.Context, opts BackfillOptions) (Backfi
 				mu.Unlock()
 
 				requestsSent++
+				_ = eventWriter.Emit("backfill_requesting", map[string]any{
+					"chat_jid": chatStr,
+					"count":    opts.Count,
+					"request":  requestsSent,
+				})
 				fmt.Fprintf(os.Stderr, "Requesting %d older messages for %s...\n", opts.Count, chatStr)
 				if _, err := a.wa.RequestHistorySyncOnDemand(ctx, reqInfo, opts.Count); err != nil {
 					return err
@@ -158,17 +164,35 @@ func (a *App) BackfillHistory(ctx context.Context, opts BackfillOptions) (Backfi
 				mu.Unlock()
 
 				fmt.Fprintf(os.Stderr, "On-demand history sync: %d conversations, %d messages.\n", resp.conversations, resp.messages)
+				_ = eventWriter.Emit("backfill_response", map[string]any{
+					"chat_jid":       chatStr,
+					"conversations":  resp.conversations,
+					"messages":       resp.messages,
+					"responses_seen": responsesSeen,
+				})
 
 				newOldest, err := a.db.GetOldestMessageInfo(chatStr)
 				if err == nil && newOldest.MsgID == oldest.MsgID {
+					_ = eventWriter.Emit("backfill_stopped", map[string]any{
+						"chat_jid": chatStr,
+						"reason":   "no_older_messages_added",
+					})
 					fmt.Fprintln(os.Stderr, "No older messages were added (stopping).")
 					return nil
 				}
 				if resp.messages <= 0 {
+					_ = eventWriter.Emit("backfill_stopped", map[string]any{
+						"chat_jid": chatStr,
+						"reason":   "no_messages_returned",
+					})
 					fmt.Fprintln(os.Stderr, "No messages returned (stopping).")
 					return nil
 				}
 				if resp.endType == waHistorySync.Conversation_COMPLETE_AND_NO_MORE_MESSAGE_REMAIN_ON_PRIMARY {
+					_ = eventWriter.Emit("backfill_stopped", map[string]any{
+						"chat_jid": chatStr,
+						"reason":   "start_of_history_reached",
+					})
 					fmt.Fprintln(os.Stderr, "Reached start of chat history (stopping).")
 					return nil
 				}

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -53,6 +53,7 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 	var messagesStored atomic.Int64
 	lastEvent := atomic.Int64{}
 	lastEvent.Store(time.Now().UTC().UnixNano())
+	eventWriter := a.Events()
 
 	disconnected := make(chan struct{}, 1)
 
@@ -96,7 +97,10 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 				}
 			}
 			if err := a.storeParsedMessage(ctx, pm); err == nil {
-				messagesStored.Add(1)
+				total := messagesStored.Add(1)
+				if total%25 == 0 {
+					_ = eventWriter.Emit("progress", map[string]any{"messages_synced": total})
+				}
 			}
 			if opts.DownloadMedia && pm.Media != nil && pm.ID != "" {
 				enqueueMedia(pm.Chat.String(), pm.ID)
@@ -105,6 +109,7 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 				fmt.Fprintf(os.Stderr, "\rSynced %d messages...", messagesStored.Load())
 			}
 		case *events.HistorySync:
+			_ = eventWriter.Emit("history_sync", map[string]any{"conversations": len(v.Data.Conversations)})
 			fmt.Fprintf(os.Stderr, "\nProcessing history sync (%d conversations)...\n", len(v.Data.Conversations))
 			for _, conv := range v.Data.Conversations {
 				lastEvent.Store(time.Now().UTC().UnixNano())
@@ -122,7 +127,10 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 						continue
 					}
 					if err := a.storeParsedMessage(ctx, pm); err == nil {
-						messagesStored.Add(1)
+						total := messagesStored.Add(1)
+						if total%25 == 0 {
+							_ = eventWriter.Emit("progress", map[string]any{"messages_synced": total})
+						}
 					}
 					if opts.DownloadMedia && pm.Media != nil && pm.ID != "" {
 						enqueueMedia(pm.Chat.String(), pm.ID)
@@ -131,8 +139,10 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 			}
 			fmt.Fprintf(os.Stderr, "\rSynced %d messages...", messagesStored.Load())
 		case *events.Connected:
+			_ = eventWriter.Emit("connected", nil)
 			fmt.Fprintln(os.Stderr, "\nConnected.")
 		case *events.Disconnected:
+			_ = eventWriter.Emit("disconnected", nil)
 			fmt.Fprintln(os.Stderr, "\nDisconnected.")
 			select {
 			case disconnected <- struct{}{}:
@@ -172,9 +182,11 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 		for {
 			select {
 			case <-ctx.Done():
+				_ = eventWriter.Emit("stopping", map[string]any{"messages_synced": messagesStored.Load()})
 				fmt.Fprintln(os.Stderr, "\nStopping sync.")
 				return SyncResult{MessagesStored: messagesStored.Load()}, nil
 			case <-disconnected:
+				_ = eventWriter.Emit("reconnecting", nil)
 				fmt.Fprintln(os.Stderr, "Reconnecting...")
 				if err := a.wa.ReconnectWithBackoff(ctx, 2*time.Second, 30*time.Second); err != nil {
 					return SyncResult{MessagesStored: messagesStored.Load()}, err
@@ -193,9 +205,11 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 	for {
 		select {
 		case <-ctx.Done():
+			_ = eventWriter.Emit("stopping", map[string]any{"messages_synced": messagesStored.Load()})
 			fmt.Fprintln(os.Stderr, "\nStopping sync.")
 			return SyncResult{MessagesStored: messagesStored.Load()}, nil
 		case <-disconnected:
+			_ = eventWriter.Emit("reconnecting", nil)
 			fmt.Fprintln(os.Stderr, "Reconnecting...")
 			if err := a.wa.ReconnectWithBackoff(ctx, 2*time.Second, 30*time.Second); err != nil {
 				return SyncResult{MessagesStored: messagesStored.Load()}, err
@@ -203,6 +217,10 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 		case <-ticker.C:
 			last := time.Unix(0, lastEvent.Load())
 			if time.Since(last) >= opts.IdleExit {
+				_ = eventWriter.Emit("idle_exit", map[string]any{
+					"idle_duration":   opts.IdleExit.String(),
+					"messages_synced": messagesStored.Load(),
+				})
 				fmt.Fprintf(os.Stderr, "\nIdle for %s, exiting.\n", opts.IdleExit)
 				return SyncResult{MessagesStored: messagesStored.Load()}, nil
 			}

--- a/internal/app/sync_events_test.go
+++ b/internal/app/sync_events_test.go
@@ -1,0 +1,115 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steipete/wacli/internal/out"
+	"go.mau.fi/whatsmeow/proto/waHistorySync"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestSyncEmitsLifecycleEvents(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	var buf bytes.Buffer
+	a.opts.Events = out.NewEventWriter(&buf, true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := a.Sync(ctx, SyncOptions{
+		Mode:     SyncModeOnce,
+		AllowQR:  false,
+		IdleExit: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	lines := splitEventLines(t, buf.String())
+	assertEventSeen(t, lines, "connected")
+	assertEventSeen(t, lines, "idle_exit")
+}
+
+func TestBackfillEmitsLifecycleEvents(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	var buf bytes.Buffer
+	a.opts.Events = out.NewEventWriter(&buf, true)
+
+	chat := types.JID{User: "123", Server: types.DefaultUserServer}
+	chatStr := chat.String()
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	if err := a.db.UpsertChat(chatStr, "dm", "Alice", base); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := a.db.UpsertMessage(storeUpsertMessage(chatStr, "m2", base.Add(2*time.Second), "newer")); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	f.onDemandHistory = func(lastKnown types.MessageInfo, count int) *events.HistorySync {
+		return &events.HistorySync{
+			Data: &waHistorySync.HistorySync{
+				SyncType: waHistorySync.HistorySync_ON_DEMAND.Enum(),
+				Conversations: []*waHistorySync.Conversation{{
+					ID: proto.String("999@s.whatsapp.net"),
+				}},
+			},
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	_, err := a.BackfillHistory(ctx, BackfillOptions{
+		ChatJID:        chatStr,
+		Count:          10,
+		Requests:       1,
+		WaitPerRequest: 50 * time.Millisecond,
+		IdleExit:       20 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatalf("expected backfill to fail without a response")
+	}
+
+	lines := splitEventLines(t, buf.String())
+	assertEventSeen(t, lines, "backfill_requesting")
+}
+
+func splitEventLines(t *testing.T, raw string) []map[string]any {
+	t.Helper()
+	var lines []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(raw), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var evt map[string]any
+		if err := json.Unmarshal([]byte(line), &evt); err != nil {
+			t.Fatalf("unmarshal line %q: %v", line, err)
+		}
+		lines = append(lines, evt)
+	}
+	return lines
+}
+
+func assertEventSeen(t *testing.T, lines []map[string]any, want string) {
+	t.Helper()
+	for _, line := range lines {
+		if line["event"] == want {
+			return
+		}
+	}
+	t.Fatalf("event %q not found in %#v", want, lines)
+}

--- a/internal/out/events.go
+++ b/internal/out/events.go
@@ -1,0 +1,55 @@
+package out
+
+import (
+	"encoding/json"
+	"io"
+	"sync"
+	"time"
+)
+
+type EventWriter struct {
+	mu       sync.Mutex
+	w        io.Writer
+	enabled  bool
+	clockNow func() time.Time
+}
+
+type eventEnvelope struct {
+	Event string         `json:"event"`
+	Data  map[string]any `json:"data,omitempty"`
+	TS    int64          `json:"ts"`
+}
+
+func NewEventWriter(w io.Writer, enabled bool) *EventWriter {
+	return &EventWriter{
+		w:        w,
+		enabled:  enabled,
+		clockNow: time.Now,
+	}
+}
+
+func (e *EventWriter) Enabled() bool {
+	return e != nil && e.enabled
+}
+
+func (e *EventWriter) Emit(event string, data map[string]any) error {
+	if !e.Enabled() {
+		return nil
+	}
+
+	payload := eventEnvelope{
+		Event: event,
+		Data:  data,
+		TS:    e.clockNow().UTC().UnixMilli(),
+	}
+
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	_, err = e.w.Write(append(b, '\n'))
+	return err
+}

--- a/internal/out/events_test.go
+++ b/internal/out/events_test.go
@@ -1,0 +1,49 @@
+package out
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEventWriterDisabledIsNoOp(t *testing.T) {
+	var b bytes.Buffer
+	w := NewEventWriter(&b, false)
+	if err := w.Emit("connected", nil); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if b.Len() != 0 {
+		t.Fatalf("expected no output when disabled, got %q", b.String())
+	}
+}
+
+func TestEventWriterEmitsNDJSON(t *testing.T) {
+	var b bytes.Buffer
+	w := NewEventWriter(&b, true)
+	w.clockNow = func() time.Time { return time.UnixMilli(1234).UTC() }
+
+	if err := w.Emit("progress", map[string]any{"messages_synced": 25}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	line := strings.TrimSpace(b.String())
+	var got map[string]any
+	if err := json.Unmarshal([]byte(line), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["event"] != "progress" {
+		t.Fatalf("unexpected event: %v", got["event"])
+	}
+	if got["ts"] != float64(1234) {
+		t.Fatalf("unexpected ts: %v", got["ts"])
+	}
+	data, ok := got["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected data object, got %T", got["data"])
+	}
+	if data["messages_synced"] != float64(25) {
+		t.Fatalf("unexpected data payload: %#v", data)
+	}
+}


### PR DESCRIPTION
## Summary

Add a new global `--events` flag that emits newline-delimited JSON lifecycle events to `stderr` for long-running flows while preserving the existing human-readable output when the flag is not used.

This wires event emission into:
- `wacli auth`
- `wacli sync`
- `wacli history backfill`

## Events

Current event types include:
- `auth_starting`
- `qr_code`
- `connected`
- `disconnected`
- `history_sync`
- `progress`
- `reconnecting`
- `stopping`
- `idle_exit`
- `backfill_requesting`
- `backfill_response`
- `backfill_stopped`

## Implementation

- Add `internal/out/EventWriter` for thread-safe NDJSON event emission
- Add persistent `--events` flag on the root command
- Thread an optional event writer through `app.Options`
- Emit structured lifecycle events alongside existing stderr output in auth/sync/backfill paths
- Add focused tests for the event writer and lifecycle emission

## Testing

- `go test ./...`
- `go run ./cmd/wacli --help`

## Notes

Normal CLI behavior is unchanged unless `--events` is passed.
