### PR TITLE
bug: sanitize FTS5 user queries to prevent query-syntax injection (#57)

### DIFF
--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -44,6 +44,24 @@ func (d *DB) searchLIKE(p SearchMessagesParams) ([]Message, error) {
 	return d.scanMessages(query, args...)
 }
 
+// sanitizeFTSQuery converts a raw user query into a safe FTS5 expression by
+// quoting each whitespace-delimited token individually. This prevents FTS5
+// query-syntax injection (AND/OR/NOT/NEAR/column filters) while preserving
+// intuitive multi-word search: "hello world" matches messages containing both
+// words (implicit AND), not necessarily as an exact phrase.
+func sanitizeFTSQuery(q string) string {
+	tokens := strings.Fields(q)
+	if len(tokens) == 0 {
+		return `""`
+	}
+	quoted := make([]string, len(tokens))
+	for i, tok := range tokens {
+		// Escape embedded double-quotes by doubling them (FTS5 convention).
+		quoted[i] = `"` + strings.ReplaceAll(tok, `"`, `""`) + `"`
+	}
+	return strings.Join(quoted, " ")
+}
+
 func (d *DB) searchFTS(p SearchMessagesParams) ([]Message, error) {
 	query := `
 		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''),
@@ -52,7 +70,10 @@ func (d *DB) searchFTS(p SearchMessagesParams) ([]Message, error) {
 		JOIN messages m ON messages_fts.rowid = m.rowid
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		WHERE messages_fts MATCH ?`
-	args := []interface{}{p.Query}
+	// Sanitize to prevent FTS5 query-syntax injection (#57).
+	// Each token is individually quoted so multi-word queries still work
+	// as implicit AND (both words present, any order).
+	args := []interface{}{sanitizeFTSQuery(p.Query)}
 	query, args = applyMessageFilters(query, args, p)
 	query += " ORDER BY bm25(messages_fts) LIMIT ?"
 	args = append(args, p.Limit)

--- a/internal/store/search_fts_test.go
+++ b/internal/store/search_fts_test.go
@@ -41,3 +41,97 @@ func TestSearchMessagesUsesFTSWhenEnabled(t *testing.T) {
 		t.Fatalf("expected snippet for FTS search, got empty")
 	}
 }
+
+// TestSanitizeFTSQuery verifies that user input is sanitized before being
+// passed to the FTS5 MATCH clause, preventing query-syntax injection (#57).
+func TestSanitizeFTSQuery(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		// Basic tokens are individually quoted.
+		{"hello", `"hello"`},
+		{"hello world", `"hello" "world"`},
+		// FTS5 operators are neutralised — treated as literal tokens.
+		{"hello OR world", `"hello" "OR" "world"`},
+		{"NOT secret", `"NOT" "secret"`},
+		{"hello AND world", `"hello" "AND" "world"`},
+		// Column filter syntax is neutralised.
+		{"col:value", `"col:value"`},
+		// Prefix wildcard is neutralised.
+		{"test*", `"test*"`},
+		// NEAR operator is neutralised.
+		{"NEAR(a b)", `"NEAR(a" "b)"`},
+		// Embedded double-quotes are escaped by doubling.
+		{`say "hi"`, `"say" """hi"""`},
+		// Extra whitespace is collapsed.
+		{"  spaced  ", `"spaced"`},
+		// Empty / blank input returns empty quoted token.
+		{"", `""`},
+		{"   ", `""`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			got := sanitizeFTSQuery(tc.input)
+			if got != tc.want {
+				t.Errorf("sanitizeFTSQuery(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFTSInjectionPrevented verifies end-to-end that FTS5 syntax in user
+// queries does not cause errors or unexpected results (#57).
+func TestFTSInjectionPrevented(t *testing.T) {
+	db := openTestDB(t)
+	if !db.HasFTS() {
+		t.Skip("FTS5 not enabled")
+	}
+
+	chat := "555@s.whatsapp.net"
+	if err := db.UpsertChat(chat, "dm", "Bob", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	msgs := []struct{ id, text string }{
+		{"m1", "hello world"},
+		{"m2", "price is 100% confirmed"},
+		{"m3", "OR operator test"},
+	}
+	for _, m := range msgs {
+		if err := db.UpsertMessage(UpsertMessageParams{
+			ChatJID: chat, MsgID: m.id, Timestamp: time.Now(), Text: m.text,
+		}); err != nil {
+			t.Fatalf("UpsertMessage: %v", err)
+		}
+	}
+
+	injectionQueries := []string{
+		"OR hello",          // bare OR would be a syntax error in raw FTS5
+		"NOT hello",         // bare NOT would be a syntax error
+		"hello AND world",   // AND as operator vs literal
+		"NEAR(hello world)", // NEAR function syntax
+		`"hello"`,           // raw quoted phrase
+	}
+
+	for _, q := range injectionQueries {
+		t.Run(q, func(t *testing.T) {
+			// Must not panic or return an error — injection is neutralised.
+			_, err := db.SearchMessages(SearchMessagesParams{Query: q, Limit: 10})
+			if err != nil {
+				t.Errorf("SearchMessages(%q) returned unexpected error: %v", q, err)
+			}
+		})
+	}
+
+	// Multi-word search should still work (implicit AND between tokens).
+	t.Run("multi-word implicit AND", func(t *testing.T) {
+		ms, err := db.SearchMessages(SearchMessagesParams{Query: "hello world", Limit: 10})
+		if err != nil {
+			t.Fatalf("SearchMessages: %v", err)
+		}
+		if len(ms) != 1 || ms[0].MsgID != "m1" {
+			t.Errorf("expected m1 for 'hello world', got %v", ms)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

User search queries are passed directly to the FTS5 `MATCH` clause. FTS5 has its own query syntax (AND, OR, NOT, NEAR, column filters, prefix `*`) — passing raw user input allows:
- Syntax errors that return confusing empty results (`OR hello`)
- Unintended operator behaviour (`hello AND world` performs an intersection instead of a substring search)
- Column filter injection (`text:secret`)

## Changes

Add `sanitizeFTSQuery` which splits the input on whitespace and individually double-quotes each token (escaping embedded `"` by doubling). This prevents FTS5 operator injection while preserving intuitive multi-word search: `hello world` matches messages containing **both** words (implicit AND), rather than the exact phrase.

## Testing

- 12 unit tests for `sanitizeFTSQuery` covering: basic tokens, OR/NOT/AND operators, column filters, prefix wildcards, NEAR function, embedded quotes, extra whitespace, and empty input.
- 5 end-to-end injection tests that verify no panics/errors for `OR hello`, `NOT hello`, `hello AND world`, `NEAR(hello world)`, and `"hello"`.
- 1 test verifying multi-word implicit AND still works correctly.
- All existing FTS tests pass.

Closes #57
