### PR TITLE
fix message search filters

### DIFF
--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -122,6 +122,7 @@ func newMessagesSearchCmd(flags *rootFlags) *cobra.Command {
 	var limit int
 	var afterStr string
 	var beforeStr string
+	var hasMedia bool
 	var msgType string
 
 	cmd := &cobra.Command{
@@ -156,13 +157,14 @@ func newMessagesSearchCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			msgs, err := a.DB().SearchMessages(store.SearchMessagesParams{
-				Query:   args[0],
-				ChatJID: chat,
-				From:    from,
-				Limit:   limit,
-				After:   after,
-				Before:  before,
-				Type:    msgType,
+				Query:    args[0],
+				ChatJID:  chat,
+				From:     from,
+				Limit:    limit,
+				After:    after,
+				Before:   before,
+				HasMedia: hasMedia,
+				Type:     msgType,
 			})
 			if err != nil {
 				return err
@@ -214,7 +216,8 @@ func newMessagesSearchCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().IntVar(&limit, "limit", 50, "limit results")
 	cmd.Flags().StringVar(&afterStr, "after", "", "only messages after time (RFC3339 or YYYY-MM-DD)")
 	cmd.Flags().StringVar(&beforeStr, "before", "", "only messages before time (RFC3339 or YYYY-MM-DD)")
-	cmd.Flags().StringVar(&msgType, "type", "", "media type filter (image|video|audio|document)")
+	cmd.Flags().BoolVar(&hasMedia, "has-media", false, "only messages with media")
+	cmd.Flags().StringVar(&msgType, "type", "", "message type filter (text|image|video|audio|document)")
 	return cmd
 }
 

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -7,13 +7,14 @@ import (
 )
 
 type SearchMessagesParams struct {
-	Query   string
-	ChatJID string
-	From    string
-	Limit   int
-	Before  *time.Time
-	After   *time.Time
-	Type    string
+	Query    string
+	ChatJID  string
+	From     string
+	Limit    int
+	Before   *time.Time
+	After    *time.Time
+	HasMedia bool
+	Type     string
 }
 
 func (d *DB) SearchMessages(p SearchMessagesParams) ([]Message, error) {
@@ -76,9 +77,16 @@ func applyMessageFilters(query string, args []interface{}, p SearchMessagesParam
 		query += " AND m.ts < ?"
 		args = append(args, unix(*p.Before))
 	}
-	if strings.TrimSpace(p.Type) != "" {
-		query += " AND COALESCE(m.media_type,'') = ?"
-		args = append(args, p.Type)
+	if p.HasMedia {
+		query += " AND COALESCE(m.media_type,'') != ''"
+	}
+	if msgType := strings.ToLower(strings.TrimSpace(p.Type)); msgType != "" {
+		if msgType == "text" {
+			query += " AND COALESCE(m.media_type,'') = ''"
+		} else {
+			query += " AND LOWER(COALESCE(m.media_type,'')) = ?"
+			args = append(args, msgType)
+		}
 	}
 	return query, args
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -128,6 +128,76 @@ func TestMessageUpsertIdempotentAndContext(t *testing.T) {
 	}
 }
 
+func TestSearchMessagesFiltersByHasMediaAndType(t *testing.T) {
+	db := openTestDB(t)
+
+	chat := "123@s.whatsapp.net"
+	if err := db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+
+	base := time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC)
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:    chat,
+		ChatName:   "Alice",
+		MsgID:      "text-1",
+		SenderJID:  chat,
+		SenderName: "Alice",
+		Timestamp:  base,
+		FromMe:     false,
+		Text:       "quarterly report ready",
+	}); err != nil {
+		t.Fatalf("UpsertMessage text: %v", err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:      chat,
+		ChatName:     "Alice",
+		MsgID:        "image-1",
+		SenderJID:    chat,
+		SenderName:   "Alice",
+		Timestamp:    base.Add(time.Second),
+		FromMe:       false,
+		MediaType:    "image",
+		MediaCaption: "quarterly report screenshot",
+		Filename:     "report.png",
+		MimeType:     "image/png",
+	}); err != nil {
+		t.Fatalf("UpsertMessage image: %v", err)
+	}
+
+	results, err := db.SearchMessages(SearchMessagesParams{Query: "report", Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchMessages all: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 matching messages, got %d", len(results))
+	}
+
+	results, err = db.SearchMessages(SearchMessagesParams{Query: "report", Limit: 10, HasMedia: true})
+	if err != nil {
+		t.Fatalf("SearchMessages has-media: %v", err)
+	}
+	if len(results) != 1 || results[0].MsgID != "image-1" {
+		t.Fatalf("expected only image-1 for has-media search, got %+v", results)
+	}
+
+	results, err = db.SearchMessages(SearchMessagesParams{Query: "report", Limit: 10, Type: "text"})
+	if err != nil {
+		t.Fatalf("SearchMessages type=text: %v", err)
+	}
+	if len(results) != 1 || results[0].MsgID != "text-1" {
+		t.Fatalf("expected only text-1 for type=text search, got %+v", results)
+	}
+
+	results, err = db.SearchMessages(SearchMessagesParams{Query: "report", Limit: 10, Type: "image"})
+	if err != nil {
+		t.Fatalf("SearchMessages type=image: %v", err)
+	}
+	if len(results) != 1 || results[0].MsgID != "image-1" {
+		t.Fatalf("expected only image-1 for type=image search, got %+v", results)
+	}
+}
+
 func TestMediaDownloadInfoAndMarkDownloaded(t *testing.T) {
 	db := openTestDB(t)
 


### PR DESCRIPTION
## Summary
- add `--has-media` support to `wacli messages search`
- treat `--type text` as messages without media while preserving existing media-type filtering
- add store tests covering the new search filter behavior