### PR TITLE
[codex] Add store-dir env override and Windows locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Run (local build only):
 
 ## Quick start
 
-Default store directory is `~/.wacli` (override with `--store DIR`).
+Default store directory is `~/.wacli` (override with `--store DIR` or `WACLI_STORE_DIR`).
 
 ```bash
 # 1) Authenticate (shows QR), then bootstrap sync
@@ -87,12 +87,13 @@ This project is heavily inspired by (and learns from) the excellent `whatsapp-cl
 
 ## Storage
 
-Defaults to `~/.wacli` (override with `--store DIR`).
+Defaults to `~/.wacli` (override with `--store DIR` or `WACLI_STORE_DIR`).
 
 ## Environment overrides
 
 - `WACLI_DEVICE_LABEL`: set the linked device label (shown in WhatsApp).
 - `WACLI_DEVICE_PLATFORM`: override the linked device platform (defaults to `CHROME` if unset or invalid).
+- `WACLI_STORE_DIR`: override the default store directory when `--store` is not set.
 
 ## Backfilling older history
 

--- a/cmd/wacli/doctor.go
+++ b/cmd/wacli/doctor.go
@@ -24,10 +24,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			ctx, cancel := withTimeout(context.Background(), flags)
 			defer cancel()
 
-			storeDir := flags.storeDir
-			if storeDir == "" {
-				storeDir = config.DefaultStoreDir()
-			}
+			storeDir := config.ResolveStoreDir(flags.storeDir)
 			storeDir, _ = filepath.Abs(storeDir)
 
 			var lockHeld bool

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -34,7 +34,7 @@ func execute(args []string) error {
 	}
 	rootCmd.SetVersionTemplate("wacli {{.Version}}\n")
 
-	rootCmd.PersistentFlags().StringVar(&flags.storeDir, "store", "", "store directory (default: ~/.wacli)")
+	rootCmd.PersistentFlags().StringVar(&flags.storeDir, "store", "", "store directory (default: $WACLI_STORE_DIR or ~/.wacli)")
 	rootCmd.PersistentFlags().BoolVar(&flags.asJSON, "json", false, "output JSON instead of human-readable text")
 	rootCmd.PersistentFlags().DurationVar(&flags.timeout, "timeout", 5*time.Minute, "command timeout (non-sync commands)")
 
@@ -59,10 +59,7 @@ func execute(args []string) error {
 }
 
 func newApp(ctx context.Context, flags *rootFlags, needLock bool, allowUnauthed bool) (*app.App, *lock.Lock, error) {
-	storeDir := flags.storeDir
-	if storeDir == "" {
-		storeDir = config.DefaultStoreDir()
-	}
+	storeDir := config.ResolveStoreDir(flags.storeDir)
 	storeDir, _ = filepath.Abs(storeDir)
 
 	var lk *lock.Lock

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -132,7 +132,7 @@ Fallback:
 
 Global flags:
 
-- `--store DIR` (default `~/.wacli`)
+- `--store DIR` (default `WACLI_STORE_DIR` or `~/.wacli`)
 - `--json` (default: human text)
 - `--timeout DURATION` (non-sync commands; e.g. `5m`)
 - `--version` (prints version and exits)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,7 +3,10 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
+
+const StoreDirEnvVar = "WACLI_STORE_DIR"
 
 func DefaultStoreDir() string {
 	home, err := os.UserHomeDir()
@@ -11,4 +14,14 @@ func DefaultStoreDir() string {
 		return ".wacli"
 	}
 	return filepath.Join(home, ".wacli")
+}
+
+func ResolveStoreDir(explicit string) string {
+	if s := strings.TrimSpace(explicit); s != "" {
+		return s
+	}
+	if s := strings.TrimSpace(os.Getenv(StoreDirEnvVar)); s != "" {
+		return s
+	}
+	return DefaultStoreDir()
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,30 @@
+package config
+
+import "testing"
+
+func TestResolveStoreDirPrefersFlag(t *testing.T) {
+	t.Setenv(StoreDirEnvVar, "/tmp/from-env")
+
+	got := ResolveStoreDir("/tmp/from-flag")
+	if got != "/tmp/from-flag" {
+		t.Fatalf("ResolveStoreDir() = %q, want explicit flag value", got)
+	}
+}
+
+func TestResolveStoreDirUsesEnv(t *testing.T) {
+	t.Setenv(StoreDirEnvVar, "/tmp/from-env")
+
+	got := ResolveStoreDir("")
+	if got != "/tmp/from-env" {
+		t.Fatalf("ResolveStoreDir() = %q, want env value", got)
+	}
+}
+
+func TestResolveStoreDirIgnoresWhitespaceEnv(t *testing.T) {
+	t.Setenv(StoreDirEnvVar, "   ")
+
+	got := ResolveStoreDir("")
+	if got != DefaultStoreDir() {
+		t.Fatalf("ResolveStoreDir() = %q, want default store dir %q", got, DefaultStoreDir())
+	}
+}

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -24,7 +23,7 @@ func Acquire(storeDir string) (*Lock, error) {
 		return nil, fmt.Errorf("open lock file: %w", err)
 	}
 
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+	if err := lockFile(f); err != nil {
 		_, _ = f.Seek(0, 0)
 		b, _ := os.ReadFile(path)
 		_ = f.Close()
@@ -47,7 +46,7 @@ func (l *Lock) Release() error {
 	if l == nil || l.f == nil {
 		return nil
 	}
-	_ = syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+	_ = unlockFile(l.f)
 	err := l.f.Close()
 	l.f = nil
 	return err

--- a/internal/lock/lock_unix.go
+++ b/internal/lock/lock_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package lock
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+}
+
+func unlockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/internal/lock/lock_windows.go
+++ b/internal/lock/lock_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package lock
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFile(f *os.File) error {
+	var ol windows.Overlapped
+	return windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		&ol,
+	)
+}
+
+func unlockFile(f *os.File) error {
+	var ol windows.Overlapped
+	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, &ol)
+}


### PR DESCRIPTION
## Summary
- add `WACLI_STORE_DIR` as a default store-directory override, while keeping `--store` highest priority
- document the new store-dir override in the CLI help, README, and spec
- split file locking into Unix and Windows implementations so the CLI compiles and enforces single-instance locking on Windows

## Why
- issue #36 asks for an environment-based store-dir override
- while validating the change on Windows, the current lock implementation failed to compile because it depends on Unix-only `syscall.Flock`

## Validation
- `go test ./internal/config ./internal/lock`
- `go test ./cmd/wacli -run TestDoesNotExist`
