### PR TITLE
Fix FTS5 detection when migration was applied by non-FTS5 build

### DIFF
--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -66,6 +66,20 @@ func (d *DB) ensureSchema() error {
 		}
 	}
 
+	// Post-migration: detect FTS5 availability even when migration 3 was
+	// already applied by a non-FTS5 build. The table may exist (created by
+	// system sqlite or a prior run) but ftsEnabled was never set because the
+	// migration was skipped.
+	if !d.ftsEnabled {
+		if ok, _ := d.tableExists("messages_fts"); ok {
+			var dummy int
+			err := d.sql.QueryRow(`SELECT rowid FROM messages_fts LIMIT 1`).Scan(&dummy)
+			if err == nil || errors.Is(err, sql.ErrNoRows) {
+				d.ftsEnabled = true
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Fixes a bug where `ftsEnabled` stays `false` when an FTS5-capable binary opens a database whose migration 3 was previously applied by a non-FTS5 build
- The migration system skips already-applied migrations, so the FTS5 enablement path in migration 3 is never reached on subsequent opens
- Adds a post-migration check: if `ftsEnabled` is still false after migrations, probes for an existing `messages_fts` table and verifies it is queryable before setting `ftsEnabled = true`

## Bug details

1. User runs wacli built **without** FTS5 → migration 3 runs, creates FTS tables using system SQLite (which may or may not support FTS5)
2. User upgrades to wacli built **with** FTS5 → migration 3 is skipped (DB already at version 3+)
3. `ftsEnabled` remains `false` → full-text search is silently unavailable despite the binary supporting it and the table existing

## Test plan

- [ ] Build without FTS5, run to apply migration 3, then rebuild with FTS5 and verify full-text search works
- [ ] Fresh install with FTS5 build still works as before
- [ ] DB without any FTS table does not incorrectly set `ftsEnabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)