### PR TITLE
feat: add --from-me, --from-them, --asc, --sender flags to messages list

### DIFF
--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -27,9 +27,13 @@ func newMessagesCmd(flags *rootFlags) *cobra.Command {
 
 func newMessagesListCmd(flags *rootFlags) *cobra.Command {
 	var chat string
+	var sender string
 	var limit int
 	var afterStr string
 	var beforeStr string
+	var fromMe bool
+	var fromThem bool
+	var asc bool
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -61,11 +65,22 @@ func newMessagesListCmd(flags *rootFlags) *cobra.Command {
 				before = &t
 			}
 
+			var fromMeFilter *bool
+			if fromMe {
+				t := true
+				fromMeFilter = &t
+			} else if fromThem {
+				f := false
+				fromMeFilter = &f
+			}
 			msgs, err := a.DB().ListMessages(store.ListMessagesParams{
-				ChatJID: chat,
-				Limit:   limit,
-				After:   after,
-				Before:  before,
+				ChatJID:   chat,
+				SenderJID: sender,
+				Limit:     limit,
+				After:     after,
+				Before:    before,
+				FromMe:    fromMeFilter,
+				Asc:       asc,
 			})
 			if err != nil {
 				return err
@@ -89,9 +104,11 @@ func newMessagesListCmd(flags *rootFlags) *cobra.Command {
 				if chatLabel == "" {
 					chatLabel = m.ChatJID
 				}
-				text := strings.TrimSpace(m.DisplayText)
+				// Prefer raw text; fall back to display text (which may contain
+				// protocol placeholders like "(message)").
+				text := strings.TrimSpace(m.Text)
 				if text == "" {
-					text = strings.TrimSpace(m.Text)
+					text = strings.TrimSpace(m.DisplayText)
 				}
 				if m.MediaType != "" && text == "" {
 					text = "Sent " + m.MediaType
@@ -109,10 +126,14 @@ func newMessagesListCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&chat, "chat", "", "chat JID")
-	cmd.Flags().IntVar(&limit, "limit", 50, "limit results")
+	cmd.Flags().StringVar(&chat, "chat", "", "filter by chat JID")
+	cmd.Flags().StringVar(&sender, "sender", "", "filter by sender JID")
+	cmd.Flags().IntVar(&limit, "limit", 50, "max number of messages to return")
 	cmd.Flags().StringVar(&afterStr, "after", "", "only messages after time (RFC3339 or YYYY-MM-DD)")
 	cmd.Flags().StringVar(&beforeStr, "before", "", "only messages before time (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().BoolVar(&fromMe, "from-me", false, "only messages sent by me")
+	cmd.Flags().BoolVar(&fromThem, "from-them", false, "only messages received (not sent by me)")
+	cmd.Flags().BoolVar(&asc, "asc", false, "show oldest messages first (default: newest first)")
 	return cmd
 }
 

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -59,10 +59,13 @@ func (d *DB) UpsertMessage(p UpsertMessageParams) error {
 }
 
 type ListMessagesParams struct {
-	ChatJID string
-	Limit   int
-	Before  *time.Time
-	After   *time.Time
+	ChatJID   string
+	SenderJID string
+	Limit     int
+	Before    *time.Time
+	After     *time.Time
+	FromMe    *bool // nil = all, true = sent by me, false = received
+	Asc       bool  // true = oldest first (default: newest first)
 }
 
 func (d *DB) ListMessages(p ListMessagesParams) ([]Message, error) {
@@ -87,7 +90,22 @@ func (d *DB) ListMessages(p ListMessagesParams) ([]Message, error) {
 		query += " AND m.ts < ?"
 		args = append(args, unix(*p.Before))
 	}
-	query += " ORDER BY m.ts DESC LIMIT ?"
+	if strings.TrimSpace(p.SenderJID) != "" {
+		query += " AND m.sender_jid = ?"
+		args = append(args, p.SenderJID)
+	}
+	if p.FromMe != nil {
+		if *p.FromMe {
+			query += " AND m.from_me = 1"
+		} else {
+			query += " AND m.from_me = 0"
+		}
+	}
+	if p.Asc {
+		query += " ORDER BY m.ts ASC LIMIT ?"
+	} else {
+		query += " ORDER BY m.ts DESC LIMIT ?"
+	}
 	args = append(args, p.Limit)
 	return d.scanMessages(query, args...)
 }


### PR DESCRIPTION
## Summary

`messages list` was useful for basic listing but lacked filtering options that are essential for scripting and automation — particularly for AI agents and bots that need to process only incoming or outgoing messages.

## Changes

### New flags

```
--from-me       only messages sent by me
--from-them     only messages received (not sent by me)  
--asc           chronological order, oldest first (default: newest first)
--sender JID    filter by a specific sender JID
```

### Examples

```bash
# Show my last 20 sent messages
wacli messages list --from-me --limit 20

# Show incoming messages in a specific chat, oldest first
wacli messages list --chat +15551234567 --from-them --asc --limit 50

# Filter by sender in a group
wacli messages list --chat 1234567890-123456789@g.us --sender +15559876543
```

### Bug fix: text display priority

The display order for the TEXT column was reversed — `DisplayText` was shown first, which contains the `(message)` placeholder for system/protocol messages. Changed to prefer `Text` and fall back to `DisplayText`.

## Internal changes

`ListMessagesParams` gains `SenderJID string`, `FromMe *bool`, and `Asc bool` fields.

## Testing

- Verified all new flags against a real WhatsApp store (90 messages, 50 chats)
- `--from-me` correctly filters to sent messages only
- `--asc` produces chronological output
- `--sender` correctly filters by JID
- All existing tests pass
