### PR TITLE
feat: add --reply-to flag to 'wacli send text' for quoted replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Messages: show display text for replies, reactions, and media in `messages context`. (#183 — thanks @fuleinist)
 - Send: strip a leading `+` from phone-number recipients before building WhatsApp JIDs. (#74 — thanks @FrederickStempfle)
 - Search: keep FTS5 enabled after reopening existing databases with already-applied migrations. (#185 — thanks @iamhitarth)
+- Send: add `send text --reply-to` for quoted replies, with sender inference for synced group messages. (#154 — thanks @draix)
 - Send: persist retry-message plaintext so linked devices can decrypt retried messages. (#186 — thanks @SimDamDev)
 - Sync: keep `sync --once` idle timing focused on message/history events so connection chatter cannot hang exit. (#119 — thanks @jyothepro)
 - Sync: start `sync --once` idle timing after the `Connected` event. (#171 — thanks @fuleinist)

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -2,14 +2,21 @@ package main
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/steipete/wacli/internal/app"
 	"github.com/steipete/wacli/internal/out"
 	"github.com/steipete/wacli/internal/store"
 	"github.com/steipete/wacli/internal/wa"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
 )
 
 func newSendCmd(flags *rootFlags) *cobra.Command {
@@ -25,6 +32,8 @@ func newSendCmd(flags *rootFlags) *cobra.Command {
 func newSendTextCmd(flags *rootFlags) *cobra.Command {
 	var to string
 	var message string
+	var replyTo string
+	var replyToSender string
 
 	cmd := &cobra.Command{
 		Use:   "text",
@@ -55,7 +64,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			msgID, err := a.WA().SendText(ctx, toJID, message)
+			msgID, err := sendTextMessage(ctx, a, toJID, message, replyTo, replyToSender)
 			if err != nil {
 				return err
 			}
@@ -90,5 +99,65 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 
 	cmd.Flags().StringVar(&to, "to", "", "recipient phone number or JID")
 	cmd.Flags().StringVar(&message, "message", "", "message text")
+	cmd.Flags().StringVar(&replyTo, "reply-to", "", "message ID to quote/reply to")
+	cmd.Flags().StringVar(&replyToSender, "reply-to-sender", "", "sender JID of the quoted message (required for unsynced group replies)")
 	return cmd
+}
+
+type sendTextApp interface {
+	WA() app.WAClient
+	DB() *store.DB
+}
+
+func sendTextMessage(ctx context.Context, a sendTextApp, to types.JID, text, replyTo, replyToSender string) (types.MessageID, error) {
+	replyTo = strings.TrimSpace(replyTo)
+	if replyTo == "" {
+		return a.WA().SendText(ctx, to, text)
+	}
+
+	sender, err := resolveReplySender(a.DB(), to, replyTo, replyToSender)
+	if err != nil {
+		return "", err
+	}
+
+	stanzaID := replyTo
+	info := &waProto.ContextInfo{StanzaID: proto.String(stanzaID)}
+	if !sender.IsEmpty() {
+		participant := sender.String()
+		info.Participant = proto.String(participant)
+	}
+
+	return a.WA().SendProtoMessage(ctx, to, &waProto.Message{
+		ExtendedTextMessage: &waProto.ExtendedTextMessage{
+			Text:        proto.String(text),
+			ContextInfo: info,
+		},
+	})
+}
+
+func resolveReplySender(db *store.DB, chat types.JID, replyTo, override string) (types.JID, error) {
+	if strings.TrimSpace(override) != "" {
+		jid, err := wa.ParseUserOrJID(override)
+		if err != nil {
+			return types.JID{}, fmt.Errorf("invalid --reply-to-sender: %w", err)
+		}
+		return jid, nil
+	}
+
+	msg, err := db.GetMessage(chat.String(), replyTo)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return types.JID{}, fmt.Errorf("lookup quoted message: %w", err)
+	}
+	if err == nil && strings.TrimSpace(msg.SenderJID) != "" {
+		jid, err := types.ParseJID(msg.SenderJID)
+		if err != nil {
+			return types.JID{}, fmt.Errorf("stored quoted sender is invalid: %w", err)
+		}
+		return jid, nil
+	}
+
+	if chat.Server == types.GroupServer {
+		return types.JID{}, fmt.Errorf("--reply-to-sender is required for unsynced group replies")
+	}
+	return types.JID{}, nil
 }

--- a/cmd/wacli/send_test.go
+++ b/cmd/wacli/send_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steipete/wacli/internal/store"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func openSendTestDB(t *testing.T) *store.DB {
+	t.Helper()
+	db, err := store.Open(t.TempDir() + "/wacli.db")
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestResolveReplySenderFromStore(t *testing.T) {
+	db := openSendTestDB(t)
+	chat := types.JID{User: "12345", Server: types.GroupServer}
+	sender := "15551234567@s.whatsapp.net"
+
+	if err := db.UpsertChat(chat.String(), "group", "Group", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := db.UpsertMessage(store.UpsertMessageParams{
+		ChatJID:   chat.String(),
+		MsgID:     "quoted",
+		SenderJID: sender,
+		Timestamp: time.Now(),
+		Text:      "hello",
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	got, err := resolveReplySender(db, chat, "quoted", "")
+	if err != nil {
+		t.Fatalf("resolveReplySender: %v", err)
+	}
+	if got.String() != sender {
+		t.Fatalf("sender = %q, want %q", got.String(), sender)
+	}
+}
+
+func TestResolveReplySenderOverride(t *testing.T) {
+	db := openSendTestDB(t)
+	chat := types.JID{User: "12345", Server: types.GroupServer}
+
+	got, err := resolveReplySender(db, chat, "missing", "+15551234567")
+	if err != nil {
+		t.Fatalf("resolveReplySender: %v", err)
+	}
+	if got.String() != "15551234567@s.whatsapp.net" {
+		t.Fatalf("sender = %q", got.String())
+	}
+}
+
+func TestResolveReplySenderRequiresGroupSenderWhenMissing(t *testing.T) {
+	db := openSendTestDB(t)
+	chat := types.JID{User: "12345", Server: types.GroupServer}
+
+	_, err := resolveReplySender(db, chat, "missing", "")
+	if err == nil || !strings.Contains(err.Error(), "--reply-to-sender is required") {
+		t.Fatalf("expected group sender error, got %v", err)
+	}
+}
+
+func TestResolveReplySenderAllowsDirectMessageWithoutSender(t *testing.T) {
+	db := openSendTestDB(t)
+	chat := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+
+	got, err := resolveReplySender(db, chat, "missing", "")
+	if err != nil {
+		t.Fatalf("resolveReplySender: %v", err)
+	}
+	if !got.IsEmpty() {
+		t.Fatalf("expected empty sender for direct reply, got %q", got.String())
+	}
+}


### PR DESCRIPTION
## Summary

Quoted/threaded replies are the most basic building block for conversational bots and AI agent integrations. Without `--reply-to`, every wacli message arrives as a standalone message with no conversation threading — making it hard for users to track which bot response belongs to which question.

## Usage

```bash
# Quote a message in a DM
wacli send text --to +15551234567 --message "Got it!" --reply-to 3EB0A3DCA3175E17850852

# Quote a message in a group (--reply-to-sender required)
wacli send text --to 1234567890-123456789@g.us \
  --message "Agreed with @Alice" \
  --reply-to 3EB0A3DCA3175E17850852 \
  --reply-to-sender +15559876543
```

## Flags added

```
--reply-to          message ID to quote/reply to
--reply-to-sender   JID of the quoted message's author (required for group replies)
```

## Implementation

Add `SendTextReply` to `wa.Client` using whatsmeow's `ExtendedTextMessage` + `ContextInfo{StanzaID, Participant}`. When `--reply-to` is present, routes through `SendTextReply`; otherwise falls through to the existing `SendText`.

## Testing

Tested against a real WhatsApp account — quoted reply delivered correctly with the green quote bubble showing the original message.

Used in production at [Zapia](https://zapia.ai) for AI agent responses that quote the user's question.
