### PR TITLE
fix: sanitize user input in FTS5 search queries

### DIFF
--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -44,6 +44,18 @@ func (d *DB) searchLIKE(p SearchMessagesParams) ([]Message, error) {
 	return d.scanMessages(query, args...)
 }
 
+func sanitizeFTSQuery(q string) string {
+	tokens := strings.Fields(q)
+	if len(tokens) == 0 {
+		return `""`
+	}
+	quoted := make([]string, len(tokens))
+	for i, tok := range tokens {
+		quoted[i] = `"` + strings.ReplaceAll(tok, `"`, `""`) + `"`
+	}
+	return strings.Join(quoted, " ")
+}
+
 func (d *DB) searchFTS(p SearchMessagesParams) ([]Message, error) {
 	query := `
 		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''),
@@ -52,7 +64,7 @@ func (d *DB) searchFTS(p SearchMessagesParams) ([]Message, error) {
 		JOIN messages m ON messages_fts.rowid = m.rowid
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		WHERE messages_fts MATCH ?`
-	args := []interface{}{p.Query}
+	args := []interface{}{sanitizeFTSQuery(p.Query)}
 	query, args = applyMessageFilters(query, args, p)
 	query += " ORDER BY bm25(messages_fts) LIMIT ?"
 	args = append(args, p.Limit)

--- a/internal/store/search_fts_test.go
+++ b/internal/store/search_fts_test.go
@@ -7,6 +7,78 @@ import (
 	"time"
 )
 
+func TestSanitizeFTSQuery(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"hello world", `"hello" "world"`},
+		{"hello OR world", `"hello" "OR" "world"`},
+		{"NOT secret", `"NOT" "secret"`},
+		{`say "hi"`, `"say" """hi"""`},
+		{"col:value", `"col:value"`},
+		{"test*", `"test*"`},
+		{"NEAR(a b)", `"NEAR(a" "b)"`},
+		{"  spaced  ", `"spaced"`},
+	}
+	for _, tt := range tests {
+		got := sanitizeFTSQuery(tt.input)
+		if got != tt.want {
+			t.Errorf("sanitizeFTSQuery(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestFTSSearchWithSpecialCharacters(t *testing.T) {
+	db := openTestDB(t)
+	if !db.HasFTS() {
+		t.Fatalf("expected HasFTS=true in sqlite_fts5 build")
+	}
+
+	chat := "123@s.whatsapp.net"
+	if err := db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:    chat,
+		ChatName:   "Alice",
+		MsgID:      "m1",
+		SenderJID:  chat,
+		SenderName: "Alice",
+		Timestamp:  time.Now(),
+		FromMe:     false,
+		Text:       "meeting notes for project",
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	// These queries previously caused FTS5 parse errors or unexpected behavior.
+	dangerous := []string{
+		`"unclosed`,
+		`hello OR world`,
+		`NOT meeting`,
+		`col:meeting`,
+		`test*`,
+		`NEAR(meeting notes)`,
+		`meeting AND notes`,
+	}
+	for _, q := range dangerous {
+		_, err := db.SearchMessages(SearchMessagesParams{Query: q, Limit: 10})
+		if err != nil {
+			t.Errorf("SearchMessages(%q) failed: %v", q, err)
+		}
+	}
+
+	// Verify a normal search still finds the message.
+	ms, err := db.SearchMessages(SearchMessagesParams{Query: "meeting", Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchMessages: %v", err)
+	}
+	if len(ms) != 1 {
+		t.Fatalf("expected 1 result for 'meeting', got %d", len(ms))
+	}
+}
+
 func TestSearchMessagesUsesFTSWhenEnabled(t *testing.T) {
 	db := openTestDB(t)
 	if !db.HasFTS() {


### PR DESCRIPTION
## Summary

Fixes #57 — FTS5 query syntax is exposed to user input without sanitization, causing crashes and unexpected search behavior.

## Root Cause

`searchFTS()` passes raw user input directly as an FTS5 `MATCH` expression:

```go
// BEFORE (vulnerable)
WHERE messages_fts MATCH ?
// args = []interface{}{p.Query}  ← raw user input
```

FTS5 has its own query language with operators (`OR`, `AND`, `NOT`), prefix wildcards (`*`), column filters (`col:`), phrase matching (`"..."`), and proximity searches (`NEAR(...)`). User input containing any of these triggers FTS5 query parsing, not literal text matching.

**Without the fix, these user queries crash:**

| Query | Error |
|---|---|
| `"unclosed` | `unterminated string` |
| `NOT meeting` | `fts5: syntax error near "NOT"` |
| `col:meeting` | `no such column: col` |

## Fix

Added `sanitizeFTSQuery()` that wraps each whitespace-separated token in double quotes, escaping any internal `"` by doubling them (FTS5's escape convention). This forces FTS5 to treat all input as literal text:

```go
func sanitizeFTSQuery(q string) string {
    tokens := strings.Fields(q)
    if len(tokens) == 0 {
        return `""`
    }
    quoted := make([]string, len(tokens))
    for i, tok := range tokens {
        quoted[i] = `"` + strings.ReplaceAll(tok, `"`, `""`) + `"`
    }
    return strings.Join(quoted, " ")
}
```

Examples:
- `hello world` → `"hello" "world"` (literal search, implicit AND)
- `hello OR world` → `"hello" "OR" "world"` (OR treated as literal word)
- `"unclosed` → `"""unclosed"` (quote escaped, no parse error)
- `col:value` → `"col:value"` (no column filter interpretation)

## Regression Tests

### `TestFTSSearchWithSpecialCharacters`
Runs 7 previously-dangerous queries against a real FTS5 table and asserts none return errors:

**Without the fix — 3 failures:**
```
SearchMessages("\"unclosed") failed: unterminated string
SearchMessages("NOT meeting") failed: fts5: syntax error near "NOT"
SearchMessages("col:meeting") failed: no such column: col
--- FAIL: TestFTSSearchWithSpecialCharacters
```

**With the fix — all pass:**
```
--- PASS: TestFTSSearchWithSpecialCharacters (0.01s)
```

### `TestSanitizeFTSQuery`
Unit tests for the sanitization function covering operators, quotes, column filters, wildcards, NEAR, and whitespace normalization.

## Test plan

- [x] `TestSanitizeFTSQuery` — unit tests for sanitization logic
- [x] `TestFTSSearchWithSpecialCharacters` — dangerous queries no longer crash
- [x] `TestSearchMessagesUsesFTSWhenEnabled` — existing FTS search still works
- [x] Full test suite passes: `go test ./...` and `go test -tags sqlite_fts5 ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)