### PR TITLE
feat: add `send react` command for message reactions

### DIFF
--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -19,6 +19,7 @@ func newSendCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.AddCommand(newSendTextCmd(flags))
 	cmd.AddCommand(newSendFileCmd(flags))
+	cmd.AddCommand(newSendReactCmd(flags))
 	return cmd
 }
 

--- a/cmd/wacli/send_react.go
+++ b/cmd/wacli/send_react.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/steipete/wacli/internal/app"
+	"github.com/steipete/wacli/internal/store"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func sendReact(ctx context.Context, a interface {
+	WA() app.WAClient
+	DB() *store.DB
+}, chatJID types.JID, messageID, emoji string) (string, error) {
+	resp, err := a.WA().SendReaction(ctx, chatJID, messageID, emoji)
+	if err != nil {
+		return "", err
+	}
+
+	now := time.Now().UTC()
+	chatName := a.WA().ResolveChatName(ctx, chatJID, "")
+	kind := chatKindFromJID(chatJID)
+	_ = a.DB().UpsertChat(chatJID.String(), kind, chatName, now)
+
+	text := emoji
+	if text == "" {
+		text = "[reaction removed]"
+	}
+	_ = a.DB().UpsertMessage(store.UpsertMessageParams{
+		ChatJID:    chatJID.String(),
+		ChatName:   chatName,
+		MsgID:      string(resp.ID),
+		SenderJID:  "",
+		SenderName: "me",
+		Timestamp:  now,
+		FromMe:     true,
+		Text:       text,
+	})
+
+	return string(resp.ID), nil
+}

--- a/cmd/wacli/send_react_cmd.go
+++ b/cmd/wacli/send_react_cmd.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/steipete/wacli/internal/out"
+	"github.com/steipete/wacli/internal/wa"
+)
+
+func newSendReactCmd(flags *rootFlags) *cobra.Command {
+	var to string
+	var messageID string
+	var emoji string
+
+	cmd := &cobra.Command{
+		Use:   "react",
+		Short: "Send a reaction to a message (or remove one with empty emoji)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if to == "" || messageID == "" {
+				return fmt.Errorf("--to and --id are required")
+			}
+			if !cmd.Flags().Changed("emoji") {
+				return fmt.Errorf("--emoji is required (use empty string to remove a reaction)")
+			}
+
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+
+			toJID, err := wa.ParseUserOrJID(to)
+			if err != nil {
+				return err
+			}
+
+			msgID, err := sendReact(ctx, a, toJID, messageID, emoji)
+			if err != nil {
+				return err
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"sent":       true,
+					"to":         toJID.String(),
+					"id":         msgID,
+					"target_id":  messageID,
+					"emoji":      emoji,
+				})
+			}
+			if emoji == "" {
+				fmt.Fprintf(os.Stdout, "Removed reaction on %s in %s (id %s)\n", messageID, toJID.String(), msgID)
+			} else {
+				fmt.Fprintf(os.Stdout, "Reacted %s on %s in %s (id %s)\n", emoji, messageID, toJID.String(), msgID)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&to, "to", "", "recipient phone number or JID (chat where the target message is)")
+	cmd.Flags().StringVar(&messageID, "id", "", "message ID to react to")
+	cmd.Flags().StringVar(&emoji, "emoji", "", "reaction emoji (empty string to remove)")
+	return cmd
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -39,6 +39,7 @@ type WAClient interface {
 
 	SendText(ctx context.Context, to types.JID, text string) (types.MessageID, error)
 	SendProtoMessage(ctx context.Context, to types.JID, msg *waProto.Message) (types.MessageID, error)
+	SendReaction(ctx context.Context, chatJID types.JID, targetMsgID string, emoji string) (whatsmeow.SendResponse, error)
 	Upload(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error)
 	DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error)
 
@@ -64,7 +65,7 @@ func New(opts Options) (*App, error) {
 	if opts.StoreDir == "" {
 		return nil, fmt.Errorf("store dir is required")
 	}
-	if err := os.MkdirAll(opts.StoreDir, 0700); err != nil {
+	if err := os.MkdirAll(opts.StoreDir, 0o700); err != nil {
 		return nil, fmt.Errorf("create store dir: %w", err)
 	}
 

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -212,6 +212,10 @@ func (f *fakeWA) SendProtoMessage(ctx context.Context, to types.JID, msg *waProt
 	return types.MessageID("msgid"), nil
 }
 
+func (f *fakeWA) SendReaction(ctx context.Context, chatJID types.JID, targetMsgID string, emoji string) (whatsmeow.SendResponse, error) {
+	return whatsmeow.SendResponse{ID: types.MessageID("reactid")}, nil
+}
+
 func (f *fakeWA) Upload(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error) {
 	return whatsmeow.UploadResponse{}, nil
 }

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -197,6 +197,30 @@ func (c *Client) SendProtoMessage(ctx context.Context, to types.JID, msg *waProt
 	return resp.ID, nil
 }
 
+func (c *Client) SendReaction(ctx context.Context, chatJID types.JID, targetMsgID string, emoji string) (whatsmeow.SendResponse, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return whatsmeow.SendResponse{}, fmt.Errorf("not connected")
+	}
+
+	remoteJID := chatJID.String()
+	msg := &waProto.Message{
+		ReactionMessage: &waProto.ReactionMessage{
+			Key: &waProto.MessageKey{
+				RemoteJID: &remoteJID,
+				ID:        &targetMsgID,
+			},
+			Text:              &emoji,
+			SenderTimestampMS: ptrInt64(time.Now().UnixMilli()),
+		},
+	}
+	return cli.SendMessage(ctx, chatJID, msg)
+}
+
+func ptrInt64(v int64) *int64 { return &v }
+
 func (c *Client) Upload(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error) {
 	c.mu.Lock()
 	cli := c.client


### PR DESCRIPTION
## Summary

Closes #42.

- Add `wacli send react --to <jid> --id <msg-id> --emoji <emoji>` command
- Pass empty `--emoji ""` to remove a reaction
- Stores the reaction in the local DB via `UpsertMessage`
- Supports `--json` output

## Changes

- `internal/app/app.go` — Added `SendReaction()` to `WAClient` interface
- `internal/wa/client.go` — Implemented `SendReaction()` using `waProto.ReactionMessage`
- `cmd/wacli/send_react.go` — Business logic (send + store in DB)
- `cmd/wacli/send_react_cmd.go` — Cobra command with `--to`, `--id`, `--emoji` flags
- `cmd/wacli/send.go` — Registered in send command group
- `internal/app/fake_wa_test.go` — Test double updated

## Usage

```bash
# React to a message with thumbs up
wacli send react --to 1234567890 --id ABC123 --emoji "👍"

# Remove a reaction
wacli send react --to 1234567890 --id ABC123 --emoji ""
```

## Test plan

- [x] `go build -tags sqlite_fts5 ./cmd/wacli` compiles
- [x] `go test ./...` — all tests pass
- [x] go.mod/go.sum unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)