### PR TITLE
feat: add 'wacli send react' command for message reactions (#42)

### DIFF
--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -19,6 +19,7 @@ func newSendCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.AddCommand(newSendTextCmd(flags))
 	cmd.AddCommand(newSendFileCmd(flags))
+	cmd.AddCommand(newSendReactCmd(flags))
 	return cmd
 }
 

--- a/cmd/wacli/send_react_cmd.go
+++ b/cmd/wacli/send_react_cmd.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/steipete/wacli/internal/out"
+	"github.com/steipete/wacli/internal/wa"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func newSendReactCmd(flags *rootFlags) *cobra.Command {
+	var to string
+	var msgID string
+	var emoji string
+	var sender string
+
+	cmd := &cobra.Command{
+		Use:   "react",
+		Short: "React to a message with an emoji",
+		Long: `Send an emoji reaction to a specific WhatsApp message.
+
+Requires the conversation JID (--to) and the target message ID (--id).
+For group messages, also pass the message author's JID via --sender.
+
+To remove an existing reaction, pass an empty --reaction flag:
+
+  wacli send react --to +15551234567 --id MSGID --reaction ""`,
+		Example: `  # React with 👍 (default)
+  wacli send react --to +15551234567 --id 3EB0A3DCA3175E17850852
+
+  # React with a custom emoji
+  wacli send react --to +15551234567 --id 3EB0A3DCA3175E17850852 --reaction 🔥
+
+  # React in a group (sender JID required)
+  wacli send react --to 1234567890-123456789@g.us --id MSGID --sender +15559876543 --reaction ❤️
+
+  # Remove a reaction
+  wacli send react --to +15551234567 --id MSGID --reaction ""`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(to) == "" {
+				return fmt.Errorf("--to is required")
+			}
+			if strings.TrimSpace(msgID) == "" {
+				return fmt.Errorf("--id is required")
+			}
+
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+
+			toJID, err := wa.ParseUserOrJID(to)
+			if err != nil {
+				return fmt.Errorf("invalid --to: %w", err)
+			}
+
+			var senderJID types.JID
+			if strings.TrimSpace(sender) != "" {
+				senderJID, err = wa.ParseUserOrJID(sender)
+				if err != nil {
+					return fmt.Errorf("invalid --sender: %w", err)
+				}
+			}
+
+			sentID, err := a.WA().SendReaction(ctx, toJID, senderJID, types.MessageID(msgID), emoji)
+			if err != nil {
+				return err
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"sent":     true,
+					"to":       toJID.String(),
+					"id":       sentID,
+					"target":   msgID,
+					"reaction": emoji,
+				})
+			}
+
+			if emoji == "" {
+				fmt.Fprintf(os.Stdout, "Removed reaction from message %s (sent id %s)\n", msgID, sentID)
+			} else {
+				fmt.Fprintf(os.Stdout, "Reacted %s to message %s (sent id %s)\n", emoji, msgID, sentID)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&to, "to", "", "recipient phone number or JID")
+	cmd.Flags().StringVar(&msgID, "id", "", "target message ID to react to")
+	cmd.Flags().StringVar(&emoji, "reaction", "👍", `reaction emoji (pass "" to remove an existing reaction)`)
+	cmd.Flags().StringVar(&sender, "sender", "", "message author JID (required for group messages)")
+	return cmd
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -45,6 +45,8 @@ type WAClient interface {
 	DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error)
 	RequestHistorySyncOnDemand(ctx context.Context, lastKnown types.MessageInfo, count int) (types.MessageID, error)
 	Logout(ctx context.Context) error
+	LinkedJID() string
+	SendReaction(ctx context.Context, chat, sender types.JID, targetID types.MessageID, reaction string) (types.MessageID, error)
 }
 
 type Options struct {

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -250,3 +250,9 @@ func (f *fakeWA) Logout(ctx context.Context) error {
 	f.authed = false
 	return nil
 }
+
+func (f *fakeWA) LinkedJID() string { return "5491112345678@s.whatsapp.net" }
+
+func (f *fakeWA) SendReaction(_ context.Context, _, _ types.JID, _ types.MessageID, _ string) (types.MessageID, error) {
+	return "reaction-msg-id", nil
+}

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -370,3 +370,35 @@ func (c *Client) ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay ti
 		}
 	}
 }
+
+// SendReaction sends an emoji reaction to a specific message.
+// Set chat to the conversation JID, sender to the message author's JID
+// (required for group messages; can be empty for DMs), targetID to the
+// message ID being reacted to, and reaction to the emoji (empty string
+// removes an existing reaction).
+func (c *Client) SendReaction(ctx context.Context, chat, sender types.JID, targetID types.MessageID, reaction string) (types.MessageID, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return "", fmt.Errorf("not connected")
+	}
+	msg := cli.BuildReaction(chat, sender, targetID, reaction)
+	resp, err := cli.SendMessage(ctx, chat, msg)
+	if err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
+// LinkedJID returns the JID of the linked WhatsApp account, or an empty
+// string if not authenticated.
+func (c *Client) LinkedJID() string {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || cli.Store == nil || cli.Store.ID == nil {
+		return ""
+	}
+	return cli.Store.ID.ToNonAD().String()
+}


### PR DESCRIPTION
## Summary

wacli has great send primitives (`send text`, `send file`) but no way to react to messages. Reactions are widely used for lightweight acknowledgements and status updates in WhatsApp — especially useful for AI agent integrations that need to signal "seen" or "done" without sending a full message reply.

## Usage

```bash
# React with 👍 (default)
wacli send react --to +15551234567 --id 3EB0A3DCA3175E17850852

# Custom emoji
wacli send react --to +15551234567 --id 3EB0A3DCA3175E17850852 --reaction 🔥

# Group message (--sender required)
wacli send react --to 1234567890-123456789@g.us --id MSGID --sender +15559876543 --reaction ❤️

# Remove a reaction
wacli send react --to +15551234567 --id MSGID --reaction ""

# JSON output for scripting
wacli send react --to +15551234567 --id MSGID --reaction 👍 --json
```

## Implementation

- `wa.Client.SendReaction()` wrapping `whatsmeow.BuildReaction + SendMessage`
- `SendReaction` added to `WAClient` interface
- `react` registered as a subcommand of `send`
- Full `--json` support
- `--sender` flag for group message reactions

## Testing

Tested against a real WhatsApp account:
- ✅ DM reaction
- ✅ Group reaction with --sender
- ✅ Emoji change (re-react without removing first)
- ✅ Remove reaction with `--reaction ""`
- ✅ JSON output

Closes #42
