### PR TITLE
fix: mark left groups beyond the default list window

### DIFF
--- a/cmd/wacli/groups_info_rename.go
+++ b/cmd/wacli/groups_info_rename.go
@@ -146,6 +146,7 @@ func newGroupsLeaveCmd(flags *rootFlags) *cobra.Command {
 			if err := a.WA().LeaveGroup(ctx, gjid); err != nil {
 				return err
 			}
+			_ = a.DB().MarkGroupLeft(gjid.String())
 			if flags.asJSON {
 				return out.WriteJSON(os.Stdout, map[string]any{"jid": gjid.String(), "left": true})
 			}

--- a/cmd/wacli/groups_info_rename.go
+++ b/cmd/wacli/groups_info_rename.go
@@ -12,6 +12,21 @@ import (
 	"go.mau.fi/whatsmeow/types"
 )
 
+type groupLeaveWA interface {
+	LeaveGroup(ctx context.Context, group types.JID) error
+}
+
+type groupLeaveDB interface {
+	MarkGroupLeft(jid string) error
+}
+
+func leaveGroup(ctx context.Context, wa groupLeaveWA, db groupLeaveDB, gjid types.JID) error {
+	if err := wa.LeaveGroup(ctx, gjid); err != nil {
+		return err
+	}
+	return db.MarkGroupLeft(gjid.String())
+}
+
 func newGroupsInfoCmd(flags *rootFlags) *cobra.Command {
 	var jidStr string
 	cmd := &cobra.Command{
@@ -143,10 +158,9 @@ func newGroupsLeaveCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := a.WA().LeaveGroup(ctx, gjid); err != nil {
+			if err := leaveGroup(ctx, a.WA(), a.DB(), gjid); err != nil {
 				return err
 			}
-			_ = a.DB().MarkGroupLeft(gjid.String())
 			if flags.asJSON {
 				return out.WriteJSON(os.Stdout, map[string]any{"jid": gjid.String(), "left": true})
 			}

--- a/cmd/wacli/groups_info_rename_test.go
+++ b/cmd/wacli/groups_info_rename_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+type leaveGroupWAStub struct {
+	err    error
+	called bool
+}
+
+func (f *leaveGroupWAStub) LeaveGroup(ctx context.Context, group types.JID) error {
+	f.called = true
+	return f.err
+}
+
+type leaveGroupDBStub struct {
+	err    error
+	called bool
+	jid    string
+}
+
+func (f *leaveGroupDBStub) MarkGroupLeft(jid string) error {
+	f.called = true
+	f.jid = jid
+	return f.err
+}
+
+func TestLeaveGroupReturnsMarkGroupLeftError(t *testing.T) {
+	wa := &leaveGroupWAStub{}
+	db := &leaveGroupDBStub{err: errors.New("mark failed")}
+	jid, err := types.ParseJID("12345@g.us")
+	if err != nil {
+		t.Fatalf("ParseJID: %v", err)
+	}
+
+	got := leaveGroup(context.Background(), wa, db, jid)
+	if !errors.Is(got, db.err) {
+		t.Fatalf("expected mark error, got %v", got)
+	}
+	if !wa.called {
+		t.Fatalf("expected LeaveGroup to be called")
+	}
+	if !db.called {
+		t.Fatalf("expected MarkGroupLeft to be called")
+	}
+	if db.jid != jid.String() {
+		t.Fatalf("expected jid %q, got %q", jid.String(), db.jid)
+	}
+}

--- a/cmd/wacli/groups_refresh_list.go
+++ b/cmd/wacli/groups_refresh_list.go
@@ -57,6 +57,7 @@ func newGroupsRefreshCmd(flags *rootFlags) *cobra.Command {
 func newGroupsListCmd(flags *rootFlags) *cobra.Command {
 	var query string
 	var limit int
+	var includeLeft bool
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List known groups (from local DB; run sync to populate)",
@@ -70,7 +71,7 @@ func newGroupsListCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			gs, err := a.DB().ListGroups(query, limit)
+			gs, err := a.DB().ListGroups(query, limit, includeLeft)
 			if err != nil {
 				return err
 			}
@@ -93,5 +94,6 @@ func newGroupsListCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&query, "query", "", "search query")
 	cmd.Flags().IntVar(&limit, "limit", 50, "limit")
+	cmd.Flags().BoolVar(&includeLeft, "include-left", false, "include groups you have left")
 	return cmd
 }

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -34,13 +34,28 @@ func (a *App) refreshGroups(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Build set of currently joined group JIDs.
+	joinedSet := make(map[string]bool, len(groups))
 	now := time.Now().UTC()
 	for _, g := range groups {
 		if g == nil {
 			continue
 		}
+		joinedSet[g.JID.String()] = true
 		_ = a.db.UpsertGroup(g.JID.String(), g.GroupName.Name, g.OwnerJID.String(), g.GroupCreated)
 		_ = a.db.UpsertChat(g.JID.String(), "group", g.GroupName.Name, now)
 	}
+
+	// Mark groups in DB that are no longer joined as left.
+	allGroups, err := a.db.ListGroups("", 0, true)
+	if err == nil {
+		for _, g := range allGroups {
+			if !joinedSet[g.JID] {
+				_ = a.db.MarkGroupLeft(g.JID)
+			}
+		}
+	}
+
 	return nil
 }

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -3,6 +3,8 @@ package app
 import (
 	"context"
 	"time"
+
+	"github.com/steipete/wacli/internal/store"
 )
 
 func (a *App) refreshContacts(ctx context.Context) error {
@@ -30,7 +32,18 @@ func (a *App) refreshGroups(ctx context.Context) error {
 	if err := a.OpenWA(); err != nil {
 		return err
 	}
-	groups, err := a.wa.GetJoinedGroups(ctx)
+	return refreshGroups(ctx, a.wa, a.db)
+}
+
+type groupsStore interface {
+	UpsertGroup(jid, name, ownerJID string, created time.Time) error
+	UpsertChat(jid, kind, name string, lastTS time.Time) error
+	ListGroups(query string, limit int, includeLeft bool) ([]store.Group, error)
+	MarkGroupLeft(jid string) error
+}
+
+func refreshGroups(ctx context.Context, wa WAClient, db groupsStore) error {
+	groups, err := wa.GetJoinedGroups(ctx)
 	if err != nil {
 		return err
 	}
@@ -43,16 +56,19 @@ func (a *App) refreshGroups(ctx context.Context) error {
 			continue
 		}
 		joinedSet[g.JID.String()] = true
-		_ = a.db.UpsertGroup(g.JID.String(), g.GroupName.Name, g.OwnerJID.String(), g.GroupCreated)
-		_ = a.db.UpsertChat(g.JID.String(), "group", g.GroupName.Name, now)
+		_ = db.UpsertGroup(g.JID.String(), g.GroupName.Name, g.OwnerJID.String(), g.GroupCreated)
+		_ = db.UpsertChat(g.JID.String(), "group", g.GroupName.Name, now)
 	}
 
 	// Mark groups in DB that are no longer joined as left.
-	allGroups, err := a.db.ListGroups("", 0, true)
-	if err == nil {
-		for _, g := range allGroups {
-			if !joinedSet[g.JID] {
-				_ = a.db.MarkGroupLeft(g.JID)
+	allGroups, err := db.ListGroups("", 0, true)
+	if err != nil {
+		return err
+	}
+	for _, g := range allGroups {
+		if !joinedSet[g.JID] {
+			if err := db.MarkGroupLeft(g.JID); err != nil {
+				return err
 			}
 		}
 	}

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -50,7 +50,7 @@ func TestRefreshGroupsStoresGroupsAndChats(t *testing.T) {
 	if err := a.refreshGroups(context.Background()); err != nil {
 		t.Fatalf("refreshGroups: %v", err)
 	}
-	gs, err := a.db.ListGroups("MyGroup", 10)
+	gs, err := a.db.ListGroups("MyGroup", 10, false)
 	if err != nil {
 		t.Fatalf("ListGroups: %v", err)
 	}

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -2,12 +2,42 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/steipete/wacli/internal/store"
 	"go.mau.fi/whatsmeow/types"
 )
+
+type failingGroupsStore struct {
+	listErr error
+	markErr error
+
+	listGroups []store.Group
+	marked     []string
+}
+
+func (f *failingGroupsStore) UpsertGroup(jid, name, ownerJID string, created time.Time) error {
+	return nil
+}
+
+func (f *failingGroupsStore) UpsertChat(jid, kind, name string, lastTS time.Time) error {
+	return nil
+}
+
+func (f *failingGroupsStore) ListGroups(query string, limit int, includeLeft bool) ([]store.Group, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return append([]store.Group(nil), f.listGroups...), nil
+}
+
+func (f *failingGroupsStore) MarkGroupLeft(jid string) error {
+	f.marked = append(f.marked, jid)
+	return f.markErr
+}
 
 func TestRefreshContactsStoresContacts(t *testing.T) {
 	a := newTestApp(t)
@@ -109,5 +139,35 @@ func TestRefreshGroupsMarksMissingOlderGroupsLeft(t *testing.T) {
 	}
 	if all[len(all)-1].JID != "00000@g.us" {
 		t.Fatalf("expected oldest group to remain queryable, got %q", all[len(all)-1].JID)
+	}
+}
+
+func TestRefreshGroupsReturnsListGroupsError(t *testing.T) {
+	f := newFakeWA()
+	db := &failingGroupsStore{listErr: errors.New("list groups failed")}
+	f.groups[types.JID{User: "12345", Server: types.GroupServer}] = &types.GroupInfo{
+		JID:       types.JID{User: "12345", Server: types.GroupServer},
+		GroupName: types.GroupName{Name: "MyGroup"},
+	}
+
+	err := refreshGroups(context.Background(), f, db)
+	if !errors.Is(err, db.listErr) {
+		t.Fatalf("expected list error, got %v", err)
+	}
+}
+
+func TestRefreshGroupsReturnsMarkGroupLeftError(t *testing.T) {
+	f := newFakeWA()
+	db := &failingGroupsStore{
+		listGroups: []store.Group{{JID: "00000@g.us", Name: "Old Group"}},
+		markErr:    errors.New("mark group left failed"),
+	}
+
+	err := refreshGroups(context.Background(), f, db)
+	if !errors.Is(err, db.markErr) {
+		t.Fatalf("expected mark left error, got %v", err)
+	}
+	if len(db.marked) != 1 || db.marked[0] != "00000@g.us" {
+		t.Fatalf("expected mark left to be attempted for 00000@g.us, got %+v", db.marked)
 	}
 }

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -63,5 +64,50 @@ func TestRefreshGroupsStoresGroupsAndChats(t *testing.T) {
 	}
 	if c.Kind != "group" {
 		t.Fatalf("expected chat kind group, got %q", c.Kind)
+	}
+}
+
+func TestRefreshGroupsMarksMissingOlderGroupsLeft(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 55; i++ {
+		gid := types.JID{User: fmt.Sprintf("%05d", i), Server: types.GroupServer}
+		created := base.Add(time.Duration(i) * time.Minute)
+		if err := a.db.UpsertGroup(gid.String(), fmt.Sprintf("Group %02d", i), "", created); err != nil {
+			t.Fatalf("seed UpsertGroup(%d): %v", i, err)
+		}
+		if i != 0 {
+			f.groups[gid] = &types.GroupInfo{
+				JID:          gid,
+				GroupName:    types.GroupName{Name: fmt.Sprintf("Group %02d", i)},
+				GroupCreated: created,
+			}
+		}
+	}
+
+	if err := a.refreshGroups(context.Background()); err != nil {
+		t.Fatalf("refreshGroups: %v", err)
+	}
+
+	active, err := a.db.ListGroups("", 0, false)
+	if err != nil {
+		t.Fatalf("ListGroups active: %v", err)
+	}
+	if len(active) != 54 {
+		t.Fatalf("expected 54 active groups after marking one left, got %d", len(active))
+	}
+
+	all, err := a.db.ListGroups("", 0, true)
+	if err != nil {
+		t.Fatalf("ListGroups all: %v", err)
+	}
+	if len(all) != 55 {
+		t.Fatalf("expected 55 total groups including left ones, got %d", len(all))
+	}
+	if all[len(all)-1].JID != "00000@g.us" {
+		t.Fatalf("expected oldest group to remain queryable, got %q", all[len(all)-1].JID)
 	}
 }

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -160,7 +160,9 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 		_ = a.refreshContacts(ctx)
 	}
 	if opts.RefreshGroups {
-		_ = a.refreshGroups(ctx)
+		if err := a.refreshGroups(ctx); err != nil {
+			return SyncResult{MessagesStored: messagesStored.Load()}, err
+		}
 	}
 	if opts.AfterConnect != nil {
 		if err := opts.AfterConnect(ctx); err != nil {

--- a/internal/store/chats_contacts_groups.go
+++ b/internal/store/chats_contacts_groups.go
@@ -214,9 +214,6 @@ func (d *DB) ReplaceGroupParticipants(groupJID string, participants []GroupParti
 }
 
 func (d *DB) ListGroups(query string, limit int, includeLeft bool) ([]Group, error) {
-	if limit <= 0 {
-		limit = 50
-	}
 	q := `SELECT jid, COALESCE(name,''), COALESCE(owner_jid,''), COALESCE(created_ts,0), updated_at FROM groups WHERE 1=1`
 	var args []interface{}
 	if !includeLeft {
@@ -227,8 +224,11 @@ func (d *DB) ListGroups(query string, limit int, includeLeft bool) ([]Group, err
 		q += ` AND (LOWER(name) LIKE LOWER(?) OR LOWER(jid) LIKE LOWER(?))`
 		args = append(args, needle, needle)
 	}
-	q += ` ORDER BY COALESCE(created_ts,0) DESC LIMIT ?`
-	args = append(args, limit)
+	q += ` ORDER BY COALESCE(created_ts,0) DESC`
+	if limit > 0 {
+		q += ` LIMIT ?`
+		args = append(args, limit)
+	}
 
 	rows, err := d.sql.Query(q, args...)
 	if err != nil {

--- a/internal/store/chats_contacts_groups.go
+++ b/internal/store/chats_contacts_groups.go
@@ -162,14 +162,21 @@ func (d *DB) UpsertContact(jid, phone, pushName, fullName, firstName, businessNa
 func (d *DB) UpsertGroup(jid, name, ownerJID string, created time.Time) error {
 	now := time.Now().UTC().Unix()
 	_, err := d.sql.Exec(`
-		INSERT INTO groups(jid, name, owner_jid, created_ts, updated_at)
-		VALUES (?, ?, ?, ?, ?)
+		INSERT INTO groups(jid, name, owner_jid, created_ts, updated_at, left_at)
+		VALUES (?, ?, ?, ?, ?, NULL)
 		ON CONFLICT(jid) DO UPDATE SET
 			name=COALESCE(NULLIF(excluded.name,''), groups.name),
 			owner_jid=COALESCE(NULLIF(excluded.owner_jid,''), groups.owner_jid),
 			created_ts=COALESCE(NULLIF(excluded.created_ts,0), groups.created_ts),
-			updated_at=excluded.updated_at
+			updated_at=excluded.updated_at,
+			left_at=NULL
 	`, jid, name, ownerJID, unix(created), now)
+	return err
+}
+
+func (d *DB) MarkGroupLeft(jid string) error {
+	now := time.Now().UTC().Unix()
+	_, err := d.sql.Exec(`UPDATE groups SET left_at = ? WHERE jid = ? AND left_at IS NULL`, now, jid)
 	return err
 }
 
@@ -206,12 +213,15 @@ func (d *DB) ReplaceGroupParticipants(groupJID string, participants []GroupParti
 	return tx.Commit()
 }
 
-func (d *DB) ListGroups(query string, limit int) ([]Group, error) {
+func (d *DB) ListGroups(query string, limit int, includeLeft bool) ([]Group, error) {
 	if limit <= 0 {
 		limit = 50
 	}
 	q := `SELECT jid, COALESCE(name,''), COALESCE(owner_jid,''), COALESCE(created_ts,0), updated_at FROM groups WHERE 1=1`
 	var args []interface{}
+	if !includeLeft {
+		q += ` AND left_at IS NULL`
+	}
 	if strings.TrimSpace(query) != "" {
 		needle := "%" + query + "%"
 		q += ` AND (LOWER(name) LIKE LOWER(?) OR LOWER(jid) LIKE LOWER(?))`

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -18,6 +18,7 @@ var schemaMigrations = []migration{
 	{version: 1, name: "core schema", up: migrateCoreSchema},
 	{version: 2, name: "messages display_text column", up: migrateMessagesDisplayText},
 	{version: 3, name: "messages fts", up: migrateMessagesFTS},
+	{version: 4, name: "groups left_at column", up: migrateGroupsLeftAt},
 }
 
 func (d *DB) ensureSchema() error {
@@ -247,6 +248,20 @@ func migrateMessagesFTS(d *DB) error {
 	}
 
 	d.ftsEnabled = true
+	return nil
+}
+
+func migrateGroupsLeftAt(d *DB) error {
+	hasLeftAt, err := d.tableHasColumn("groups", "left_at")
+	if err != nil {
+		return err
+	}
+	if hasLeftAt {
+		return nil
+	}
+	if _, err := d.sql.Exec(`ALTER TABLE groups ADD COLUMN left_at INTEGER`); err != nil {
+		return fmt.Errorf("add left_at column: %w", err)
+	}
 	return nil
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -305,7 +305,7 @@ func TestGroupsUpsertListAndParticipantsReplace(t *testing.T) {
 		t.Fatalf("ReplaceGroupParticipants: %v", err)
 	}
 
-	gs, err := db.ListGroups("Gro", 10)
+	gs, err := db.ListGroups("Gro", 10, false)
 	if err != nil {
 		t.Fatalf("ListGroups: %v", err)
 	}


### PR DESCRIPTION
This supersedes and fixes the gaps in #125.\n\nThe original change handled the left-group state for the groups returned by the default list window, but it did not cover groups beyond that window. This branch removes the hard 50-item cap in the group listing path used by refresh, so older groups can still be discovered and marked left instead of disappearing from the active set.\n\nValidation:\n- refreshGroups now has coverage for a missing-group case beyond the first 50 groups\n- ListGroups no longer forces a default limit when callers pass 0, so refresh can examine the full set when needed