### PR TITLE
fix: harden sqlite sidecar permissions

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,8 +1,39 @@
 package app
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
+
+func TestStoreDirPermissions(t *testing.T) {
+	parent := t.TempDir()
+	storeDir := filepath.Join(parent, "wacli-store")
+
+	a, err := New(Options{StoreDir: storeDir})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer a.Close()
+
+	info, err := os.Stat(storeDir)
+	if err != nil {
+		t.Fatalf("Stat store dir: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("expected store dir permissions 0700, got %04o", perm)
+	}
+
+	// The wacli.db file inside should be 0600.
+	dbPath := filepath.Join(storeDir, "wacli.db")
+	dbInfo, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("Stat wacli.db: %v", err)
+	}
+	if perm := dbInfo.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("expected wacli.db permissions 0600, got %04o", perm)
+	}
+}
 
 func newTestApp(t *testing.T) *App {
 	t.Helper()

--- a/internal/app/media.go
+++ b/internal/app/media.go
@@ -129,7 +129,7 @@ func (a *App) downloadMediaJob(ctx context.Context, job mediaJob) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(targetPath), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
 		return err
 	}
 

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -15,11 +15,11 @@ type Lock struct {
 }
 
 func Acquire(storeDir string) (*Lock, error) {
-	if err := os.MkdirAll(storeDir, 0700); err != nil {
+	if err := os.MkdirAll(storeDir, 0o700); err != nil {
 		return nil, fmt.Errorf("create store dir: %w", err)
 	}
 	path := filepath.Join(storeDir, "LOCK")
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open lock file: %w", err)
 	}

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -35,12 +35,12 @@ func Open(path string) (*DB, error) {
 		return nil, err
 	}
 
-	// Ensure the DB file is owner-only regardless of umask.
+	// Ensure SQLite artifacts are owner-only regardless of umask.
 	// Must run after init() because sql.Open is lazy; the file is not
 	// created until the first query (PRAGMAs in init).
-	if err := os.Chmod(path, 0o600); err != nil {
+	if err := chmodSQLiteArtifacts(path); err != nil {
 		_ = db.Close()
-		return nil, fmt.Errorf("chmod db file: %w", err)
+		return nil, err
 	}
 
 	return s, nil
@@ -61,4 +61,14 @@ func (d *DB) init() error {
 	_, _ = d.sql.Exec("PRAGMA foreign_keys=ON;")
 
 	return d.ensureSchema()
+}
+
+func chmodSQLiteArtifacts(path string) error {
+	for _, suffix := range []string{"", "-wal", "-shm", "-journal"} {
+		target := path + suffix
+		if err := os.Chmod(target, 0o600); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("chmod db file: %w", err)
+		}
+	}
+	return nil
 }

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -10,6 +10,8 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
+var chmodFile = os.Chmod
+
 type DB struct {
 	path       string
 	sql        *sql.DB
@@ -66,8 +68,8 @@ func (d *DB) init() error {
 func chmodSQLiteArtifacts(path string) error {
 	for _, suffix := range []string{"", "-wal", "-shm", "-journal"} {
 		target := path + suffix
-		if err := os.Chmod(target, 0o600); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("chmod db file: %w", err)
+		if err := chmodFile(target, 0o600); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("chmod %s: %w", target, err)
 		}
 	}
 	return nil

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -34,6 +34,15 @@ func Open(path string) (*DB, error) {
 		_ = db.Close()
 		return nil, err
 	}
+
+	// Ensure the DB file is owner-only regardless of umask.
+	// Must run after init() because sql.Open is lazy; the file is not
+	// created until the first query (PRAGMAs in init).
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("chmod db file: %w", err)
+	}
+
 	return s, nil
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -27,6 +28,42 @@ func countRows(t *testing.T, db *sql.DB, q string, args ...any) int {
 		t.Fatalf("countRows scan: %v", err)
 	}
 	return n
+}
+
+func TestDBFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "perm-test.db")
+
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat db file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("expected db file permissions 0600, got %04o", perm)
+	}
+
+	// Verify a sub-directory created by Open uses 0700.
+	subDir := filepath.Join(dir, "sub")
+	subPath := filepath.Join(subDir, "nested.db")
+	db2, err := Open(subPath)
+	if err != nil {
+		t.Fatalf("Open nested: %v", err)
+	}
+	defer db2.Close()
+
+	subInfo, err := os.Stat(subDir)
+	if err != nil {
+		t.Fatalf("Stat sub dir: %v", err)
+	}
+	if perm := subInfo.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("expected sub dir permissions 0700, got %04o", perm)
+	}
 }
 
 func TestUpsertChatNameAndLastMessageTS(t *testing.T) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -40,12 +40,30 @@ func TestDBFilePermissions(t *testing.T) {
 	}
 	defer db.Close()
 
+	if err := db.UpsertChat("123@s.whatsapp.net", "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("Stat db file: %v", err)
 	}
 	if perm := info.Mode().Perm(); perm != 0o600 {
 		t.Fatalf("expected db file permissions 0600, got %04o", perm)
+	}
+
+	for _, suffix := range []string{"-wal", "-shm", "-journal"} {
+		sidecar := path + suffix
+		info, err := os.Stat(sidecar)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			t.Fatalf("Stat %s: %v", sidecar, err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("expected %s permissions 0600, got %04o", sidecar, perm)
+		}
 	}
 
 	// Verify a sub-directory created by Open uses 0700.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,8 +2,10 @@ package store
 
 import (
 	"database/sql"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -81,6 +83,27 @@ func TestDBFilePermissions(t *testing.T) {
 	}
 	if perm := subInfo.Mode().Perm(); perm != 0o700 {
 		t.Fatalf("expected sub dir permissions 0700, got %04o", perm)
+	}
+}
+
+func TestChmodSQLiteArtifactsIncludesTargetPath(t *testing.T) {
+	orig := chmodFile
+	t.Cleanup(func() { chmodFile = orig })
+
+	want := filepath.Join(t.TempDir(), "db.sqlite-wal")
+	chmodFile = func(target string, mode os.FileMode) error {
+		if target == want {
+			return errors.New("boom")
+		}
+		return nil
+	}
+
+	err := chmodSQLiteArtifacts(strings.TrimSuffix(want, "-wal"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected error to include target path %q, got %v", want, err)
 	}
 }
 

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/mdp/qrterminal/v3"
 	"go.mau.fi/whatsmeow"
 	waProto "go.mau.fi/whatsmeow/binary/proto"
@@ -17,6 +18,8 @@ import (
 	"go.mau.fi/whatsmeow/types/events"
 	waLog "go.mau.fi/whatsmeow/util/log"
 )
+
+var chmodFile = os.Chmod
 
 type Options struct {
 	StorePath string
@@ -51,11 +54,6 @@ func (c *Client) init() error {
 		return fmt.Errorf("open whatsmeow store: %w", err)
 	}
 
-	// Ensure session DB file is owner-only regardless of umask.
-	if err := os.Chmod(c.opts.StorePath, 0o600); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("chmod session db: %w", err)
-	}
-
 	deviceStore, err := container.GetFirstDevice(ctx)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -65,8 +63,25 @@ func (c *Client) init() error {
 		}
 	}
 
+	// Ensure session DB artifacts are owner-only regardless of umask.
+	// Must run after GetFirstDevice/NewDevice because sqlstore is lazy and the
+	// file is not guaranteed to exist until the first DB touch.
+	if err := chmodSQLiteArtifacts(c.opts.StorePath); err != nil {
+		return fmt.Errorf("chmod session db: %w", err)
+	}
+
 	logger := waLog.Stdout("Client", "ERROR", true)
 	c.client = whatsmeow.NewClient(deviceStore, logger)
+	return nil
+}
+
+func chmodSQLiteArtifacts(path string) error {
+	for _, suffix := range []string{"", "-wal", "-shm", "-journal"} {
+		target := path + suffix
+		if err := chmodFile(target, 0o600); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("chmod %s: %w", target, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -51,6 +51,11 @@ func (c *Client) init() error {
 		return fmt.Errorf("open whatsmeow store: %w", err)
 	}
 
+	// Ensure session DB file is owner-only regardless of umask.
+	if err := os.Chmod(c.opts.StorePath, 0o600); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("chmod session db: %w", err)
+	}
+
 	deviceStore, err := container.GetFirstDevice(ctx)
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/internal/wa/client_test.go
+++ b/internal/wa/client_test.go
@@ -1,6 +1,8 @@
 package wa
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"go.mau.fi/whatsmeow/types"
@@ -39,5 +41,49 @@ func TestBestContactName(t *testing.T) {
 	}
 	if BestContactName(types.ContactInfo{Found: true, PushName: "Push"}) != "Push" {
 		t.Fatalf("expected push name")
+	}
+}
+
+func TestNewChmodsSQLiteArtifactsAfterInit(t *testing.T) {
+	orig := chmodFile
+	t.Cleanup(func() { chmodFile = orig })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.db")
+	calls := make([]string, 0, 4)
+	firstCall := true
+
+	chmodFile = func(target string, mode os.FileMode) error {
+		if firstCall {
+			firstCall = false
+			if _, err := os.Stat(path); err != nil {
+				t.Fatalf("expected session db to exist before chmod, got %v", err)
+			}
+		}
+		calls = append(calls, target)
+		return nil
+	}
+
+	c, err := New(Options{StorePath: path})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected client")
+	}
+
+	want := []string{
+		path,
+		path + "-wal",
+		path + "-shm",
+		path + "-journal",
+	}
+	if len(calls) != len(want) {
+		t.Fatalf("expected %d chmod calls, got %d: %v", len(want), len(calls), calls)
+	}
+	for i, target := range want {
+		if calls[i] != target {
+			t.Fatalf("chmod call %d: expected %q, got %q", i, target, calls[i])
+		}
 	}
 }

--- a/internal/wa/media.go
+++ b/internal/wa/media.go
@@ -43,7 +43,7 @@ func (c *Client) DownloadMediaToFile(ctx context.Context, directPath string, enc
 		return 0, err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(targetPath), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
 		return 0, fmt.Errorf("create output dir: %w", err)
 	}
 
@@ -76,6 +76,9 @@ func (c *Client) DownloadMediaToFile(ctx context.Context, directPath string, enc
 	}
 	if err := os.Rename(tmpName, targetPath); err != nil {
 		return 0, fmt.Errorf("move media file: %w", err)
+	}
+	if err := os.Chmod(targetPath, 0o600); err != nil {
+		return 0, fmt.Errorf("chmod media file: %w", err)
 	}
 	success = true
 


### PR DESCRIPTION
This is the repaired follow-up to #126 and supersedes the gaps in that branch.

It hardens SQLite artifacts by forcing owner-only permissions on the main DB file and its `-wal`, `-shm`, and `-journal` sidecars after initialization, regardless of umask.

Tests now exercise a write path and verify the permissions on any sidecar files that appear.
