### PR TITLE
feat: add WACLI_STORE_DIR env variable to configure store directory (#36)

### DIFF
--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -34,7 +34,7 @@ func execute(args []string) error {
 	}
 	rootCmd.SetVersionTemplate("wacli {{.Version}}\n")
 
-	rootCmd.PersistentFlags().StringVar(&flags.storeDir, "store", "", "store directory (default: ~/.wacli)")
+	rootCmd.PersistentFlags().StringVar(&flags.storeDir, "store", "", "store directory (default: $WACLI_STORE_DIR or ~/.wacli)")
 	rootCmd.PersistentFlags().BoolVar(&flags.asJSON, "json", false, "output JSON instead of human-readable text")
 	rootCmd.PersistentFlags().DurationVar(&flags.timeout, "timeout", 5*time.Minute, "command timeout (non-sync commands)")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,7 +5,18 @@ import (
 	"path/filepath"
 )
 
+// EnvStoreDir is the environment variable that overrides the default store
+// directory. This is useful for Docker, CI, and multi-tenant deployments
+// where the store path needs to be configured without passing --store on
+// every invocation.
+const EnvStoreDir = "WACLI_STORE_DIR"
+
+// DefaultStoreDir returns the store directory to use when --store is not
+// supplied. It checks WACLI_STORE_DIR first, then falls back to ~/.wacli.
 func DefaultStoreDir() string {
+	if dir := os.Getenv(EnvStoreDir); dir != "" {
+		return dir
+	}
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		return ".wacli"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultStoreDir(t *testing.T) {
+	t.Run("env var overrides default", func(t *testing.T) {
+		t.Setenv(EnvStoreDir, "/custom/store/path")
+		got := DefaultStoreDir()
+		if got != "/custom/store/path" {
+			t.Errorf("DefaultStoreDir() = %q, want %q", got, "/custom/store/path")
+		}
+	})
+
+	t.Run("falls back to ~/.wacli when env unset", func(t *testing.T) {
+		t.Setenv(EnvStoreDir, "")
+		got := DefaultStoreDir()
+		home, _ := os.UserHomeDir()
+		want := filepath.Join(home, ".wacli")
+		if got != want {
+			t.Errorf("DefaultStoreDir() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("env var constant is WACLI_STORE_DIR", func(t *testing.T) {
+		if EnvStoreDir != "WACLI_STORE_DIR" {
+			t.Errorf("EnvStoreDir = %q, want %q", EnvStoreDir, "WACLI_STORE_DIR")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Docker containers, CI pipelines, and multi-tenant deployments often need to set the store path via environment variable rather than passing `--store` on every invocation. This is a common pattern used by tools like `DOCKER_HOST`, `KUBECONFIG`, etc.

## Changes

`DefaultStoreDir()` now checks `WACLI_STORE_DIR` before falling back to `~/.wacli`. The `--store` flag still takes precedence over the env var when explicitly provided.

The `--store` flag description is updated to reflect this:
```
--store string   store directory (default: $WACLI_STORE_DIR or ~/.wacli)
```

## Usage

```bash
# Docker / CI
WACLI_STORE_DIR=/data/wacli wacli sync --follow

# Multi-tenant (one store per account)
WACLI_STORE_DIR=/var/wacli/account1 wacli doctor
WACLI_STORE_DIR=/var/wacli/account2 wacli doctor
```

## Testing

- 3 unit tests: env var overrides default, falls back when unset, constant value check
- Verified: path resolution, relative paths (resolved to absolute), and invalid paths (graceful error)
- All existing tests pass

Closes #36
