### PR TITLE
CLI: add read-only mode for automation and agent safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Internal architecture: split store and groups command logic into focused modules for cleaner maintenance and safer follow-up changes.
+- CLI: add read-only mode via `--readonly` / `WACLI_READONLY=1` to block explicit mutating commands for automation and agent use.
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Defaults to `~/.wacli` (override with `--store DIR`).
 
 - `WACLI_DEVICE_LABEL`: set the linked device label (shown in WhatsApp).
 - `WACLI_DEVICE_PLATFORM`: override the linked device platform (defaults to `CHROME` if unset or invalid).
+- `WACLI_READONLY=1`: disable explicit mutating commands such as `send`, `auth`, group changes, and local alias/tag writes. You can also pass `--readonly`.
 
 ## Backfilling older history
 

--- a/cmd/wacli/auth.go
+++ b/cmd/wacli/auth.go
@@ -23,6 +23,9 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 		Use:   "auth",
 		Short: "Authenticate with WhatsApp (QR) and bootstrap sync",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireWritable(flags); err != nil {
+				return err
+			}
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 			defer stop()
 
@@ -116,6 +119,9 @@ func newAuthLogoutCmd(flags *rootFlags) *cobra.Command {
 		Use:   "logout",
 		Short: "Logout (invalidate session)",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireWritable(flags); err != nil {
+				return err
+			}
 			ctx, cancel := withTimeout(context.Background(), flags)
 			defer cancel()
 

--- a/cmd/wacli/contacts.go
+++ b/cmd/wacli/contacts.go
@@ -168,6 +168,9 @@ func newContactsAliasCmd(flags *rootFlags) *cobra.Command {
 		Use:   "set",
 		Short: "Set alias",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireWritable(flags); err != nil {
+				return err
+			}
 			jid, _ := cmd.Flags().GetString("jid")
 			alias, _ := cmd.Flags().GetString("alias")
 			if strings.TrimSpace(jid) == "" || strings.TrimSpace(alias) == "" {
@@ -194,6 +197,9 @@ func newContactsAliasCmd(flags *rootFlags) *cobra.Command {
 		Use:   "rm",
 		Short: "Remove alias",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireWritable(flags); err != nil {
+				return err
+			}
 			jid, _ := cmd.Flags().GetString("jid")
 			if strings.TrimSpace(jid) == "" {
 				return fmt.Errorf("--jid is required")
@@ -230,6 +236,9 @@ func newContactsTagsCmd(flags *rootFlags) *cobra.Command {
 		Use:   "add",
 		Short: "Add tag",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireWritable(flags); err != nil {
+				return err
+			}
 			jid, _ := cmd.Flags().GetString("jid")
 			tag, _ := cmd.Flags().GetString("tag")
 			if strings.TrimSpace(jid) == "" || strings.TrimSpace(tag) == "" {
@@ -256,6 +265,9 @@ func newContactsTagsCmd(flags *rootFlags) *cobra.Command {
 		Use:   "rm",
 		Short: "Remove tag",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireWritable(flags); err != nil {
+				return err
+			}
 			jid, _ := cmd.Flags().GetString("jid")
 			tag, _ := cmd.Flags().GetString("tag")
 			if strings.TrimSpace(jid) == "" || strings.TrimSpace(tag) == "" {

--- a/cmd/wacli/groups_info_rename.go
+++ b/cmd/wacli/groups_info_rename.go
@@ -74,6 +74,9 @@ func newGroupsRenameCmd(flags *rootFlags) *cobra.Command {
 		Use:   "rename",
 		Short: "Rename group",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireWritable(flags); err != nil {
+				return err
+			}
 			if strings.TrimSpace(jidStr) == "" || strings.TrimSpace(name) == "" {
 				return fmt.Errorf("--jid and --name are required")
 			}
@@ -121,6 +124,9 @@ func newGroupsLeaveCmd(flags *rootFlags) *cobra.Command {
 		Use:   "leave",
 		Short: "Leave a group",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireWritable(flags); err != nil {
+				return err
+			}
 			if strings.TrimSpace(jidStr) == "" {
 				return fmt.Errorf("--jid is required")
 			}

--- a/cmd/wacli/groups_invite_join.go
+++ b/cmd/wacli/groups_invite_join.go
@@ -79,6 +79,9 @@ func newGroupsInviteLinkRevokeCmd(flags *rootFlags) *cobra.Command {
 		Use:   "revoke",
 		Short: "Revoke/reset invite link",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireWritable(flags); err != nil {
+				return err
+			}
 			if strings.TrimSpace(jidStr) == "" {
 				return fmt.Errorf("--jid is required")
 			}
@@ -122,6 +125,9 @@ func newGroupsJoinCmd(flags *rootFlags) *cobra.Command {
 		Use:   "join",
 		Short: "Join group by invite code",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireWritable(flags); err != nil {
+				return err
+			}
 			if strings.TrimSpace(code) == "" {
 				return fmt.Errorf("--code is required")
 			}

--- a/cmd/wacli/groups_participants.go
+++ b/cmd/wacli/groups_participants.go
@@ -31,6 +31,9 @@ func newGroupsParticipantsActionCmd(flags *rootFlags, action string) *cobra.Comm
 		Use:   action,
 		Short: action + " participants",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireWritable(flags); err != nil {
+				return err
+			}
 			if strings.TrimSpace(group) == "" || len(users) == 0 {
 				return fmt.Errorf("--jid and at least one --user are required")
 			}

--- a/cmd/wacli/readonly_test.go
+++ b/cmd/wacli/readonly_test.go
@@ -1,0 +1,54 @@
+package main
+
+import "testing"
+
+func TestSendTextBlockedInReadOnlyMode(t *testing.T) {
+	flags := &rootFlags{readOnly: true}
+	cmd := newSendTextCmd(flags)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--to", "1234567890", "--message", "hello"})
+
+	err := cmd.Execute()
+	if err == nil || err.Error() != readOnlyErrorMessage {
+		t.Fatalf("expected read-only error, got %v", err)
+	}
+}
+
+func TestAuthBlockedInReadOnlyMode(t *testing.T) {
+	flags := &rootFlags{readOnly: true}
+	cmd := newAuthCmd(flags)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	if err == nil || err.Error() != readOnlyErrorMessage {
+		t.Fatalf("expected read-only error, got %v", err)
+	}
+}
+
+func TestGroupsRenameBlockedInReadOnlyMode(t *testing.T) {
+	flags := &rootFlags{readOnly: true}
+	cmd := newGroupsRenameCmd(flags)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--jid", "123456@g.us", "--name", "Renamed"})
+
+	err := cmd.Execute()
+	if err == nil || err.Error() != readOnlyErrorMessage {
+		t.Fatalf("expected read-only error, got %v", err)
+	}
+}
+
+func TestContactsAliasSetBlockedInReadOnlyMode(t *testing.T) {
+	flags := &rootFlags{readOnly: true}
+	cmd := newContactsAliasCmd(flags)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"set", "--jid", "1234567890@s.whatsapp.net", "--alias", "Alice"})
+
+	err := cmd.Execute()
+	if err == nil || err.Error() != readOnlyErrorMessage {
+		t.Fatalf("expected read-only error, got %v", err)
+	}
+}

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -21,10 +21,15 @@ type rootFlags struct {
 	storeDir string
 	asJSON   bool
 	timeout  time.Duration
+	readOnly bool
 }
 
+const readOnlyErrorMessage = "wacli is running in read-only mode (--readonly or WACLI_READONLY=1); write operations are disabled"
+
 func execute(args []string) error {
-	var flags rootFlags
+	flags := rootFlags{
+		readOnly: config.ReadOnlyEnabled(),
+	}
 
 	rootCmd := &cobra.Command{
 		Use:           "wacli",
@@ -37,6 +42,7 @@ func execute(args []string) error {
 	rootCmd.PersistentFlags().StringVar(&flags.storeDir, "store", "", "store directory (default: ~/.wacli)")
 	rootCmd.PersistentFlags().BoolVar(&flags.asJSON, "json", false, "output JSON instead of human-readable text")
 	rootCmd.PersistentFlags().DurationVar(&flags.timeout, "timeout", 5*time.Minute, "command timeout (non-sync commands)")
+	rootCmd.PersistentFlags().BoolVar(&flags.readOnly, "readonly", flags.readOnly, "disable write operations (or set WACLI_READONLY=1)")
 
 	rootCmd.AddCommand(newVersionCmd())
 	rootCmd.AddCommand(newDoctorCmd(&flags))
@@ -114,4 +120,11 @@ func wrapErr(err error, msg string) error {
 		return err
 	}
 	return fmt.Errorf("%s: %w", msg, err)
+}
+
+func requireWritable(flags *rootFlags) error {
+	if flags == nil || !flags.readOnly {
+		return nil
+	}
+	return fmt.Errorf(readOnlyErrorMessage)
 }

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -30,6 +30,9 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 		Use:   "text",
 		Short: "Send a text message",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireWritable(flags); err != nil {
+				return err
+			}
 			if to == "" || message == "" {
 				return fmt.Errorf("--to and --message are required")
 			}

--- a/cmd/wacli/send_file_cmd.go
+++ b/cmd/wacli/send_file_cmd.go
@@ -21,6 +21,9 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 		Use:   "file",
 		Short: "Send a file (image/video/audio/document)",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireWritable(flags); err != nil {
+				return err
+			}
 			if to == "" || filePath == "" {
 				return fmt.Errorf("--to and --file are required")
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func DefaultStoreDir() string {
@@ -11,4 +12,14 @@ func DefaultStoreDir() string {
 		return ".wacli"
 	}
 	return filepath.Join(home, ".wacli")
+}
+
+func ReadOnlyEnabled() bool {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv("WACLI_READONLY")))
+	switch value {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,19 @@
+package config
+
+import "testing"
+
+func TestReadOnlyEnabled(t *testing.T) {
+	t.Setenv("WACLI_READONLY", "1")
+
+	if !ReadOnlyEnabled() {
+		t.Fatalf("expected WACLI_READONLY=1 to enable read-only mode")
+	}
+}
+
+func TestReadOnlyEnabledFalseByDefault(t *testing.T) {
+	t.Setenv("WACLI_READONLY", "")
+
+	if ReadOnlyEnabled() {
+		t.Fatalf("expected empty WACLI_READONLY to leave read-only mode disabled")
+	}
+}


### PR DESCRIPTION
## Summary
- add a global `--readonly` flag plus `WACLI_READONLY=1`
- block explicit mutating commands early with a consistent error before any network or WhatsApp session work begins
- keep read-oriented workflows such as search, sync, backfill, and diagnostics unaffected

## Testing
- `pnpm -s test:go`
- `pnpm -s test:fts`
- `pnpm -s lint`
- `pnpm -s build`

## Commit Stack
- `refactor(cli): wire read-only mode configuration.`
- `feat(cli): enforce read-only command guards.`
- `test(readonly): cover command and env enforcement.`
- `docs(readonly): document read-only mode.`

Closes #96.
