### PR TITLE
[fix] bounded-backpressure media queue for sync

### DIFF
--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/steipete/wacli/internal/wa"
@@ -31,6 +32,7 @@ type fakeWA struct {
 
 	onDemandHistory func(lastKnown types.MessageInfo, count int) *events.HistorySync
 	downloadDelay   time.Duration
+	downloadCount   atomic.Int64
 }
 
 func newFakeWA() *fakeWA {
@@ -222,6 +224,7 @@ func (f *fakeWA) DecryptReaction(ctx context.Context, reaction *events.Message) 
 }
 
 func (f *fakeWA) DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error) {
+	f.downloadCount.Add(1)
 	if f.downloadDelay > 0 {
 		select {
 		case <-time.After(f.downloadDelay):

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -30,6 +30,7 @@ type fakeWA struct {
 	groups   map[types.JID]*types.GroupInfo
 
 	onDemandHistory func(lastKnown types.MessageInfo, count int) *events.HistorySync
+	downloadDelay   time.Duration
 }
 
 func newFakeWA() *fakeWA {
@@ -221,6 +222,13 @@ func (f *fakeWA) DecryptReaction(ctx context.Context, reaction *events.Message) 
 }
 
 func (f *fakeWA) DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error) {
+	if f.downloadDelay > 0 {
+		select {
+		case <-time.After(f.downloadDelay):
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
+	}
 	if err := os.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
 		return 0, err
 	}

--- a/internal/app/media.go
+++ b/internal/app/media.go
@@ -81,7 +81,6 @@ func (a *App) runMediaWorkers(ctx context.Context, jobs <-chan mediaJob, workers
 		return func() {}, nil
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
 	var wg sync.WaitGroup
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
@@ -104,7 +103,6 @@ func (a *App) runMediaWorkers(ctx context.Context, jobs <-chan mediaJob, workers
 	}
 
 	stop := func() {
-		cancel()
 		wg.Wait()
 	}
 	return stop, nil

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -68,13 +68,9 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 			select {
 			case mediaJobs <- mediaJob{chatJID: chatJID, msgID: msgID}:
 			default:
-				// Avoid blocking the event handler.
-				go func() {
-					select {
-					case mediaJobs <- mediaJob{chatJID: chatJID, msgID: msgID}:
-					case <-ctx.Done():
-					}
-				}()
+				// Drop the job rather than spawning an unbounded goroutine.
+				// Media can still be downloaded later via `wacli media download`.
+				fmt.Fprintf(os.Stderr, "\rmedia queue full, skipping download for %s/%s\n", chatJID, msgID)
 			}
 		}
 	}

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -67,10 +67,7 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 			}
 			select {
 			case mediaJobs <- mediaJob{chatJID: chatJID, msgID: msgID}:
-			default:
-				// Drop the job rather than spawning an unbounded goroutine.
-				// Media can still be downloaded later via `wacli media download`.
-				fmt.Fprintf(os.Stderr, "\rmedia queue full, skipping download for %s/%s\n", chatJID, msgID)
+			case <-ctx.Done():
 			}
 		}
 	}
@@ -138,10 +135,6 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 	})
 	defer a.wa.RemoveEventHandler(handlerID)
 
-	if err := a.Connect(ctx, opts.AllowQR, opts.OnQRCode); err != nil {
-		return SyncResult{}, err
-	}
-
 	if opts.DownloadMedia {
 		var err error
 		stopMedia, err = a.runMediaWorkers(ctx, mediaJobs, 4)
@@ -149,6 +142,10 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 			return SyncResult{}, err
 		}
 		defer stopMedia()
+	}
+
+	if err := a.Connect(ctx, opts.AllowQR, opts.OnQRCode); err != nil {
+		return SyncResult{}, err
 	}
 
 	// Optional: bootstrap imports (helps contacts/groups management without waiting for events).

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -58,16 +58,19 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 
 	var stopMedia func()
 	var mediaJobs chan mediaJob
+	mediaCtx := ctx
+	mediaCancel := func() {}
 	enqueueMedia := func(chatJID, msgID string) {}
 	if opts.DownloadMedia {
 		mediaJobs = make(chan mediaJob, 512)
+		mediaCtx, mediaCancel = context.WithCancel(ctx)
 		enqueueMedia = func(chatJID, msgID string) {
 			if strings.TrimSpace(chatJID) == "" || strings.TrimSpace(msgID) == "" {
 				return
 			}
 			select {
 			case mediaJobs <- mediaJob{chatJID: chatJID, msgID: msgID}:
-			case <-ctx.Done():
+			case <-mediaCtx.Done():
 			}
 		}
 	}
@@ -133,15 +136,20 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 			}
 		}
 	})
-	defer a.wa.RemoveEventHandler(handlerID)
+	defer func() {
+		a.wa.RemoveEventHandler(handlerID)
+		mediaCancel()
+		if stopMedia != nil {
+			stopMedia()
+		}
+	}()
 
 	if opts.DownloadMedia {
 		var err error
-		stopMedia, err = a.runMediaWorkers(ctx, mediaJobs, 4)
+		stopMedia, err = a.runMediaWorkers(mediaCtx, mediaJobs, 4)
 		if err != nil {
 			return SyncResult{}, err
 		}
-		defer stopMedia()
 	}
 
 	if err := a.Connect(ctx, opts.AllowQR, opts.OnQRCode); err != nil {

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -296,7 +296,7 @@ func TestSyncMediaEnqueueHandlesOverflow(t *testing.T) {
 		AfterConnect: func(_ context.Context) error {
 			deadline := time.Now().Add(10 * time.Second)
 			for time.Now().Before(deadline) {
-				if int(f.downloadCount.Load()) == totalJobs {
+				if f.downloadCount.Load() >= int64(totalJobs) {
 					goroutinesDuring = runtime.NumGoroutine()
 					cancel()
 					return nil

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -232,6 +234,81 @@ func TestSyncStoresDisplayText(t *testing.T) {
 	}
 	if msg.DisplayText != "Reacted 👍 to hello" {
 		t.Fatalf("unexpected reaction display text: %q", msg.DisplayText)
+	}
+}
+
+func TestSyncMediaEnqueueDropsOverflow(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	// Slow downloads so workers can't drain the channel during event processing.
+	f.downloadDelay = 5 * time.Second
+
+	chat := types.JID{User: "123", Server: types.DefaultUserServer}
+	f.contacts[chat.ToNonAD()] = types.ContactInfo{
+		Found:    true,
+		FullName: "Alice",
+		PushName: "Alice",
+	}
+
+	// Create 600 media messages — more than the 512 channel buffer.
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	var msgs []interface{}
+	for i := 0; i < 600; i++ {
+		msgs = append(msgs, &events.Message{
+			Info: types.MessageInfo{
+				MessageSource: types.MessageSource{
+					Chat:     chat,
+					Sender:   chat,
+					IsFromMe: false,
+					IsGroup:  false,
+				},
+				ID:        fmt.Sprintf("m-%d", i),
+				Timestamp: base.Add(time.Duration(i) * time.Second),
+				PushName:  "Alice",
+			},
+			Message: &waProto.Message{
+				ImageMessage: &waProto.ImageMessage{
+					Mimetype:      proto.String("image/jpeg"),
+					DirectPath:    proto.String("/direct"),
+					MediaKey:      []byte{1},
+					FileSHA256:    []byte{2},
+					FileEncSHA256: []byte{3},
+					FileLength:    proto.Uint64(10),
+				},
+			},
+		})
+	}
+	f.connectEvents = msgs
+
+	goroutinesBefore := runtime.NumGoroutine()
+	var goroutinesDuring int
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	_, err := a.Sync(ctx, SyncOptions{
+		Mode:          SyncModeFollow,
+		AllowQR:       false,
+		DownloadMedia: true,
+		AfterConnect: func(_ context.Context) error {
+			// All 600 events have been emitted by now. With slow workers,
+			// the 512-slot channel is full and overflow goroutines are blocked.
+			goroutinesDuring = runtime.NumGoroutine()
+			cancel()
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	// Before the fix, overflow media jobs spawned ~88 blocked goroutines
+	// (600 messages - 512 channel slots). With the fix, overflow is dropped.
+	leaked := goroutinesDuring - goroutinesBefore
+	if leaked > 20 {
+		t.Fatalf("goroutine leak: %d new goroutines during sync with 600 media messages (before=%d, during=%d)",
+			leaked, goroutinesBefore, goroutinesDuring)
 	}
 }
 

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -237,13 +237,14 @@ func TestSyncStoresDisplayText(t *testing.T) {
 	}
 }
 
-func TestSyncMediaEnqueueDropsOverflow(t *testing.T) {
+func TestSyncMediaEnqueueHandlesOverflow(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()
 	a.wa = f
 
-	// Slow downloads so workers can't drain the channel during event processing.
-	f.downloadDelay = 5 * time.Second
+	// Slow downloads so the media queue fills, but not so slow that the test
+	// takes an unreasonable amount of time to finish once backpressure kicks in.
+	f.downloadDelay = 20 * time.Millisecond
 
 	chat := types.JID{User: "123", Server: types.DefaultUserServer}
 	f.contacts[chat.ToNonAD()] = types.ContactInfo{
@@ -286,25 +287,32 @@ func TestSyncMediaEnqueueDropsOverflow(t *testing.T) {
 	var goroutinesDuring int
 
 	ctx, cancel := context.WithCancel(context.Background())
+	totalJobs := len(msgs)
 
 	_, err := a.Sync(ctx, SyncOptions{
 		Mode:          SyncModeFollow,
 		AllowQR:       false,
 		DownloadMedia: true,
 		AfterConnect: func(_ context.Context) error {
-			// All 600 events have been emitted by now. With slow workers,
-			// the 512-slot channel is full and overflow goroutines are blocked.
+			deadline := time.Now().Add(10 * time.Second)
+			for time.Now().Before(deadline) {
+				if int(f.downloadCount.Load()) == totalJobs {
+					goroutinesDuring = runtime.NumGoroutine()
+					cancel()
+					return nil
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
 			goroutinesDuring = runtime.NumGoroutine()
 			cancel()
-			return nil
+			return fmt.Errorf("expected %d media downloads, got %d", totalJobs, f.downloadCount.Load())
 		},
 	})
 	if err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
 
-	// Before the fix, overflow media jobs spawned ~88 blocked goroutines
-	// (600 messages - 512 channel slots). With the fix, overflow is dropped.
+	// The queue should be backpressured, not leak goroutines or drop media jobs.
 	leaked := goroutinesDuring - goroutinesBefore
 	if leaked > 20 {
 		t.Fatalf("goroutine leak: %d new goroutines during sync with 600 media messages (before=%d, during=%d)",


### PR DESCRIPTION
This supersedes and fixes the remaining gaps in #121.

The change tightens the media sync path with bounded backpressure so downloads do not pile up unboundedly during sync. That keeps the queue under control while still allowing media to flow through as capacity becomes available.

Summary:
- bound the media queue instead of letting sync enqueue without limit
- preserve sync progress while preventing runaway in-flight media work
- cover the behavior in tests so the queue pressure stays observable

Root cause: the previous flow could accumulate too much media work during sync, which made the queue grow beyond what the consumer path could drain promptly.
