### PR TITLE
feat: filter out left groups from `groups list`

### DIFF
--- a/cmd/wacli/groups_info_rename.go
+++ b/cmd/wacli/groups_info_rename.go
@@ -146,6 +146,7 @@ func newGroupsLeaveCmd(flags *rootFlags) *cobra.Command {
 			if err := a.WA().LeaveGroup(ctx, gjid); err != nil {
 				return err
 			}
+			_ = a.DB().MarkGroupLeft(gjid.String())
 			if flags.asJSON {
 				return out.WriteJSON(os.Stdout, map[string]any{"jid": gjid.String(), "left": true})
 			}

--- a/cmd/wacli/groups_refresh_list.go
+++ b/cmd/wacli/groups_refresh_list.go
@@ -57,6 +57,7 @@ func newGroupsRefreshCmd(flags *rootFlags) *cobra.Command {
 func newGroupsListCmd(flags *rootFlags) *cobra.Command {
 	var query string
 	var limit int
+	var includeLeft bool
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List known groups (from local DB; run sync to populate)",
@@ -70,7 +71,7 @@ func newGroupsListCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			gs, err := a.DB().ListGroups(query, limit)
+			gs, err := a.DB().ListGroups(query, limit, includeLeft)
 			if err != nil {
 				return err
 			}
@@ -93,5 +94,6 @@ func newGroupsListCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&query, "query", "", "search query")
 	cmd.Flags().IntVar(&limit, "limit", 50, "limit")
+	cmd.Flags().BoolVar(&includeLeft, "include-left", false, "include groups you have left")
 	return cmd
 }

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -34,13 +34,28 @@ func (a *App) refreshGroups(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Build set of currently joined group JIDs.
+	joinedSet := make(map[string]bool, len(groups))
 	now := time.Now().UTC()
 	for _, g := range groups {
 		if g == nil {
 			continue
 		}
+		joinedSet[g.JID.String()] = true
 		_ = a.db.UpsertGroup(g.JID.String(), g.GroupName.Name, g.OwnerJID.String(), g.GroupCreated)
 		_ = a.db.UpsertChat(g.JID.String(), "group", g.GroupName.Name, now)
 	}
+
+	// Mark groups in DB that are no longer joined as left.
+	allGroups, err := a.db.ListGroups("", 0, true)
+	if err == nil {
+		for _, g := range allGroups {
+			if !joinedSet[g.JID] {
+				_ = a.db.MarkGroupLeft(g.JID)
+			}
+		}
+	}
+
 	return nil
 }

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -50,7 +50,7 @@ func TestRefreshGroupsStoresGroupsAndChats(t *testing.T) {
 	if err := a.refreshGroups(context.Background()); err != nil {
 		t.Fatalf("refreshGroups: %v", err)
 	}
-	gs, err := a.db.ListGroups("MyGroup", 10)
+	gs, err := a.db.ListGroups("MyGroup", 10, false)
 	if err != nil {
 		t.Fatalf("ListGroups: %v", err)
 	}

--- a/internal/store/chats_contacts_groups.go
+++ b/internal/store/chats_contacts_groups.go
@@ -214,9 +214,6 @@ func (d *DB) ReplaceGroupParticipants(groupJID string, participants []GroupParti
 }
 
 func (d *DB) ListGroups(query string, limit int, includeLeft bool) ([]Group, error) {
-	if limit <= 0 {
-		limit = 50
-	}
 	q := `SELECT jid, COALESCE(name,''), COALESCE(owner_jid,''), COALESCE(created_ts,0), updated_at FROM groups WHERE 1=1`
 	var args []interface{}
 	if !includeLeft {
@@ -227,8 +224,11 @@ func (d *DB) ListGroups(query string, limit int, includeLeft bool) ([]Group, err
 		q += ` AND (LOWER(name) LIKE LOWER(?) OR LOWER(jid) LIKE LOWER(?))`
 		args = append(args, needle, needle)
 	}
-	q += ` ORDER BY COALESCE(created_ts,0) DESC LIMIT ?`
-	args = append(args, limit)
+	q += ` ORDER BY COALESCE(created_ts,0) DESC`
+	if limit > 0 {
+		q += ` LIMIT ?`
+		args = append(args, limit)
+	}
 
 	rows, err := d.sql.Query(q, args...)
 	if err != nil {

--- a/internal/store/chats_contacts_groups.go
+++ b/internal/store/chats_contacts_groups.go
@@ -162,14 +162,21 @@ func (d *DB) UpsertContact(jid, phone, pushName, fullName, firstName, businessNa
 func (d *DB) UpsertGroup(jid, name, ownerJID string, created time.Time) error {
 	now := time.Now().UTC().Unix()
 	_, err := d.sql.Exec(`
-		INSERT INTO groups(jid, name, owner_jid, created_ts, updated_at)
-		VALUES (?, ?, ?, ?, ?)
+		INSERT INTO groups(jid, name, owner_jid, created_ts, updated_at, left_at)
+		VALUES (?, ?, ?, ?, ?, NULL)
 		ON CONFLICT(jid) DO UPDATE SET
 			name=COALESCE(NULLIF(excluded.name,''), groups.name),
 			owner_jid=COALESCE(NULLIF(excluded.owner_jid,''), groups.owner_jid),
 			created_ts=COALESCE(NULLIF(excluded.created_ts,0), groups.created_ts),
-			updated_at=excluded.updated_at
+			updated_at=excluded.updated_at,
+			left_at=NULL
 	`, jid, name, ownerJID, unix(created), now)
+	return err
+}
+
+func (d *DB) MarkGroupLeft(jid string) error {
+	now := time.Now().UTC().Unix()
+	_, err := d.sql.Exec(`UPDATE groups SET left_at = ? WHERE jid = ? AND left_at IS NULL`, now, jid)
 	return err
 }
 
@@ -206,12 +213,15 @@ func (d *DB) ReplaceGroupParticipants(groupJID string, participants []GroupParti
 	return tx.Commit()
 }
 
-func (d *DB) ListGroups(query string, limit int) ([]Group, error) {
+func (d *DB) ListGroups(query string, limit int, includeLeft bool) ([]Group, error) {
 	if limit <= 0 {
 		limit = 50
 	}
 	q := `SELECT jid, COALESCE(name,''), COALESCE(owner_jid,''), COALESCE(created_ts,0), updated_at FROM groups WHERE 1=1`
 	var args []interface{}
+	if !includeLeft {
+		q += ` AND left_at IS NULL`
+	}
 	if strings.TrimSpace(query) != "" {
 		needle := "%" + query + "%"
 		q += ` AND (LOWER(name) LIKE LOWER(?) OR LOWER(jid) LIKE LOWER(?))`

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -18,6 +18,7 @@ var schemaMigrations = []migration{
 	{version: 1, name: "core schema", up: migrateCoreSchema},
 	{version: 2, name: "messages display_text column", up: migrateMessagesDisplayText},
 	{version: 3, name: "messages fts", up: migrateMessagesFTS},
+	{version: 4, name: "groups left_at column", up: migrateGroupsLeftAt},
 }
 
 func (d *DB) ensureSchema() error {
@@ -247,6 +248,20 @@ func migrateMessagesFTS(d *DB) error {
 	}
 
 	d.ftsEnabled = true
+	return nil
+}
+
+func migrateGroupsLeftAt(d *DB) error {
+	hasLeftAt, err := d.tableHasColumn("groups", "left_at")
+	if err != nil {
+		return err
+	}
+	if hasLeftAt {
+		return nil
+	}
+	if _, err := d.sql.Exec(`ALTER TABLE groups ADD COLUMN left_at INTEGER`); err != nil {
+		return fmt.Errorf("add left_at column: %w", err)
+	}
 	return nil
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -305,7 +305,7 @@ func TestGroupsUpsertListAndParticipantsReplace(t *testing.T) {
 		t.Fatalf("ReplaceGroupParticipants: %v", err)
 	}
 
-	gs, err := db.ListGroups("Gro", 10)
+	gs, err := db.ListGroups("Gro", 10, false)
 	if err != nil {
 		t.Fatalf("ListGroups: %v", err)
 	}


### PR DESCRIPTION
## Summary

Closes #23.

Groups the user has left are now excluded from `groups list` by default. A new `--include-left` flag shows all groups including left ones.

## Changes

- **Migration 4**: Adds `left_at INTEGER` column to `groups` table (idempotent)
- **`UpsertGroup()`**: Resets `left_at=NULL` on upsert (group is active if we see it)
- **`MarkGroupLeft(jid)`**: Sets `left_at` to current Unix timestamp
- **`ListGroups(query, limit, includeLeft)`**: Filters `WHERE left_at IS NULL` when `includeLeft=false`
- **`refreshGroups()`**: After fetching joined groups from WhatsApp, marks any DB-only groups as left
- **`groups leave`**: Marks the group as left in DB after successful leave
- **`groups list --include-left`**: New flag (default: false)

## Usage

```bash
# List only active groups (default)
wacli groups list

# Include groups you've left
wacli groups list --include-left
```

## Test plan

- [x] `go build -tags sqlite_fts5 ./cmd/wacli` compiles
- [x] `go test -tags sqlite_fts5 ./...` — all tests pass
- [x] go.mod/go.sum unchanged
- [x] Migration is idempotent (checks column existence before ALTER)

🤖 Generated with [Claude Code](https://claude.com/claude-code)