### PR TITLE
security: validate SQLite URI path against '?' and '#' injection (#59)

### DIFF
--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -20,6 +20,10 @@ func Open(path string) (*DB, error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, fmt.Errorf("db path is required")
 	}
+	// Reject paths that could inject SQLite URI parameters (#59).
+	if strings.ContainsAny(path, "?#") {
+		return nil, fmt.Errorf("db path must not contain '?' or '#'")
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return nil, fmt.Errorf("create db directory: %w", err)
 	}


### PR DESCRIPTION
## Summary

The `--store` path is passed directly into a SQLite connection URI via `fmt.Sprintf("file:%s?...", path)`. A path containing `?` could inject additional SQLite connection parameters (e.g. `?mode=ro` to force read-only, `?cache=shared` to change isolation).

## Changes

Reject paths containing `?` or `#` before constructing the URI. Both characters have special meaning in SQLite URI syntax.

## Testing

- Existing schema test continues to pass.
- Manual verification: `store.Open("/tmp/test?mode=ro")` now returns `db path must not contain '?' or '#'` immediately.

Closes #59
