### PR TITLE
fix: strip leading '+' from phone numbers to prevent usync timeout (#28)

### DIFF
--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -255,6 +255,10 @@ func ParseUserOrJID(s string) (types.JID, error) {
 	if strings.Contains(s, "@") {
 		return types.ParseJID(s)
 	}
+	// Strip a leading + so both "+15551234567" and "15551234567" work.
+	// WhatsApp JIDs use digits only; a leading + causes usync query timeouts
+	// because the server receives "+15551234567@s.whatsapp.net" which is invalid.
+	s = strings.TrimPrefix(s, "+")
 	return types.JID{User: s, Server: types.DefaultUserServer}, nil
 }
 

--- a/internal/wa/client_test.go
+++ b/internal/wa/client_test.go
@@ -41,3 +41,28 @@ func TestBestContactName(t *testing.T) {
 		t.Fatalf("expected push name")
 	}
 }
+
+// TestParseUserOrJIDPlusPrefix verifies that a leading '+' is stripped from
+// phone numbers so "+15551234567" and "15551234567" produce the same JID (#28).
+func TestParseUserOrJIDPlusPrefix(t *testing.T) {
+	cases := []struct {
+		input    string
+		wantUser string
+	}{
+		{"+15551234567", "15551234567"},
+		{"+49123456789", "49123456789"},
+		{"15551234567", "15551234567"},   // no + — unchanged
+		{"+1 555 123 4567", "1 555 123 4567"}, // spaces preserved (WA strips them)
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			j, err := ParseUserOrJID(tc.input)
+			if err != nil {
+				t.Fatalf("ParseUserOrJID(%q): %v", tc.input, err)
+			}
+			if j.User != tc.wantUser {
+				t.Errorf("ParseUserOrJID(%q).User = %q, want %q", tc.input, j.User, tc.wantUser)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Passing a phone number with a leading `+` (the common international format, e.g. `+15551234567`) built an invalid JID `+15551234567@s.whatsapp.net`. WhatsApp servers reject this with a `usync query timed out` error, which appeared as a confusing 5-second hang followed by a failure.

## Changes

Strip the leading `+` in `ParseUserOrJID` before constructing the JID. JIDs containing `@` are routed through `types.ParseJID` as before and are unaffected.

## Testing

- 4 new sub-tests: `+15551234567` → `15551234567`, `+49123456789` → `49123456789`, no-`+` unchanged, `+1 555...` (spaces preserved)
- Verified against a real WhatsApp account: `wacli send text --to +447451294587 ...` now sends successfully

Closes #28
