### PR TITLE
fix: bound send hangs and retry stale sessions

### DIFF
--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -55,7 +55,12 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			msgID, err := a.WA().SendText(ctx, toJID, message)
+			msgID, err := runSendOperation(ctx, func(ctx context.Context) error {
+				a.WA().Close()
+				return a.Connect(ctx, false, nil)
+			}, func(ctx context.Context) (string, error) {
+				return a.WA().SendText(ctx, toJID, message)
+			})
 			if err != nil {
 				return err
 			}

--- a/cmd/wacli/send_file_cmd.go
+++ b/cmd/wacli/send_file_cmd.go
@@ -46,10 +46,24 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			msgID, meta, err := sendFile(ctx, a, toJID, filePath, filename, caption, mimeOverride)
+			type sendFileResult struct {
+				id   string
+				meta map[string]string
+			}
+			res, err := runSendOperation(ctx, func(ctx context.Context) error {
+				a.WA().Close()
+				return a.Connect(ctx, false, nil)
+			}, func(ctx context.Context) (sendFileResult, error) {
+				msgID, meta, err := sendFile(ctx, a, toJID, filePath, filename, caption, mimeOverride)
+				if err != nil {
+					return sendFileResult{}, err
+				}
+				return sendFileResult{id: msgID, meta: meta}, nil
+			})
 			if err != nil {
 				return err
 			}
+			msgID, meta := res.id, res.meta
 
 			if flags.asJSON {
 				return out.WriteJSON(os.Stdout, map[string]any{

--- a/cmd/wacli/send_helpers.go
+++ b/cmd/wacli/send_helpers.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.mau.fi/whatsmeow"
+)
+
+const sendAttemptTimeout = 45 * time.Second
+
+func runSendOperation[T any](
+	ctx context.Context,
+	reconnect func(context.Context) error,
+	op func(context.Context) (T, error),
+) (T, error) {
+	result, err := runSendAttempt(ctx, sendAttemptTimeout, op)
+	if err == nil {
+		return result, nil
+	}
+
+	var zero T
+	if !isRetryableSendError(err) || ctx.Err() != nil {
+		return zero, err
+	}
+
+	if reconnectErr := reconnect(ctx); reconnectErr != nil {
+		return zero, fmt.Errorf("%w; reconnect failed: %v", err, reconnectErr)
+	}
+
+	return runSendAttempt(ctx, sendAttemptTimeout, op)
+}
+
+func runSendAttempt[T any](ctx context.Context, timeout time.Duration, op func(context.Context) (T, error)) (T, error) {
+	attemptCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	type result struct {
+		value T
+		err   error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		value, err := op(attemptCtx)
+		ch <- result{value: value, err: err}
+	}()
+
+	select {
+	case res := <-ch:
+		return res.value, res.err
+	case <-attemptCtx.Done():
+		var zero T
+		if errors.Is(attemptCtx.Err(), context.DeadlineExceeded) {
+			return zero, fmt.Errorf("send timed out after %s", timeout)
+		}
+		return zero, attemptCtx.Err()
+	}
+}
+
+func isRetryableSendError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, whatsmeow.ErrIQTimedOut) {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "failed to send usync query") ||
+		strings.Contains(msg, "failed to get user info") ||
+		strings.Contains(msg, "failed to get device list") ||
+		strings.Contains(msg, "info query timed out") ||
+		strings.Contains(msg, "not connected")
+}

--- a/cmd/wacli/send_helpers_test.go
+++ b/cmd/wacli/send_helpers_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow"
+)
+
+func TestRunSendOperationRetriesRetryableError(t *testing.T) {
+	var reconnects int
+	attempts := 0
+
+	got, err := runSendOperation(context.Background(), func(ctx context.Context) error {
+		reconnects++
+		return nil
+	}, func(ctx context.Context) (string, error) {
+		attempts++
+		if attempts == 1 {
+			return "", fmt.Errorf("failed to get device list: failed to send usync query: %w", whatsmeow.ErrIQTimedOut)
+		}
+		return "ok", nil
+	})
+	if err != nil {
+		t.Fatalf("runSendOperation: %v", err)
+	}
+	if got != "ok" {
+		t.Fatalf("expected ok, got %q", got)
+	}
+	if reconnects != 1 {
+		t.Fatalf("expected 1 reconnect, got %d", reconnects)
+	}
+}
+
+func TestRunSendAttemptTimesOut(t *testing.T) {
+	_, err := runSendAttempt(context.Background(), 20*time.Millisecond, func(ctx context.Context) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	})
+	if err == nil {
+		t.Fatalf("expected timeout error")
+	}
+	if err.Error() != "send timed out after 20ms" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestIsRetryableSendError(t *testing.T) {
+	if !isRetryableSendError(fmt.Errorf("wrapped: %w", whatsmeow.ErrIQTimedOut)) {
+		t.Fatalf("expected ErrIQTimedOut to be retryable")
+	}
+	if !isRetryableSendError(errors.New("failed to get user info for 123@s.whatsapp.net to fill LID cache: failed to send usync query: info query timed out")) {
+		t.Fatalf("expected wrapped usync timeout to be retryable")
+	}
+	if isRetryableSendError(errors.New("permission denied")) {
+		t.Fatalf("did not expect arbitrary error to be retryable")
+	}
+}


### PR DESCRIPTION
## Summary

Fix the send-path failure mode where `wacli send text` / `wacli send file` can appear to hang indefinitely or fail after a long wait when the session is authenticated but the underlying WhatsApp connection is stale or unhealthy.

This targets the issue cluster around:
- #104
- #91
- #44

## What changed

- Add a shared send helper that runs each send attempt with a bounded per-attempt timeout
- Return a clear error like `send timed out after 45s` instead of silently hanging
- Retry once after a clean reconnect when the failure looks like a stale/disconnected session or a usync/LID lookup timeout
- Apply the same bounded/retrying behavior to both `send text` and `send file`

## Retry conditions

The reconnect + retry path only kicks in for clearly connection-shaped failures, including:
- `info query timed out`
- `failed to send usync query`
- `failed to get user info`
- `failed to get device list`
- `not connected`

This keeps ordinary validation or file errors unchanged.

## Testing

- `go test ./cmd/wacli`
- `go test ./...`

## Notes

This does not try to redesign the full send/LID flow. The goal here is to make the current send path much safer operationally by avoiding indefinite stalls and recovering once from stale-session failures.
