### PR TITLE
fix: restrict file permissions on databases and sensitive files

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,8 +1,39 @@
 package app
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
+
+func TestStoreDirPermissions(t *testing.T) {
+	parent := t.TempDir()
+	storeDir := filepath.Join(parent, "wacli-store")
+
+	a, err := New(Options{StoreDir: storeDir})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer a.Close()
+
+	info, err := os.Stat(storeDir)
+	if err != nil {
+		t.Fatalf("Stat store dir: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("expected store dir permissions 0700, got %04o", perm)
+	}
+
+	// The wacli.db file inside should be 0600.
+	dbPath := filepath.Join(storeDir, "wacli.db")
+	dbInfo, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("Stat wacli.db: %v", err)
+	}
+	if perm := dbInfo.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("expected wacli.db permissions 0600, got %04o", perm)
+	}
+}
 
 func newTestApp(t *testing.T) *App {
 	t.Helper()

--- a/internal/app/media.go
+++ b/internal/app/media.go
@@ -129,7 +129,7 @@ func (a *App) downloadMediaJob(ctx context.Context, job mediaJob) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(targetPath), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
 		return err
 	}
 

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -15,11 +15,11 @@ type Lock struct {
 }
 
 func Acquire(storeDir string) (*Lock, error) {
-	if err := os.MkdirAll(storeDir, 0700); err != nil {
+	if err := os.MkdirAll(storeDir, 0o700); err != nil {
 		return nil, fmt.Errorf("create store dir: %w", err)
 	}
 	path := filepath.Join(storeDir, "LOCK")
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open lock file: %w", err)
 	}

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -35,12 +35,17 @@ func Open(path string) (*DB, error) {
 		return nil, err
 	}
 
-	// Ensure the DB file is owner-only regardless of umask.
+	// Ensure the DB file and WAL/SHM sidecars are owner-only regardless of umask.
 	// Must run after init() because sql.Open is lazy; the file is not
 	// created until the first query (PRAGMAs in init).
-	if err := os.Chmod(path, 0o600); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("chmod db file: %w", err)
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		p := path + suffix
+		if _, statErr := os.Stat(p); statErr == nil {
+			if err := os.Chmod(p, 0o600); err != nil {
+				_ = db.Close()
+				return nil, fmt.Errorf("chmod %s: %w", filepath.Base(p), err)
+			}
+		}
 	}
 
 	return s, nil

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -34,6 +34,15 @@ func Open(path string) (*DB, error) {
 		_ = db.Close()
 		return nil, err
 	}
+
+	// Ensure the DB file is owner-only regardless of umask.
+	// Must run after init() because sql.Open is lazy; the file is not
+	// created until the first query (PRAGMAs in init).
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("chmod db file: %w", err)
+	}
+
 	return s, nil
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -27,6 +28,42 @@ func countRows(t *testing.T, db *sql.DB, q string, args ...any) int {
 		t.Fatalf("countRows scan: %v", err)
 	}
 	return n
+}
+
+func TestDBFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "perm-test.db")
+
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat db file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("expected db file permissions 0600, got %04o", perm)
+	}
+
+	// Verify a sub-directory created by Open uses 0700.
+	subDir := filepath.Join(dir, "sub")
+	subPath := filepath.Join(subDir, "nested.db")
+	db2, err := Open(subPath)
+	if err != nil {
+		t.Fatalf("Open nested: %v", err)
+	}
+	defer db2.Close()
+
+	subInfo, err := os.Stat(subDir)
+	if err != nil {
+		t.Fatalf("Stat sub dir: %v", err)
+	}
+	if perm := subInfo.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("expected sub dir permissions 0700, got %04o", perm)
+	}
 }
 
 func TestUpsertChatNameAndLastMessageTS(t *testing.T) {

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -51,9 +52,14 @@ func (c *Client) init() error {
 		return fmt.Errorf("open whatsmeow store: %w", err)
 	}
 
-	// Ensure session DB file is owner-only regardless of umask.
-	if err := os.Chmod(c.opts.StorePath, 0o600); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("chmod session db: %w", err)
+	// Ensure session DB file and WAL/SHM sidecars are owner-only regardless of umask.
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		p := c.opts.StorePath + suffix
+		if _, statErr := os.Stat(p); statErr == nil {
+			if err := os.Chmod(p, 0o600); err != nil {
+				return fmt.Errorf("chmod %s: %w", filepath.Base(p), err)
+			}
+		}
 	}
 
 	deviceStore, err := container.GetFirstDevice(ctx)

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -51,6 +51,11 @@ func (c *Client) init() error {
 		return fmt.Errorf("open whatsmeow store: %w", err)
 	}
 
+	// Ensure session DB file is owner-only regardless of umask.
+	if err := os.Chmod(c.opts.StorePath, 0o600); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("chmod session db: %w", err)
+	}
+
 	deviceStore, err := container.GetFirstDevice(ctx)
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/internal/wa/media.go
+++ b/internal/wa/media.go
@@ -43,7 +43,7 @@ func (c *Client) DownloadMediaToFile(ctx context.Context, directPath string, enc
 		return 0, err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(targetPath), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
 		return 0, fmt.Errorf("create output dir: %w", err)
 	}
 
@@ -76,6 +76,9 @@ func (c *Client) DownloadMediaToFile(ctx context.Context, directPath string, enc
 	}
 	if err := os.Rename(tmpName, targetPath); err != nil {
 		return 0, fmt.Errorf("move media file: %w", err)
+	}
+	if err := os.Chmod(targetPath, 0o600); err != nil {
+		return 0, fmt.Errorf("chmod media file: %w", err)
 	}
 	success = true
 


### PR DESCRIPTION
## Summary

Closes #50.

Ensures all database files, session data, and downloaded media are created with restricted permissions — not world-readable.

## Changes

- **`internal/store/db.go`** — `os.Chmod(path, 0o600)` after DB init (wacli.db)
- **`internal/wa/client.go`** — `os.Chmod(storePath, 0o600)` after session.db creation
- **`internal/wa/media.go`** — `os.Chmod(targetPath, 0o600)` on downloaded media files; standardized dir perms to `0o700`
- **`internal/lock/lock.go`** — Standardized octal notation (`0700` → `0o700`, `0600` → `0o600`)
- **`internal/app/media.go`** — Standardized octal notation for media dir

## Permission model

| Resource | Permission | Rationale |
|----------|-----------|-----------|
| Store directory (`~/.wacli/`) | `0o700` | Only owner can list contents |
| Database files (`.db`) | `0o600` | Contains messages, session keys |
| Lock file | `0o600` | Contains PID |
| Downloaded media | `0o600` | User's private media |
| Media directories | `0o700` | Only owner can traverse |

## Tests added

- `TestDBFilePermissions` — verifies DB files are `0o600` and subdirs are `0o700`
- `TestStoreDirPermissions` — verifies store dir is `0o700` and wacli.db is `0o600`

## Test plan

- [x] `go build -tags sqlite_fts5 ./cmd/wacli` compiles
- [x] `go test -tags sqlite_fts5 ./...` — all tests pass
- [x] go.mod/go.sum unchanged
- [x] No functional behavior change — only permission hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)