### PR TITLE
Messages: add media-aware search filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Internal architecture: split store and groups command logic into focused modules for cleaner maintenance and safer follow-up changes.
+- Messages: add `messages search --has-media` plus normalized `--type` filtering, including `--type text` for plain messages.
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ pnpm wacli doctor
 
 # Search messages
 pnpm wacli messages search "meeting"
+pnpm wacli messages search "project" --has-media
+pnpm wacli messages search "project" --type text
 
 # Backfill older messages for a chat (best-effort; requires your primary device online)
 pnpm wacli history backfill --chat 1234567890@s.whatsapp.net --requests 10 --count 50

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -123,6 +123,7 @@ func newMessagesSearchCmd(flags *rootFlags) *cobra.Command {
 	var afterStr string
 	var beforeStr string
 	var msgType string
+	var hasMedia bool
 
 	cmd := &cobra.Command{
 		Use:   "search <query>",
@@ -155,14 +156,23 @@ func newMessagesSearchCmd(flags *rootFlags) *cobra.Command {
 				before = &t
 			}
 
+			normalizedType, err := normalizeMessageType(msgType)
+			if err != nil {
+				return err
+			}
+			if hasMedia && normalizedType == "text" {
+				return fmt.Errorf("--has-media cannot be combined with --type text")
+			}
+
 			msgs, err := a.DB().SearchMessages(store.SearchMessagesParams{
-				Query:   args[0],
-				ChatJID: chat,
-				From:    from,
-				Limit:   limit,
-				After:   after,
-				Before:  before,
-				Type:    msgType,
+				Query:    args[0],
+				ChatJID:  chat,
+				From:     from,
+				Limit:    limit,
+				After:    after,
+				Before:   before,
+				Type:     normalizedType,
+				HasMedia: hasMedia,
 			})
 			if err != nil {
 				return err
@@ -214,7 +224,8 @@ func newMessagesSearchCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().IntVar(&limit, "limit", 50, "limit results")
 	cmd.Flags().StringVar(&afterStr, "after", "", "only messages after time (RFC3339 or YYYY-MM-DD)")
 	cmd.Flags().StringVar(&beforeStr, "before", "", "only messages before time (RFC3339 or YYYY-MM-DD)")
-	cmd.Flags().StringVar(&msgType, "type", "", "media type filter (image|video|audio|document)")
+	cmd.Flags().StringVar(&msgType, "type", "", "message type filter (text|image|video|audio|document|gif|sticker)")
+	cmd.Flags().BoolVar(&hasMedia, "has-media", false, "only return messages that include media")
 	return cmd
 }
 
@@ -331,4 +342,14 @@ func newMessagesContextCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().IntVar(&before, "before", 5, "messages before")
 	cmd.Flags().IntVar(&after, "after", 5, "messages after")
 	return cmd
+}
+
+func normalizeMessageType(value string) (string, error) {
+	msgType := strings.ToLower(strings.TrimSpace(value))
+	switch msgType {
+	case "", "text", "image", "video", "audio", "document", "gif", "sticker":
+		return msgType, nil
+	default:
+		return "", fmt.Errorf("unsupported --type %q (use text, image, video, audio, document, gif, or sticker)", value)
+	}
 }

--- a/cmd/wacli/messages_search_test.go
+++ b/cmd/wacli/messages_search_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestNormalizeMessageType(t *testing.T) {
+	tests := map[string]string{
+		"":         "",
+		"text":     "text",
+		" IMAGE ":  "image",
+		"video":    "video",
+		"audio":    "audio",
+		"document": "document",
+		"gif":      "gif",
+		"sticker":  "sticker",
+	}
+
+	for input, want := range tests {
+		got, err := normalizeMessageType(input)
+		if err != nil {
+			t.Fatalf("normalizeMessageType(%q) returned error: %v", input, err)
+		}
+		if got != want {
+			t.Fatalf("normalizeMessageType(%q)=%q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestNormalizeMessageTypeRejectsUnsupportedValues(t *testing.T) {
+	if _, err := normalizeMessageType("voice-note"); err == nil {
+		t.Fatalf("expected unsupported type to return an error")
+	}
+}

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -7,13 +7,14 @@ import (
 )
 
 type SearchMessagesParams struct {
-	Query   string
-	ChatJID string
-	From    string
-	Limit   int
-	Before  *time.Time
-	After   *time.Time
-	Type    string
+	Query    string
+	ChatJID  string
+	From     string
+	Limit    int
+	Before   *time.Time
+	After    *time.Time
+	Type     string
+	HasMedia bool
 }
 
 func (d *DB) SearchMessages(p SearchMessagesParams) ([]Message, error) {
@@ -76,9 +77,16 @@ func applyMessageFilters(query string, args []interface{}, p SearchMessagesParam
 		query += " AND m.ts < ?"
 		args = append(args, unix(*p.Before))
 	}
-	if strings.TrimSpace(p.Type) != "" {
-		query += " AND COALESCE(m.media_type,'') = ?"
-		args = append(args, p.Type)
+	if p.HasMedia {
+		query += " AND COALESCE(m.media_type,'') != ''"
+	}
+	switch msgType := strings.ToLower(strings.TrimSpace(p.Type)); msgType {
+	case "":
+	case "text":
+		query += " AND COALESCE(m.media_type,'') = ''"
+	default:
+		query += " AND LOWER(COALESCE(m.media_type,'')) = ?"
+		args = append(args, msgType)
 	}
 	return query, args
 }

--- a/internal/store/search_fts_test.go
+++ b/internal/store/search_fts_test.go
@@ -41,3 +41,52 @@ func TestSearchMessagesUsesFTSWhenEnabled(t *testing.T) {
 		t.Fatalf("expected snippet for FTS search, got empty")
 	}
 }
+
+func TestSearchMessagesAppliesMediaFiltersWithFTS(t *testing.T) {
+	db := openTestDB(t)
+	chat := seedSearchFilterMessages(t, db)
+
+	withMedia, err := db.SearchMessages(SearchMessagesParams{
+		Query:    "project",
+		ChatJID:  chat,
+		HasMedia: true,
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("SearchMessages with media: %v", err)
+	}
+	if len(withMedia) != 2 {
+		t.Fatalf("expected 2 media results, got %d", len(withMedia))
+	}
+	for _, msg := range withMedia {
+		if msg.MediaType == "" {
+			t.Fatalf("expected only media results, got %+v", msg)
+		}
+	}
+
+	textOnly, err := db.SearchMessages(SearchMessagesParams{
+		Query:   "project",
+		ChatJID: chat,
+		Type:    "text",
+		Limit:   10,
+	})
+	if err != nil {
+		t.Fatalf("SearchMessages text: %v", err)
+	}
+	if len(textOnly) != 1 || textOnly[0].MsgID != "m-text" {
+		t.Fatalf("expected only text result, got %+v", textOnly)
+	}
+
+	imageOnly, err := db.SearchMessages(SearchMessagesParams{
+		Query:   "project",
+		ChatJID: chat,
+		Type:    "image",
+		Limit:   10,
+	})
+	if err != nil {
+		t.Fatalf("SearchMessages image: %v", err)
+	}
+	if len(imageOnly) != 1 || imageOnly[0].MsgID != "m-image" {
+		t.Fatalf("expected only image result, got %+v", imageOnly)
+	}
+}

--- a/internal/store/search_nonfts_test.go
+++ b/internal/store/search_nonfts_test.go
@@ -41,3 +41,52 @@ func TestSearchMessagesUsesLIKEWhenFTSDisabled(t *testing.T) {
 		t.Fatalf("expected empty snippet for LIKE search, got %q", ms[0].Snippet)
 	}
 }
+
+func TestSearchMessagesAppliesMediaFiltersWithoutFTS(t *testing.T) {
+	db := openTestDB(t)
+	chat := seedSearchFilterMessages(t, db)
+
+	withMedia, err := db.SearchMessages(SearchMessagesParams{
+		Query:    "project",
+		ChatJID:  chat,
+		HasMedia: true,
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("SearchMessages with media: %v", err)
+	}
+	if len(withMedia) != 2 {
+		t.Fatalf("expected 2 media results, got %d", len(withMedia))
+	}
+	for _, msg := range withMedia {
+		if msg.MediaType == "" {
+			t.Fatalf("expected only media results, got %+v", msg)
+		}
+	}
+
+	textOnly, err := db.SearchMessages(SearchMessagesParams{
+		Query:   "project",
+		ChatJID: chat,
+		Type:    "text",
+		Limit:   10,
+	})
+	if err != nil {
+		t.Fatalf("SearchMessages text: %v", err)
+	}
+	if len(textOnly) != 1 || textOnly[0].MsgID != "m-text" {
+		t.Fatalf("expected only text result, got %+v", textOnly)
+	}
+
+	imageOnly, err := db.SearchMessages(SearchMessagesParams{
+		Query:   "project",
+		ChatJID: chat,
+		Type:    "image",
+		Limit:   10,
+	})
+	if err != nil {
+		t.Fatalf("SearchMessages image: %v", err)
+	}
+	if len(imageOnly) != 1 || imageOnly[0].MsgID != "m-image" {
+		t.Fatalf("expected only image result, got %+v", imageOnly)
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -29,6 +29,60 @@ func countRows(t *testing.T, db *sql.DB, q string, args ...any) int {
 	return n
 }
 
+func seedSearchFilterMessages(t *testing.T, db *DB) string {
+	t.Helper()
+
+	chat := "123@s.whatsapp.net"
+	base := time.Date(2024, 2, 5, 0, 0, 0, 0, time.UTC)
+
+	if err := db.UpsertChat(chat, "dm", "Alice", base); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+
+	fixtures := []UpsertMessageParams{
+		{
+			ChatJID:    chat,
+			ChatName:   "Alice",
+			MsgID:      "m-text",
+			SenderJID:  chat,
+			SenderName: "Alice",
+			Timestamp:  base.Add(1 * time.Second),
+			Text:       "project update",
+		},
+		{
+			ChatJID:      chat,
+			ChatName:     "Alice",
+			MsgID:        "m-image",
+			SenderJID:    chat,
+			SenderName:   "Alice",
+			Timestamp:    base.Add(2 * time.Second),
+			Text:         "project screenshot",
+			DisplayText:  "Sent image",
+			MediaType:    "image",
+			MediaCaption: "project screenshot",
+		},
+		{
+			ChatJID:     chat,
+			ChatName:    "Alice",
+			MsgID:       "m-doc",
+			SenderJID:   chat,
+			SenderName:  "Alice",
+			Timestamp:   base.Add(3 * time.Second),
+			DisplayText: "Sent document",
+			MediaType:   "document",
+			Filename:    "project-plan.pdf",
+		},
+	}
+
+	for _, fixture := range fixtures {
+		if err := db.UpsertMessage(fixture); err != nil {
+			t.Fatalf("UpsertMessage %s: %v", fixture.MsgID, err)
+		}
+	}
+
+	return chat
+}
+
 func TestUpsertChatNameAndLastMessageTS(t *testing.T) {
 	db := openTestDB(t)
 


### PR DESCRIPTION
# Description
## Summary
- add `wacli messages search --has-media` for quickly narrowing search results to media-bearing messages
- normalize and validate `--type`, including support for `--type text` to target plain text messages with no media type
- keep FTS and non-FTS search behavior aligned with matching filter coverage in tests

## Testing
- `pnpm -s test:go`
- `pnpm -s test:fts`
- `pnpm -s lint`
- `pnpm -s build`

## Commit Stack
- `refactor(store): extend search filter plumbing.`
- `feat(messages): add media-aware search filters.`
- `test(search): cover media and text filter behavior.`
- `docs(messages): document search filter additions.`
