### PR TITLE
fix: normalize phone-style recipient input

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ pnpm wacli history backfill --chat 1234567890@s.whatsapp.net --requests 10 --cou
 
 # Send a message
 pnpm wacli send text --to 1234567890 --message "hello"
+# phone numbers can also be passed as +E164 or formatted input like "+1 (234) 567-8900"
 
 # Send a file
 ./wacli send file --to 1234567890 --file ./pic.jpg --caption "hi"

--- a/cmd/wacli/groups_participants.go
+++ b/cmd/wacli/groups_participants.go
@@ -79,6 +79,6 @@ func newGroupsParticipantsActionCmd(flags *rootFlags, action string) *cobra.Comm
 		},
 	}
 	cmd.Flags().StringVar(&group, "jid", "", "group JID (…@g.us)")
-	cmd.Flags().StringSliceVar(&users, "user", nil, "user phone number or JID (repeatable)")
+	cmd.Flags().StringSliceVar(&users, "user", nil, "user phone number (+E164 and formatting ok) or JID (repeatable)")
 	return cmd
 }

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -88,7 +88,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&to, "to", "", "recipient phone number or JID")
+	cmd.Flags().StringVar(&to, "to", "", "recipient phone number (+E164 and formatting ok) or JID")
 	cmd.Flags().StringVar(&message, "message", "", "message text")
 	return cmd
 }

--- a/cmd/wacli/send_file_cmd.go
+++ b/cmd/wacli/send_file_cmd.go
@@ -64,7 +64,7 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&to, "to", "", "recipient phone number or JID")
+	cmd.Flags().StringVar(&to, "to", "", "recipient phone number (+E164 and formatting ok) or JID")
 	cmd.Flags().StringVar(&filePath, "file", "", "path to file")
 	cmd.Flags().StringVar(&filename, "filename", "", "display name for the file (defaults to basename of --file)")
 	cmd.Flags().StringVar(&caption, "caption", "", "caption (images/videos/documents)")

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/mdp/qrterminal/v3"
 	"go.mau.fi/whatsmeow"
@@ -255,7 +256,23 @@ func ParseUserOrJID(s string) (types.JID, error) {
 	if strings.Contains(s, "@") {
 		return types.ParseJID(s)
 	}
-	return types.JID{User: s, Server: types.DefaultUserServer}, nil
+
+	var digits strings.Builder
+	for _, r := range s {
+		switch {
+		case unicode.IsDigit(r):
+			digits.WriteRune(r)
+		case r == '+', r == ' ', r == '-', r == '(', r == ')', r == '.':
+			continue
+		default:
+			return types.JID{}, fmt.Errorf("invalid recipient phone number %q; use digits, optional leading +, or a full JID", s)
+		}
+	}
+	if digits.Len() == 0 {
+		return types.JID{}, fmt.Errorf("recipient phone number %q has no digits", s)
+	}
+
+	return types.JID{User: digits.String(), Server: types.DefaultUserServer}, nil
 }
 
 func IsGroupJID(jid types.JID) bool {

--- a/internal/wa/client_test.go
+++ b/internal/wa/client_test.go
@@ -7,21 +7,51 @@ import (
 )
 
 func TestParseUserOrJID(t *testing.T) {
-	j, err := ParseUserOrJID("1234567890")
-	if err != nil {
-		t.Fatalf("ParseUserOrJID: %v", err)
-	}
-	if j.Server != types.DefaultUserServer || j.User != "1234567890" {
-		t.Fatalf("unexpected jid: %+v", j)
-	}
+	t.Run("plain digits", func(t *testing.T) {
+		j, err := ParseUserOrJID("1234567890")
+		if err != nil {
+			t.Fatalf("ParseUserOrJID: %v", err)
+		}
+		if j.Server != types.DefaultUserServer || j.User != "1234567890" {
+			t.Fatalf("unexpected jid: %+v", j)
+		}
+	})
 
-	j, err = ParseUserOrJID("123@g.us")
-	if err != nil {
-		t.Fatalf("ParseUserOrJID group: %v", err)
-	}
-	if !IsGroupJID(j) {
-		t.Fatalf("expected group jid, got %+v", j)
-	}
+	t.Run("plus e164", func(t *testing.T) {
+		j, err := ParseUserOrJID("+15551234567")
+		if err != nil {
+			t.Fatalf("ParseUserOrJID plus: %v", err)
+		}
+		if j.Server != types.DefaultUserServer || j.User != "15551234567" {
+			t.Fatalf("unexpected jid: %+v", j)
+		}
+	})
+
+	t.Run("formatted phone", func(t *testing.T) {
+		j, err := ParseUserOrJID("+1 (555) 123-4567")
+		if err != nil {
+			t.Fatalf("ParseUserOrJID formatted: %v", err)
+		}
+		if j.Server != types.DefaultUserServer || j.User != "15551234567" {
+			t.Fatalf("unexpected jid: %+v", j)
+		}
+	})
+
+	t.Run("group jid", func(t *testing.T) {
+		j, err := ParseUserOrJID("123@g.us")
+		if err != nil {
+			t.Fatalf("ParseUserOrJID group: %v", err)
+		}
+		if !IsGroupJID(j) {
+			t.Fatalf("expected group jid, got %+v", j)
+		}
+	})
+
+	t.Run("invalid phone", func(t *testing.T) {
+		if _, err := ParseUserOrJID("+1-800-FLOWERS"); err == nil {
+			t.Fatalf("expected invalid phone number error")
+		}
+	})
 }
 
 func TestBestContactName(t *testing.T) {


### PR DESCRIPTION
## Summary
Normalize phone-style recipient input so common human-entered values work without requiring exact JIDs.

### Changes
- accept `+E164` input like `+15551234567`
- accept formatted phone input like `+1 (555) 123-4567`
- preserve full JIDs like `1234567890@s.whatsapp.net` and group JIDs like `123@g.us`
- return a clearer error for invalid phone-style input containing unsupported characters
- clarify accepted recipient formats in CLI help text and README

### Testing
- `go test ./internal/wa ./cmd/wacli`
- manual verification after rebuilding the binary