### PR TITLE
Messages: polish show and context output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Internal architecture: split store and groups command logic into focused modules for cleaner maintenance and safer follow-up changes.
+- Messages: polish `messages show` and `messages context` output to prefer stored display text and show richer media details.
 
 ### Build
 

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -89,19 +89,12 @@ func newMessagesListCmd(flags *rootFlags) *cobra.Command {
 				if chatLabel == "" {
 					chatLabel = m.ChatJID
 				}
-				text := strings.TrimSpace(m.DisplayText)
-				if text == "" {
-					text = strings.TrimSpace(m.Text)
-				}
-				if m.MediaType != "" && text == "" {
-					text = "Sent " + m.MediaType
-				}
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 					m.Timestamp.Local().Format("2006-01-02 15:04:05"),
 					truncate(chatLabel, 24),
 					truncate(from, 18),
 					truncate(m.MsgID, 14),
-					truncate(text, 80),
+					truncate(messageHumanText(m), 80),
 				)
 			}
 			_ = w.Flush()
@@ -188,10 +181,7 @@ func newMessagesSearchCmd(flags *rootFlags) *cobra.Command {
 				}
 				match := m.Snippet
 				if match == "" {
-					match = strings.TrimSpace(m.DisplayText)
-				}
-				if match == "" {
-					match = m.Text
+					match = messageDisplayText(m)
 				}
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 					m.Timestamp.Local().Format("2006-01-02 15:04:05"),
@@ -254,15 +244,30 @@ func newMessagesShowCmd(flags *rootFlags) *cobra.Command {
 			}
 			fmt.Fprintf(os.Stdout, "ID: %s\n", m.MsgID)
 			fmt.Fprintf(os.Stdout, "Time: %s\n", m.Timestamp.Local().Format(time.RFC3339))
-			if m.FromMe {
-				fmt.Fprintf(os.Stdout, "From: me\n")
-			} else {
-				fmt.Fprintf(os.Stdout, "From: %s\n", m.SenderJID)
-			}
+			fmt.Fprintf(os.Stdout, "From: %s\n", messageSenderDetail(m))
 			if m.MediaType != "" {
 				fmt.Fprintf(os.Stdout, "Media: %s\n", m.MediaType)
 			}
-			fmt.Fprintf(os.Stdout, "\n%s\n", m.Text)
+			if m.MediaCaption != "" {
+				fmt.Fprintf(os.Stdout, "Caption: %s\n", m.MediaCaption)
+			}
+			if m.Filename != "" {
+				fmt.Fprintf(os.Stdout, "Filename: %s\n", m.Filename)
+			}
+			if m.MimeType != "" {
+				fmt.Fprintf(os.Stdout, "MIME type: %s\n", m.MimeType)
+			}
+			if m.LocalPath != "" {
+				fmt.Fprintf(os.Stdout, "Downloaded: %s\n", m.LocalPath)
+				if !m.DownloadedAt.IsZero() {
+					fmt.Fprintf(os.Stdout, "Downloaded at: %s\n", m.DownloadedAt.Local().Format(time.RFC3339))
+				}
+			}
+
+			fmt.Fprintf(os.Stdout, "\n%s\n", messageHumanText(m))
+			if raw := messageRawText(m); raw != "" {
+				fmt.Fprintf(os.Stdout, "\nRaw text:\n%s\n", raw)
+			}
 			return nil
 		},
 	}
@@ -307,17 +312,13 @@ func newMessagesContextCmd(flags *rootFlags) *cobra.Command {
 			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
 			fmt.Fprintln(w, "TIME\tFROM\tID\tTEXT")
 			for _, m := range msgs {
-				from := m.SenderJID
-				if m.FromMe {
-					from = "me"
-				}
-				line := m.Text
+				line := messageHumanText(m)
 				if m.MsgID == id {
 					line = ">> " + line
 				}
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
 					m.Timestamp.Local().Format("2006-01-02 15:04:05"),
-					truncate(from, 18),
+					truncate(messageSenderLabel(m), 18),
 					truncate(m.MsgID, 14),
 					truncate(line, 100),
 				)
@@ -331,4 +332,65 @@ func newMessagesContextCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().IntVar(&before, "before", 5, "messages before")
 	cmd.Flags().IntVar(&after, "after", 5, "messages after")
 	return cmd
+}
+
+func messageDisplayText(m store.Message) string {
+	text := strings.TrimSpace(m.DisplayText)
+	if text != "" {
+		return text
+	}
+	text = strings.TrimSpace(m.Text)
+	if text != "" {
+		return text
+	}
+	if mediaType := strings.TrimSpace(m.MediaType); mediaType != "" {
+		return "Sent " + mediaType
+	}
+	return ""
+}
+
+func messageHumanText(m store.Message) string {
+	if text := messageDisplayText(m); text != "" {
+		return text
+	}
+	return "(message)"
+}
+
+func messageRawText(m store.Message) string {
+	raw := strings.TrimSpace(m.Text)
+	if raw == "" {
+		return ""
+	}
+	if raw == messageDisplayText(m) {
+		return ""
+	}
+	return raw
+}
+
+func messageSenderLabel(m store.Message) string {
+	if m.FromMe {
+		return "me"
+	}
+	if name := strings.TrimSpace(m.SenderName); name != "" {
+		return name
+	}
+	return strings.TrimSpace(m.SenderJID)
+}
+
+func messageSenderDetail(m store.Message) string {
+	if m.FromMe {
+		return "me"
+	}
+	name := strings.TrimSpace(m.SenderName)
+	jid := strings.TrimSpace(m.SenderJID)
+	switch {
+	case name != "" && jid != "" && name != jid:
+		return fmt.Sprintf("%s (%s)", name, jid)
+	case name != "":
+		return name
+	case jid != "":
+		return jid
+	default:
+		return "(unknown)"
+	}
 }

--- a/cmd/wacli/messages_test.go
+++ b/cmd/wacli/messages_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/steipete/wacli/internal/store"
+)
+
+func TestMessageHumanTextPrefersDisplayText(t *testing.T) {
+	msg := store.Message{
+		Text:        "raw reply",
+		DisplayText: "> quoted text\nraw reply",
+	}
+
+	if got := messageHumanText(msg); got != "> quoted text\nraw reply" {
+		t.Fatalf("expected display text fallback, got %q", got)
+	}
+	if got := messageRawText(msg); got != "raw reply" {
+		t.Fatalf("expected raw text to remain available, got %q", got)
+	}
+}
+
+func TestMessageHumanTextFallsBackToMediaLabel(t *testing.T) {
+	msg := store.Message{MediaType: "image"}
+
+	if got := messageHumanText(msg); got != "Sent image" {
+		t.Fatalf("expected media fallback, got %q", got)
+	}
+	if got := messageRawText(msg); got != "" {
+		t.Fatalf("expected no raw text fallback, got %q", got)
+	}
+}
+
+func TestMessageSenderLabelsPreferName(t *testing.T) {
+	msg := store.Message{
+		SenderJID:  "123@s.whatsapp.net",
+		SenderName: "Alice Example",
+	}
+
+	if got := messageSenderLabel(msg); got != "Alice Example" {
+		t.Fatalf("expected sender label to prefer name, got %q", got)
+	}
+	if got := messageSenderDetail(msg); got != "Alice Example (123@s.whatsapp.net)" {
+		t.Fatalf("expected sender detail to include name and JID, got %q", got)
+	}
+}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -70,7 +70,10 @@ func (d *DB) ListMessages(p ListMessagesParams) ([]Message, error) {
 		p.Limit = 50
 	}
 	query := `
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me,
+		       COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''),
+		       COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''),
+		       COALESCE(m.downloaded_at,0), ''
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		WHERE 1=1`
@@ -94,7 +97,10 @@ func (d *DB) ListMessages(p ListMessagesParams) ([]Message, error) {
 
 func (d *DB) GetMessage(chatJID, msgID string) (Message, error) {
 	row := d.sql.QueryRow(`
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me,
+		       COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''),
+		       COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''),
+		       COALESCE(m.downloaded_at,0), ''
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		WHERE m.chat_jid = ? AND m.msg_id = ?
@@ -102,11 +108,31 @@ func (d *DB) GetMessage(chatJID, msgID string) (Message, error) {
 	var m Message
 	var ts int64
 	var fromMe int
-	if err := row.Scan(&m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &ts, &fromMe, &m.Text, &m.DisplayText, &m.MediaType, &m.Snippet); err != nil {
+	var downloadedAt int64
+	if err := row.Scan(
+		&m.ChatJID,
+		&m.ChatName,
+		&m.MsgID,
+		&m.SenderJID,
+		&m.SenderName,
+		&ts,
+		&fromMe,
+		&m.Text,
+		&m.DisplayText,
+		&m.MediaType,
+		&m.MediaCaption,
+		&m.Filename,
+		&m.MimeType,
+		&m.DirectPath,
+		&m.LocalPath,
+		&downloadedAt,
+		&m.Snippet,
+	); err != nil {
 		return Message{}, err
 	}
 	m.Timestamp = fromUnix(ts)
 	m.FromMe = fromMe != 0
+	m.DownloadedAt = fromUnix(downloadedAt)
 	return m, nil
 }
 
@@ -155,7 +181,10 @@ func (d *DB) MessageContext(chatJID, msgID string, before, after int) ([]Message
 	}
 
 	beforeRows, err := d.scanMessages(`
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me,
+		       COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''),
+		       COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''),
+		       COALESCE(m.downloaded_at,0), ''
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		WHERE m.chat_jid = ? AND m.ts < ?
@@ -167,7 +196,10 @@ func (d *DB) MessageContext(chatJID, msgID string, before, after int) ([]Message
 	}
 
 	afterRows, err := d.scanMessages(`
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me,
+		       COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''),
+		       COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''),
+		       COALESCE(m.downloaded_at,0), ''
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		WHERE m.chat_jid = ? AND m.ts > ?
@@ -202,11 +234,31 @@ func (d *DB) scanMessages(query string, args ...interface{}) ([]Message, error) 
 		var m Message
 		var ts int64
 		var fromMe int
-		if err := rows.Scan(&m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &ts, &fromMe, &m.Text, &m.DisplayText, &m.MediaType, &m.Snippet); err != nil {
+		var downloadedAt int64
+		if err := rows.Scan(
+			&m.ChatJID,
+			&m.ChatName,
+			&m.MsgID,
+			&m.SenderJID,
+			&m.SenderName,
+			&ts,
+			&fromMe,
+			&m.Text,
+			&m.DisplayText,
+			&m.MediaType,
+			&m.MediaCaption,
+			&m.Filename,
+			&m.MimeType,
+			&m.DirectPath,
+			&m.LocalPath,
+			&downloadedAt,
+			&m.Snippet,
+		); err != nil {
 			return nil, err
 		}
 		m.Timestamp = fromUnix(ts)
 		m.FromMe = fromMe != 0
+		m.DownloadedAt = fromUnix(downloadedAt)
 		out = append(out, m)
 	}
 	return out, rows.Err()

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -32,7 +32,10 @@ func (d *DB) SearchMessages(p SearchMessagesParams) ([]Message, error) {
 
 func (d *DB) searchLIKE(p SearchMessagesParams) ([]Message, error) {
 	query := `
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), ''
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me,
+		       COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''),
+		       COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''),
+		       COALESCE(m.downloaded_at,0), ''
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		WHERE (LOWER(m.text) LIKE LOWER(?) OR LOWER(m.display_text) LIKE LOWER(?) OR LOWER(m.media_caption) LIKE LOWER(?) OR LOWER(m.filename) LIKE LOWER(?) OR LOWER(COALESCE(m.chat_name,'')) LIKE LOWER(?) OR LOWER(COALESCE(m.sender_name,'')) LIKE LOWER(?) OR LOWER(COALESCE(c.name,'')) LIKE LOWER(?))`
@@ -46,7 +49,10 @@ func (d *DB) searchLIKE(p SearchMessagesParams) ([]Message, error) {
 
 func (d *DB) searchFTS(p SearchMessagesParams) ([]Message, error) {
 	query := `
-		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''),
+		SELECT m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me,
+		       COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''),
+		       COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''),
+		       COALESCE(m.downloaded_at,0),
 		       snippet(messages_fts, 0, '[', ']', '…', 12)
 		FROM messages_fts
 		JOIN messages m ON messages_fts.rowid = m.rowid

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -185,6 +185,67 @@ func TestMediaDownloadInfoAndMarkDownloaded(t *testing.T) {
 	}
 }
 
+func TestGetMessageReturnsRichDetails(t *testing.T) {
+	db := openTestDB(t)
+
+	chat := "123@s.whatsapp.net"
+	if err := db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+
+	ts := time.Date(2024, 3, 2, 0, 0, 0, 0, time.UTC)
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:       chat,
+		ChatName:      "Alice",
+		MsgID:         "mid",
+		SenderJID:     chat,
+		SenderName:    "Alice Example",
+		Timestamp:     ts,
+		FromMe:        false,
+		Text:          "caption text",
+		DisplayText:   "Sent image",
+		MediaType:     "image",
+		MediaCaption:  "caption text",
+		Filename:      "pic.jpg",
+		MimeType:      "image/jpeg",
+		DirectPath:    "/direct/path",
+		MediaKey:      []byte{1, 2, 3},
+		FileSHA256:    []byte{4, 5},
+		FileEncSHA256: []byte{6, 7},
+		FileLength:    123,
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	when := time.Date(2024, 3, 2, 0, 0, 1, 0, time.UTC)
+	if err := db.MarkMediaDownloaded(chat, "mid", "/tmp/file", when); err != nil {
+		t.Fatalf("MarkMediaDownloaded: %v", err)
+	}
+
+	msg, err := db.GetMessage(chat, "mid")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if msg.SenderName != "Alice Example" {
+		t.Fatalf("expected SenderName to round-trip, got %q", msg.SenderName)
+	}
+	if msg.DisplayText != "Sent image" {
+		t.Fatalf("expected DisplayText to round-trip, got %q", msg.DisplayText)
+	}
+	if msg.MediaCaption != "caption text" {
+		t.Fatalf("expected MediaCaption to round-trip, got %q", msg.MediaCaption)
+	}
+	if msg.Filename != "pic.jpg" || msg.MimeType != "image/jpeg" || msg.DirectPath != "/direct/path" {
+		t.Fatalf("unexpected media details: %+v", msg)
+	}
+	if msg.LocalPath != "/tmp/file" {
+		t.Fatalf("expected LocalPath to round-trip, got %q", msg.LocalPath)
+	}
+	if !msg.DownloadedAt.Equal(when) {
+		t.Fatalf("expected DownloadedAt=%s, got %s", when, msg.DownloadedAt)
+	}
+}
+
 func TestContactsAliasTagsAndSearch(t *testing.T) {
 	db := openTestDB(t)
 

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -46,16 +46,23 @@ type MediaDownloadInfo struct {
 }
 
 type Message struct {
-	ChatJID     string
-	ChatName    string
-	MsgID       string
-	SenderJID   string
-	Timestamp   time.Time
-	FromMe      bool
-	Text        string
-	DisplayText string
-	MediaType   string
-	Snippet     string
+	ChatJID      string
+	ChatName     string
+	MsgID        string
+	SenderJID    string
+	SenderName   string
+	Timestamp    time.Time
+	FromMe       bool
+	Text         string
+	DisplayText  string
+	MediaType    string
+	MediaCaption string
+	Filename     string
+	MimeType     string
+	DirectPath   string
+	LocalPath    string
+	DownloadedAt time.Time
+	Snippet      string
 }
 
 type MessageInfo struct {


### PR DESCRIPTION
# Description
## Summary
- prefer stored `display_text` when rendering `wacli messages show` and `wacli messages context`
- expose richer stored message details from the store layer so detail views can show sender names, captions, filenames, MIME types, and downloaded paths
- keep raw text available in `messages show` when it differs from the richer display text

## Testing
- `pnpm -s test:go`
- `pnpm -s test:fts`
- `pnpm -s lint`
- `pnpm -s build`

## Commit Stack
- `refactor(store): expose rich message detail fields.`
- `fix(messages): polish show and context output.`
- `test(messages): cover message detail rendering fallbacks.`
- `docs(messages): document show and context improvements.`
