### PR TITLE
fix: detect FTS5 support on every database open

### DIFF
--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -51,5 +51,22 @@ func (d *DB) init() error {
 	_, _ = d.sql.Exec("PRAGMA temp_store=MEMORY;")
 	_, _ = d.sql.Exec("PRAGMA foreign_keys=ON;")
 
-	return d.ensureSchema()
+	if err := d.ensureSchema(); err != nil {
+		return err
+	}
+
+	d.detectFTS()
+	return nil
+}
+
+func (d *DB) detectFTS() {
+	ok, err := d.tableExists("messages_fts")
+	if err != nil {
+		return
+	}
+	if ok {
+		d.ftsEnabled = true
+		return
+	}
+	_ = migrateMessagesFTS(d)
 }

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -64,9 +64,13 @@ func (d *DB) detectFTS() {
 	if err != nil {
 		return
 	}
-	if ok {
-		d.ftsEnabled = true
+	if !ok {
+		_ = migrateMessagesFTS(d)
 		return
 	}
-	_ = migrateMessagesFTS(d)
+	// Table exists — verify the engine can actually query it.
+	var n int
+	if d.sql.QueryRow("SELECT COUNT(*) FROM messages_fts LIMIT 1").Scan(&n) == nil {
+		d.ftsEnabled = true
+	}
 }


### PR DESCRIPTION
ftsEnabled was only set inside migrateMessagesFTS, which runs once and is skipped on subsequent opens. If the migration originally ran on a binary compiled without sqlite_fts5, the FTS table was never created and ftsEnabled stayed false permanently.

Probe for the messages_fts table on every Open() and re-run the FTS migration if the table is missing.

Fixes steipete/wacli#160

Made-with: Cursor