### PR TITLE
security: add panic recovery to event handler and media workers (#52)

### DIFF
--- a/internal/app/media.go
+++ b/internal/app/media.go
@@ -87,6 +87,13 @@ func (a *App) runMediaWorkers(ctx context.Context, jobs <-chan mediaJob, workers
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			// Recover from panics to prevent a bad media job from crashing
+			// the whole process (#52).
+			defer func() {
+				if r := recover(); r != nil {
+					fmt.Fprintf(os.Stderr, "media worker panic (recovered): %v\n", r)
+				}
+			}()
 			for {
 				select {
 				case <-ctx.Done():

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -80,6 +80,13 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 	}
 
 	handlerID := a.wa.AddEventHandler(func(evt interface{}) {
+		// Recover from panics so unexpected message structures do not
+		// crash the entire process (#52).
+		defer func() {
+			if r := recover(); r != nil {
+				fmt.Fprintf(os.Stderr, "\nevent handler panic (recovered): %v\n", r)
+			}
+		}()
 		lastEvent.Store(time.Now().UTC().UnixNano())
 
 		switch v := evt.(type) {


### PR DESCRIPTION
## Summary

The event handler registered with `AddEventHandler` and the media worker goroutines have no `recover()`. If any processing panics (nil pointer from unexpected message structure, unexpected field type, etc.), it crashes the **entire** wacli process — losing the authenticated session and any in-flight sync work.

## Changes

Add `defer func() { if r := recover(); r != nil { log } }()` at the top of:
- The `AddEventHandler` callback in `sync.go`
- Each media worker goroutine in `media.go`

The process now survives individual message panics and logs the incident to stderr.

## Testing

- All existing tests pass.
- Demo: a goroutine that panics with recover in place logs the error and continues; without recover it crashes the entire process.

Closes #52
