### PR TITLE
security: strip null bytes and control chars in path sanitization (#60)

### DIFF
--- a/internal/pathutil/sanitize.go
+++ b/internal/pathutil/sanitize.go
@@ -3,6 +3,7 @@ package pathutil
 import (
 	"path/filepath"
 	"strings"
+	"unicode"
 )
 
 var replacer = strings.NewReplacer(
@@ -17,8 +18,20 @@ var replacer = strings.NewReplacer(
 	"|", "_",
 )
 
+// stripControlChars removes null bytes and non-printable control characters
+// from s, providing defense-in-depth against path injection attacks.
+func stripControlChars(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == 0 || unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+}
+
 func SanitizeSegment(seg string) string {
 	seg = strings.TrimSpace(seg)
+	seg = stripControlChars(seg)
 	if seg == "" {
 		return "unknown"
 	}
@@ -30,6 +43,7 @@ func SanitizeSegment(seg string) string {
 
 func SanitizeFilename(name string) string {
 	name = strings.TrimSpace(name)
+	name = stripControlChars(name)
 	if name == "" {
 		return "file"
 	}

--- a/internal/pathutil/sanitize_test.go
+++ b/internal/pathutil/sanitize_test.go
@@ -25,3 +25,45 @@ func TestSanitizeFilename(t *testing.T) {
 		t.Fatalf("expected a_b, got %q", got)
 	}
 }
+
+// TestSanitizeControlChars verifies that null bytes and control characters
+// are stripped from both SanitizeSegment and SanitizeFilename (#60).
+func TestSanitizeControlChars(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"null byte", "foo\x00bar"},
+		{"null byte only", "\x00"},
+		{"tab", "foo\tbar"},
+		{"newline", "foo\nbar"},
+		{"carriage return", "foo\rbar"},
+		{"bell", "foo\x07bar"},
+		{"multiple control", "\x00\x01\x02hello\x7f"},
+	}
+
+	for _, tc := range cases {
+		t.Run("SanitizeSegment/"+tc.name, func(t *testing.T) {
+			got := SanitizeSegment(tc.input)
+			for _, r := range got {
+				if r == 0 || (r < 0x20 && r != 0) || r == 0x7f {
+					t.Errorf("SanitizeSegment(%q) = %q, still contains control char %q", tc.input, got, r)
+				}
+			}
+		})
+		t.Run("SanitizeFilename/"+tc.name, func(t *testing.T) {
+			got := SanitizeFilename(tc.input)
+			for _, r := range got {
+				if r == 0 || (r < 0x20 && r != 0) || r == 0x7f {
+					t.Errorf("SanitizeFilename(%q) = %q, still contains control char %q", tc.input, got, r)
+				}
+			}
+		})
+	}
+
+	// A segment of only control chars should fall back to "unknown" — after
+	// stripping, the string becomes empty and TrimSpace+fallback applies.
+	if got := SanitizeSegment("\x00\x01"); got != "unknown" {
+		t.Errorf("SanitizeSegment of only control chars: want \"unknown\", got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

`SanitizeSegment` and `SanitizeFilename` handled `..`, `/` and other dangerous chars but silently passed through null bytes (`\x00`) and Unicode control characters (tabs, newlines, bell, etc.), which can cause path traversal or unexpected filesystem behaviour on some platforms.

## Changes

Add a `stripControlChars` helper (using `strings.Map` + `unicode.IsControl`) and call it early in both sanitize functions — before the replacement table and the empty-string fallback check.

## Testing

- 14 new sub-tests covering null byte, null-only, tab, newline, carriage return, bell, and multi-control inputs for both `SanitizeSegment` and `SanitizeFilename`.
- All existing tests continue to pass.

## Notes

Go 1.20+ runtime mitigates null bytes at the syscall level, so this is defence-in-depth rather than a critical fix. The guard is still valuable for portability and to prevent any logging/display confusion caused by invisible control characters in filenames.

Closes #60