### PR TITLE
feat(send): resolve --to against local contacts, groups, and chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,12 @@ pnpm wacli history backfill --chat 1234567890@s.whatsapp.net --requests 10 --cou
 # Download media for a message (after syncing)
 ./wacli media download --chat 1234567890@s.whatsapp.net --id <message-id>
 
-# Send a message
+# Send a message — by JID, phone, or a name from your contacts/groups/chats
 pnpm wacli send text --to 1234567890 --message "hello"
+pnpm wacli send text --to "mom" --message "landed"
+pnpm wacli send text --to "Family" --message "on my way"
+# Ambiguous name? Pick non-interactively with --pick N:
+pnpm wacli send text --to john --pick 2 --message "hi"
 
 # Send a file
 ./wacli send file --to 1234567890 --file ./pic.jpg --caption "hi"

--- a/cmd/wacli/helpers.go
+++ b/cmd/wacli/helpers.go
@@ -13,6 +13,10 @@ func isTTY() bool {
 	return term.IsTerminal(int(os.Stdout.Fd()))
 }
 
+func isInteractive() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stderr.Fd()))
+}
+
 func parseTime(s string) (time.Time, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {

--- a/cmd/wacli/recipient.go
+++ b/cmd/wacli/recipient.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/steipete/wacli/internal/app"
+	"github.com/steipete/wacli/internal/resolve"
+	"github.com/steipete/wacli/internal/wa"
+	"go.mau.fi/whatsmeow/types"
+)
+
+type recipientOptions struct {
+	pick   int
+	asJSON bool
+}
+
+func resolveRecipient(a *app.App, input string, opts recipientOptions) (types.JID, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return types.JID{}, fmt.Errorf("--to is required")
+	}
+	if opts.pick < 0 {
+		return types.JID{}, fmt.Errorf("--pick must be a positive integer, got %d", opts.pick)
+	}
+
+	if strings.Contains(input, "@") {
+		return wa.ParseUserOrJID(input)
+	}
+
+	phoneShaped := resolve.LooksLikePhoneOrJID(input)
+
+	candidates, err := resolve.Resolve(a.DB(), input, 10)
+	if err != nil {
+		return types.JID{}, err
+	}
+
+	if phoneShaped {
+		exact := candidates[:0:0]
+		for _, c := range candidates {
+			if c.Score < resolve.ScoreExact {
+				continue
+			}
+			if c.Kind == resolve.KindChat && !strings.HasSuffix(c.JID, "@g.us") {
+				continue
+			}
+			exact = append(exact, c)
+		}
+		candidates = exact
+	}
+
+	if len(candidates) == 0 {
+		if phoneShaped {
+			return wa.ParseUserOrJID(resolve.NormalizePhone(input))
+		}
+		return types.JID{}, fmt.Errorf("no contacts, groups, or chats match %q (try `wacli contacts search` or pass a JID)", input)
+	}
+
+	if opts.pick > 0 {
+		if opts.pick > len(candidates) {
+			return types.JID{}, fmt.Errorf("--pick %d is out of range (only %d match%s for %q)", opts.pick, len(candidates), plural(len(candidates)), input)
+		}
+		return parseCandidateJID(candidates[opts.pick-1])
+	}
+
+	if len(candidates) == 1 {
+		return parseCandidateJID(candidates[0])
+	}
+
+	if opts.asJSON || !isInteractive() {
+		return types.JID{}, ambiguousError(input, candidates)
+	}
+
+	pick, err := promptCandidate(os.Stderr, os.Stdin, input, candidates)
+	if err != nil {
+		return types.JID{}, err
+	}
+	return parseCandidateJID(candidates[pick])
+}
+
+func parseCandidateJID(c resolve.Candidate) (types.JID, error) {
+	jid, err := wa.ParseUserOrJID(c.JID)
+	if err != nil {
+		return types.JID{}, fmt.Errorf("parse resolved JID %q: %w", c.JID, err)
+	}
+	return jid, nil
+}
+
+func ambiguousError(input string, candidates []resolve.Candidate) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%q matches %d recipients; pick one with --to <jid> or --pick N:\n", input, len(candidates))
+	for i, c := range candidates {
+		fmt.Fprintf(&b, "  %d) %s\n", i+1, formatCandidate(c))
+	}
+	return fmt.Errorf("%s", strings.TrimRight(b.String(), "\n"))
+}
+
+func formatCandidate(c resolve.Candidate) string {
+	name := c.Name
+	if name == "" {
+		name = c.JID
+	}
+	detail := strings.TrimSpace(c.Detail)
+	kind := string(c.Kind)
+	if detail != "" && detail != kind {
+		return fmt.Sprintf("%-30s  %-16s  [%s]  %s", name, detail, kind, c.JID)
+	}
+	return fmt.Sprintf("%-30s  %-16s  [%s]  %s", name, "", kind, c.JID)
+}
+
+func promptCandidate(w io.Writer, r io.Reader, input string, candidates []resolve.Candidate) (int, error) {
+	fmt.Fprintf(w, "%q matches %d recipients:\n", input, len(candidates))
+	for i, c := range candidates {
+		fmt.Fprintf(w, "  %d) %s\n", i+1, formatCandidate(c))
+	}
+	fmt.Fprintf(w, "Pick [1-%d] (or q to cancel): ", len(candidates))
+
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		return 0, fmt.Errorf("no selection made")
+	}
+	line := strings.TrimSpace(scanner.Text())
+	if line == "" || strings.EqualFold(line, "q") {
+		return 0, fmt.Errorf("cancelled")
+	}
+	n, err := strconv.Atoi(line)
+	if err != nil || n < 1 || n > len(candidates) {
+		return 0, fmt.Errorf("invalid selection %q", line)
+	}
+	return n - 1, nil
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "es"
+}

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steipete/wacli/internal/out"
 	"github.com/steipete/wacli/internal/store"
-	"github.com/steipete/wacli/internal/wa"
 )
 
 func newSendCmd(flags *rootFlags) *cobra.Command {
@@ -25,6 +24,7 @@ func newSendCmd(flags *rootFlags) *cobra.Command {
 func newSendTextCmd(flags *rootFlags) *cobra.Command {
 	var to string
 	var message string
+	var pick int
 
 	cmd := &cobra.Command{
 		Use:   "text",
@@ -46,12 +46,13 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 			if err := a.EnsureAuthed(); err != nil {
 				return err
 			}
-			if err := a.Connect(ctx, false, nil); err != nil {
+
+			toJID, err := resolveRecipient(a, to, recipientOptions{pick: pick, asJSON: flags.asJSON})
+			if err != nil {
 				return err
 			}
 
-			toJID, err := wa.ParseUserOrJID(to)
-			if err != nil {
+			if err := a.Connect(ctx, false, nil); err != nil {
 				return err
 			}
 
@@ -88,7 +89,8 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&to, "to", "", "recipient phone number or JID")
+	cmd.Flags().StringVar(&to, "to", "", "recipient JID, phone number, or name from your contacts/groups/chats")
 	cmd.Flags().StringVar(&message, "message", "", "message text")
+	cmd.Flags().IntVar(&pick, "pick", 0, "when --to is ambiguous, pick the Nth match (1-indexed) instead of prompting")
 	return cmd
 }

--- a/cmd/wacli/send_file_cmd.go
+++ b/cmd/wacli/send_file_cmd.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steipete/wacli/internal/out"
-	"github.com/steipete/wacli/internal/wa"
 )
 
 func newSendFileCmd(flags *rootFlags) *cobra.Command {
@@ -16,6 +15,7 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 	var filename string
 	var caption string
 	var mimeOverride string
+	var pick int
 
 	cmd := &cobra.Command{
 		Use:   "file",
@@ -37,12 +37,13 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 			if err := a.EnsureAuthed(); err != nil {
 				return err
 			}
-			if err := a.Connect(ctx, false, nil); err != nil {
+
+			toJID, err := resolveRecipient(a, to, recipientOptions{pick: pick, asJSON: flags.asJSON})
+			if err != nil {
 				return err
 			}
 
-			toJID, err := wa.ParseUserOrJID(to)
-			if err != nil {
+			if err := a.Connect(ctx, false, nil); err != nil {
 				return err
 			}
 
@@ -64,10 +65,11 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&to, "to", "", "recipient phone number or JID")
+	cmd.Flags().StringVar(&to, "to", "", "recipient JID, phone number, or name from your contacts/groups/chats")
 	cmd.Flags().StringVar(&filePath, "file", "", "path to file")
 	cmd.Flags().StringVar(&filename, "filename", "", "display name for the file (defaults to basename of --file)")
 	cmd.Flags().StringVar(&caption, "caption", "", "caption (images/videos/documents)")
 	cmd.Flags().StringVar(&mimeOverride, "mime", "", "override detected mime type")
+	cmd.Flags().IntVar(&pick, "pick", 0, "when --to is ambiguous, pick the Nth match (1-indexed) instead of prompting")
 	return cmd
 }

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -1,0 +1,228 @@
+package resolve
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/steipete/wacli/internal/store"
+)
+
+type Kind string
+
+const (
+	KindContact Kind = "contact"
+	KindGroup   Kind = "group"
+	KindChat    Kind = "chat"
+)
+
+const (
+	ScoreExact     = 100
+	scorePrefix    = 60
+	scoreWordStart = 30
+	scoreSubstring = 10
+)
+
+type Candidate struct {
+	JID    string
+	Name   string
+	Detail string
+	Kind   Kind
+	Score  int
+}
+
+type Source interface {
+	SearchContacts(query string, limit int) ([]store.Contact, error)
+	ListGroups(query string, limit int) ([]store.Group, error)
+	ListChats(query string, limit int) ([]store.Chat, error)
+}
+
+func LooksLikePhoneOrJID(input string) bool {
+	s := strings.TrimSpace(input)
+	if s == "" {
+		return false
+	}
+	if strings.Contains(s, "@") {
+		return true
+	}
+	hasDigit := false
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case r == '+' || r == '-' || r == ' ' || r == '(' || r == ')':
+		default:
+			return false
+		}
+	}
+	return hasDigit
+}
+
+func NormalizePhone(input string) string {
+	var b strings.Builder
+	for _, r := range strings.TrimSpace(input) {
+		if r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func Resolve(src Source, input string, limit int) ([]Candidate, error) {
+	q := strings.TrimSpace(input)
+	if q == "" {
+		return nil, fmt.Errorf("recipient is required")
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+
+	const perSource = math.MaxInt32
+
+	seen := make(map[string]int)
+	var out []Candidate
+
+	add := func(c Candidate) {
+		if c.JID == "" {
+			return
+		}
+		if idx, ok := seen[c.JID]; ok {
+			if c.Score > out[idx].Score || (c.Score == out[idx].Score && c.Kind == KindContact) {
+				out[idx] = c
+			}
+			return
+		}
+		seen[c.JID] = len(out)
+		out = append(out, c)
+	}
+
+	qLower := strings.ToLower(q)
+
+	contacts, err := src.SearchContacts(q, perSource)
+	if err != nil {
+		return nil, fmt.Errorf("search contacts: %w", err)
+	}
+	for _, c := range contacts {
+		display := pickContactName(c)
+		if display == "" && c.Phone == "" {
+			continue
+		}
+		score := rank(q, c.Name, c.Alias, c.Phone)
+		if score == 0 && !strings.Contains(strings.ToLower(c.JID), qLower) {
+			score = scoreSubstring
+		}
+		if score == 0 {
+			continue
+		}
+		add(Candidate{
+			JID:    c.JID,
+			Name:   display,
+			Detail: c.Phone,
+			Kind:   KindContact,
+			Score:  score,
+		})
+	}
+
+	groups, err := src.ListGroups(q, perSource)
+	if err != nil {
+		return nil, fmt.Errorf("search groups: %w", err)
+	}
+	for _, g := range groups {
+		if strings.TrimSpace(g.Name) == "" {
+			continue
+		}
+		score := rank(q, g.Name)
+		if score == 0 {
+			continue
+		}
+		add(Candidate{
+			JID:    g.JID,
+			Name:   g.Name,
+			Detail: "group",
+			Kind:   KindGroup,
+			Score:  score,
+		})
+	}
+
+	chats, err := src.ListChats(q, perSource)
+	if err != nil {
+		return nil, fmt.Errorf("search chats: %w", err)
+	}
+	for _, ch := range chats {
+		if strings.TrimSpace(ch.Name) == "" {
+			continue
+		}
+		score := rank(q, ch.Name)
+		if score == 0 {
+			continue
+		}
+		add(Candidate{
+			JID:    ch.JID,
+			Name:   ch.Name,
+			Detail: ch.Kind,
+			Kind:   KindChat,
+			Score:  score,
+		})
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
+	})
+
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func pickContactName(c store.Contact) string {
+	if s := strings.TrimSpace(c.Alias); s != "" {
+		return s
+	}
+	if s := strings.TrimSpace(c.Name); s != "" {
+		return s
+	}
+	return strings.TrimSpace(c.Phone)
+}
+
+func rank(query string, haystacks ...string) int {
+	q := strings.ToLower(strings.TrimSpace(query))
+	if q == "" {
+		return 0
+	}
+	best := 0
+	for _, h := range haystacks {
+		h = strings.ToLower(strings.TrimSpace(h))
+		if h == "" {
+			continue
+		}
+		score := 0
+		switch {
+		case h == q:
+			score = ScoreExact
+		case strings.HasPrefix(h, q):
+			score = scorePrefix
+		case hasWordPrefix(h, q):
+			score = scoreWordStart
+		case strings.Contains(h, q):
+			score = scoreSubstring
+		}
+		if score > best {
+			best = score
+		}
+	}
+	return best
+}
+
+func hasWordPrefix(h, q string) bool {
+	for _, word := range strings.Fields(h) {
+		if strings.HasPrefix(word, q) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -1,0 +1,255 @@
+package resolve
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steipete/wacli/internal/store"
+)
+
+type fakeSource struct {
+	contacts []store.Contact
+	groups   []store.Group
+	chats    []store.Chat
+}
+
+func (f *fakeSource) SearchContacts(query string, limit int) ([]store.Contact, error) {
+	q := strings.ToLower(query)
+	var out []store.Contact
+	for _, c := range f.contacts {
+		if contains(c.Name, q) || contains(c.Alias, q) || contains(c.Phone, q) || contains(c.JID, q) {
+			out = append(out, c)
+		}
+	}
+	return capN(out, limit), nil
+}
+
+func (f *fakeSource) ListGroups(query string, limit int) ([]store.Group, error) {
+	q := strings.ToLower(query)
+	var out []store.Group
+	for _, g := range f.groups {
+		if contains(g.Name, q) || contains(g.JID, q) {
+			out = append(out, g)
+		}
+	}
+	return capN(out, limit), nil
+}
+
+func (f *fakeSource) ListChats(query string, limit int) ([]store.Chat, error) {
+	q := strings.ToLower(query)
+	var out []store.Chat
+	for _, c := range f.chats {
+		if contains(c.Name, q) || contains(c.JID, q) {
+			out = append(out, c)
+		}
+	}
+	return capN(out, limit), nil
+}
+
+func contains(h, needle string) bool {
+	return needle == "" || strings.Contains(strings.ToLower(h), needle)
+}
+
+func capN[T any](xs []T, n int) []T {
+	if n > 0 && len(xs) > n {
+		return xs[:n]
+	}
+	return xs
+}
+
+func TestLooksLikePhoneOrJID(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"1234567890@s.whatsapp.net", true},
+		{"12345@g.us", true},
+		{"491701234567", true},
+		{"+49 170 1234567", true},
+		{"(415) 555-1212", true},
+		{"", false},
+		{"john", false},
+		{"John Smith", false},
+		{"mom", false},
+		{"jose-maria", false},
+		{"12a34", false},
+	}
+	for _, tc := range cases {
+		if got := LooksLikePhoneOrJID(tc.in); got != tc.want {
+			t.Errorf("LooksLikePhoneOrJID(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizePhone(t *testing.T) {
+	cases := map[string]string{
+		"+49 170 1234567": "491701234567",
+		"(415) 555-1212":  "4155551212",
+		"491701234567":    "491701234567",
+		"  ":              "",
+	}
+	for in, want := range cases {
+		if got := NormalizePhone(in); got != want {
+			t.Errorf("NormalizePhone(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestResolveExactMatchBeatsSubstring(t *testing.T) {
+	src := &fakeSource{
+		contacts: []store.Contact{
+			{JID: "1@s.whatsapp.net", Name: "Johnny Appleseed", Phone: "11111"},
+			{JID: "2@s.whatsapp.net", Name: "John", Phone: "22222"},
+			{JID: "3@s.whatsapp.net", Name: "Mary Johnson", Phone: "33333"},
+		},
+	}
+	got, err := Resolve(src, "John", 10)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(got) == 0 || got[0].JID != "2@s.whatsapp.net" {
+		t.Fatalf("expected exact match 'John' first, got %+v", got)
+	}
+}
+
+func TestResolveAliasedContactExactOnRealName(t *testing.T) {
+	src := &fakeSource{
+		contacts: []store.Contact{
+			{JID: "1@s.whatsapp.net", Name: "John Smith", Alias: "boss"},
+			{JID: "2@s.whatsapp.net", Name: "Johnny Different"},
+		},
+	}
+	got, err := Resolve(src, "John Smith", 10)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(got) == 0 || got[0].JID != "1@s.whatsapp.net" || got[0].Score != ScoreExact {
+		t.Fatalf("expected ScoreExact on real-name match, got %+v", got)
+	}
+}
+
+func TestResolvePrefersAlias(t *testing.T) {
+	src := &fakeSource{
+		contacts: []store.Contact{
+			{JID: "1@s.whatsapp.net", Name: "Mother Dearest"},
+			{JID: "2@s.whatsapp.net", Name: "Someone Else", Alias: "mom"},
+		},
+	}
+	got, err := Resolve(src, "mom", 10)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(got) == 0 || got[0].JID != "2@s.whatsapp.net" {
+		t.Fatalf("expected alias 'mom' to win, got %+v", got)
+	}
+}
+
+func TestResolveMatchesGroupsAndChats(t *testing.T) {
+	src := &fakeSource{
+		groups: []store.Group{
+			{JID: "100@g.us", Name: "Family"},
+		},
+		chats: []store.Chat{
+			{JID: "100@g.us", Name: "Family", Kind: "group"},
+			{JID: "200@s.whatsapp.net", Name: "Family Lawyer", Kind: "dm"},
+		},
+	}
+	got, err := Resolve(src, "family", 10)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(got) != 2 || got[0].Name != "Family" {
+		t.Fatalf("expected Family first and 2 unique JIDs, got %+v", got)
+	}
+}
+
+func TestResolveSubstringHitScoresBelowExact(t *testing.T) {
+	src := &fakeSource{
+		contacts: []store.Contact{
+			{JID: "1@s.whatsapp.net", Name: "Trip 2024"},
+		},
+	}
+	got, err := Resolve(src, "2024", 10)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(got) != 1 || got[0].Score >= ScoreExact {
+		t.Fatalf("expected substring hit below ScoreExact, got %+v", got)
+	}
+}
+
+func TestResolveNumericName(t *testing.T) {
+	src := &fakeSource{
+		groups: []store.Group{
+			{JID: "2024@g.us", Name: "2024"},
+		},
+	}
+	got, err := Resolve(src, "2024", 10)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(got) != 1 || got[0].JID != "2024@g.us" {
+		t.Fatalf("expected group '2024' to resolve, got %+v", got)
+	}
+}
+
+func TestResolveKeepsHiddenFieldHits(t *testing.T) {
+	src := &forcingSource{forced: []store.Contact{
+		{JID: "push@s.whatsapp.net", Name: "Unrelated Display"},
+	}}
+	got, err := Resolve(src, "qwerty", 10)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(got) != 1 || got[0].JID != "push@s.whatsapp.net" || got[0].Score == 0 {
+		t.Fatalf("expected hidden-field hit to survive with non-zero score, got %+v", got)
+	}
+}
+
+type forcingSource struct {
+	forced []store.Contact
+}
+
+func (f *forcingSource) SearchContacts(string, int) ([]store.Contact, error) {
+	return f.forced, nil
+}
+func (f *forcingSource) ListGroups(string, int) ([]store.Group, error) { return nil, nil }
+func (f *forcingSource) ListChats(string, int) ([]store.Chat, error)   { return nil, nil }
+
+func TestResolveDropsJIDOnlyMatches(t *testing.T) {
+	src := &fakeSource{
+		groups: []store.Group{
+			{JID: "123@g.us", Name: "Family"},
+			{JID: "456@g.us", Name: "Poker Night"},
+		},
+	}
+	got, err := Resolve(src, "us", 10)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected zero hits for JID-only query, got %+v", got)
+	}
+}
+
+func TestResolveEmptyInputErrors(t *testing.T) {
+	if _, err := Resolve(&fakeSource{}, "   ", 10); err == nil {
+		t.Fatal("expected error for empty query")
+	}
+}
+
+func TestResolveWordBoundary(t *testing.T) {
+	src := &fakeSource{
+		contacts: []store.Contact{
+			{JID: "1@s.whatsapp.net", Name: "John Smith"},
+			{JID: "2@s.whatsapp.net", Name: "Smithson Holdings"},
+		},
+	}
+	got, err := Resolve(src, "smith", 10)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(got) < 2 || got[0].Name != "Smithson Holdings" {
+		t.Fatalf("expected Smithson Holdings first, got %+v", got)
+	}
+}

--- a/internal/store/chats_contacts_groups.go
+++ b/internal/store/chats_contacts_groups.go
@@ -80,11 +80,17 @@ func (d *DB) SearchContacts(query string, limit int) ([]Contact, error) {
 		       c.updated_at
 		FROM contacts c
 		LEFT JOIN contact_aliases a ON a.jid = c.jid
-		WHERE LOWER(COALESCE(a.alias,'')) LIKE LOWER(?) OR LOWER(COALESCE(c.full_name,'')) LIKE LOWER(?) OR LOWER(COALESCE(c.push_name,'')) LIKE LOWER(?) OR LOWER(COALESCE(c.phone,'')) LIKE LOWER(?) OR LOWER(c.jid) LIKE LOWER(?)
+		WHERE LOWER(COALESCE(a.alias,'')) LIKE LOWER(?)
+		   OR LOWER(COALESCE(c.full_name,'')) LIKE LOWER(?)
+		   OR LOWER(COALESCE(c.push_name,'')) LIKE LOWER(?)
+		   OR LOWER(COALESCE(c.business_name,'')) LIKE LOWER(?)
+		   OR LOWER(COALESCE(c.first_name,'')) LIKE LOWER(?)
+		   OR LOWER(COALESCE(c.phone,'')) LIKE LOWER(?)
+		   OR LOWER(c.jid) LIKE LOWER(?)
 		ORDER BY COALESCE(NULLIF(a.alias,''), NULLIF(c.full_name,''), NULLIF(c.push_name,''), c.jid)
 		LIMIT ?`
 	needle := "%" + query + "%"
-	rows, err := d.sql.Query(q, needle, needle, needle, needle, needle, limit)
+	rows, err := d.sql.Query(q, needle, needle, needle, needle, needle, needle, needle, limit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

`wacli send text`/`send file` only accepted a raw phone number or a full JID, so anyone wanting to message someone had to run `wacli chats list | grep` to copy a JID every time. This PR adds a fuzzy name resolver built on top of the existing local store so that `--to "mom"`, `--to "John Smith"`, or `--to "Family"` just works. JID and phone inputs are unchanged.

```bash
wacli send text --to mom --message "landed"
wacli send text --to "John Smith" --message hi
wacli send text --to Family --message "on my way"
wacli send text --to john --pick 2 --message hi        # scriptable disambiguation
wacli send text --to "+49 170 1234567" --message hi    # phone path unchanged
wacli send text --to 1234567890@s.whatsapp.net ...     # JID path unchanged
```

## Resolution order

1. Input contains `@` → parsed directly as a JID (no DB lookup).
2. **Phone-shaped** input (digits, `+`, spaces, dashes, parens) → take the raw-number path unless the local store holds an *authoritative exact* match (contact name, alias, group name, or group-kind chat row). DM chat rows with numeric display names are ignored so they can't hijack a raw number — this keeps `--to 2024` safe from e.g. a chat titled `Trip 2024`.
3. **Name-shaped** input → ranked fuzzy search of contacts, aliases, groups, and chats: exact > prefix > word-start > substring.

## UX

- One match → send immediately.
- Multiple matches → numbered picker when both `stdin` and `stderr` are terminals (redirecting `stdout` still works; the prompt uses `stderr`).
- `--json` mode, non-interactive sessions, or `--pick N` skip the prompt: either select the Nth match or return a structured "ambiguous" error that lists every candidate, so scripts can parse it.
- Negative `--pick` values are rejected up front; zero stays "unset".
- No match on a name-shaped input → clean error pointing at `wacli contacts search` and the JID escape hatch.
- `EnsureAuthed()` still runs before resolution so unauthenticated users see `run \`wacli auth\`` rather than a misleading "no match".

## Ranking notes

- Contacts are scored against the canonical name, alias, and phone directly, so an aliased contact still wins on its real name.
- `SearchContacts` now also `LIKE`s on `business_name` and `first_name` so business contacts and first-name-only entries are reachable.
- A DB hit explainable only by a hidden field (`push_name`, `business_name`, `first_name`) falls back to the substring score — unless the query is itself a substring of the JID, which would be noise (e.g. `us` matching every `@g.us`).
- Groups and chats have no hidden textual fields, so a zero visible rank means the query matched only the JID and the row is dropped.
- The resolver fetches every match the store returns before ranking, so an older but exactly-named chat can't be truncated away behind newer substring hits (`ListChats` orders by recency).

## Files

- `internal/resolve/` — new package, pure-Go ranked resolver with a small `Source` interface and unit tests. No new dependencies.
- `cmd/wacli/recipient.go` — CLI wrapper, picker, policy glue.
- `cmd/wacli/helpers.go` — new `isInteractive()` that checks stdin+stderr.
- `cmd/wacli/send.go`, `cmd/wacli/send_file_cmd.go` — flag wiring, help text, `--pick`.
- `internal/store/chats_contacts_groups.go` — expanded `SearchContacts` `WHERE` clause.
- `README.md` — usage snippet.

838 insertions, 13 deletions. No changes to the existing JID/phone code path.

## Test plan

- [x] `go build -tags sqlite_fts5 ./...`
- [x] `go vet -tags sqlite_fts5 ./...`
- [x] `go test -tags sqlite_fts5 ./...` — all packages green.
- [x] New unit tests in `internal/resolve/resolve_test.go` covering: phone/JID detection, phone normalization, ranking precedence, alias vs real-name scoring, numeric group names, DB hits on hidden fields, JID-only noise filtering (`us` → `@g.us`), `Trip 2024` regression, word-boundary matching, empty-input validation.
- [x] Manual end-to-end against a seeded store: JID passthrough, `--to mom` alias exact, `--to john` ambiguous picker, `--to zzz` clean no-match, `+49 170 1234567` phone normalization, `--to 2024` group exact.
- [ ] Interactive picker on a real TTY (the seeded manual run verified the non-TTY / `--json` path; a reviewer on a terminal can confirm the prompt UX).