### PR TITLE
fix: escape LIKE wildcards in ListChats, ListGroups, and SearchContacts

### DIFF
--- a/cmd/wacli/helpers.go
+++ b/cmd/wacli/helpers.go
@@ -27,14 +27,15 @@ func parseTime(s string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("unsupported time format %q (use RFC3339 or YYYY-MM-DD)", s)
 }
 
-func truncate(s string, max int) string {
+func truncate(s string, maxRunes int) string {
 	s = strings.ReplaceAll(s, "\n", " ")
 	s = strings.TrimSpace(s)
-	if max <= 0 || len(s) <= max {
+	runes := []rune(s)
+	if maxRunes <= 0 || len(runes) <= maxRunes {
 		return s
 	}
-	if max <= 1 {
-		return s[:max]
+	if maxRunes <= 1 {
+		return string(runes[:maxRunes])
 	}
-	return s[:max-1] + "…"
+	return string(runes[:maxRunes-1]) + "…"
 }

--- a/internal/store/chats_contacts_groups.go
+++ b/internal/store/chats_contacts_groups.go
@@ -28,8 +28,8 @@ func (d *DB) ListChats(query string, limit int) ([]Chat, error) {
 	q := `SELECT jid, kind, COALESCE(name,''), COALESCE(last_message_ts,0) FROM chats WHERE 1=1`
 	var args []interface{}
 	if strings.TrimSpace(query) != "" {
-		q += ` AND (LOWER(name) LIKE LOWER(?) OR LOWER(jid) LIKE LOWER(?))`
-		needle := "%" + query + "%"
+		q += ` AND (LOWER(name) LIKE LOWER(?) ESCAPE '\' OR LOWER(jid) LIKE LOWER(?) ESCAPE '\')`
+		needle := "%" + escapeLIKE(query) + "%"
 		args = append(args, needle, needle)
 	}
 	q += ` ORDER BY last_message_ts DESC LIMIT ?`
@@ -80,10 +80,10 @@ func (d *DB) SearchContacts(query string, limit int) ([]Contact, error) {
 		       c.updated_at
 		FROM contacts c
 		LEFT JOIN contact_aliases a ON a.jid = c.jid
-		WHERE LOWER(COALESCE(a.alias,'')) LIKE LOWER(?) OR LOWER(COALESCE(c.full_name,'')) LIKE LOWER(?) OR LOWER(COALESCE(c.push_name,'')) LIKE LOWER(?) OR LOWER(COALESCE(c.phone,'')) LIKE LOWER(?) OR LOWER(c.jid) LIKE LOWER(?)
+		WHERE LOWER(COALESCE(a.alias,'')) LIKE LOWER(?) ESCAPE '\' OR LOWER(COALESCE(c.full_name,'')) LIKE LOWER(?) ESCAPE '\' OR LOWER(COALESCE(c.push_name,'')) LIKE LOWER(?) ESCAPE '\' OR LOWER(COALESCE(c.phone,'')) LIKE LOWER(?) ESCAPE '\' OR LOWER(c.jid) LIKE LOWER(?) ESCAPE '\'
 		ORDER BY COALESCE(NULLIF(a.alias,''), NULLIF(c.full_name,''), NULLIF(c.push_name,''), c.jid)
 		LIMIT ?`
-	needle := "%" + query + "%"
+	needle := "%" + escapeLIKE(query) + "%"
 	rows, err := d.sql.Query(q, needle, needle, needle, needle, needle, limit)
 	if err != nil {
 		return nil, err
@@ -213,8 +213,8 @@ func (d *DB) ListGroups(query string, limit int) ([]Group, error) {
 	q := `SELECT jid, COALESCE(name,''), COALESCE(owner_jid,''), COALESCE(created_ts,0), updated_at FROM groups WHERE 1=1`
 	var args []interface{}
 	if strings.TrimSpace(query) != "" {
-		needle := "%" + query + "%"
-		q += ` AND (LOWER(name) LIKE LOWER(?) OR LOWER(jid) LIKE LOWER(?))`
+		needle := "%" + escapeLIKE(query) + "%"
+		q += ` AND (LOWER(name) LIKE LOWER(?) ESCAPE '\' OR LOWER(jid) LIKE LOWER(?) ESCAPE '\')`
 		args = append(args, needle, needle)
 	}
 	q += ` ORDER BY COALESCE(created_ts,0) DESC LIMIT ?`

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -319,3 +319,111 @@ func TestGroupsUpsertListAndParticipantsReplace(t *testing.T) {
 		t.Fatalf("expected roles admin=1 member=1, got admin=%d member=%d", admins, members)
 	}
 }
+
+// TestListChatsWildcardEscape verifies that LIKE wildcards in chat search
+// queries are treated as literals, not SQL pattern chars.
+func TestListChatsWildcardEscape(t *testing.T) {
+	db := openTestDB(t)
+
+	if err := db.UpsertChat("100@s.whatsapp.net", "dm", "100% sure", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := db.UpsertChat("101@s.whatsapp.net", "dm", "some_person", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := db.UpsertChat("102@s.whatsapp.net", "dm", "another chat", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+
+	t.Run("percent returns only exact match", func(t *testing.T) {
+		cs, err := db.ListChats("100%", 50)
+		if err != nil {
+			t.Fatalf("ListChats: %v", err)
+		}
+		if len(cs) != 1 || cs[0].JID != "100@s.whatsapp.net" {
+			t.Fatalf("expected only 100@s, got %d results: %v", len(cs), cs)
+		}
+	})
+
+	t.Run("underscore returns only exact match", func(t *testing.T) {
+		cs, err := db.ListChats("some_person", 50)
+		if err != nil {
+			t.Fatalf("ListChats: %v", err)
+		}
+		if len(cs) != 1 || cs[0].JID != "101@s.whatsapp.net" {
+			t.Fatalf("expected only 101@s, got %d results: %v", len(cs), cs)
+		}
+	})
+}
+
+// TestListGroupsWildcardEscape verifies that LIKE wildcards in group search
+// queries are treated as literals, not SQL pattern chars.
+func TestListGroupsWildcardEscape(t *testing.T) {
+	db := openTestDB(t)
+
+	if err := db.UpsertGroup("200@g.us", "Team A 100%", "owner@s.whatsapp.net", time.Now()); err != nil {
+		t.Fatalf("UpsertGroup: %v", err)
+	}
+	if err := db.UpsertGroup("201@g.us", "Team_B", "owner@s.whatsapp.net", time.Now()); err != nil {
+		t.Fatalf("UpsertGroup: %v", err)
+	}
+	if err := db.UpsertGroup("202@g.us", "Team C", "owner@s.whatsapp.net", time.Now()); err != nil {
+		t.Fatalf("UpsertGroup: %v", err)
+	}
+
+	t.Run("percent returns only exact match", func(t *testing.T) {
+		gs, err := db.ListGroups("100%", 50)
+		if err != nil {
+			t.Fatalf("ListGroups: %v", err)
+		}
+		if len(gs) != 1 || gs[0].JID != "200@g.us" {
+			t.Fatalf("expected only 200@g.us, got %d results: %v", len(gs), gs)
+		}
+	})
+
+	t.Run("underscore returns only exact match", func(t *testing.T) {
+		gs, err := db.ListGroups("Team_B", 50)
+		if err != nil {
+			t.Fatalf("ListGroups: %v", err)
+		}
+		if len(gs) != 1 || gs[0].JID != "201@g.us" {
+			t.Fatalf("expected only 201@g.us, got %d results: %v", len(gs), gs)
+		}
+	})
+}
+
+// TestSearchContactsWildcardEscape verifies that LIKE wildcards in contact
+// search queries are treated as literals, not SQL pattern chars.
+func TestSearchContactsWildcardEscape(t *testing.T) {
+	db := openTestDB(t)
+
+	if err := db.UpsertContact("300@s.whatsapp.net", "300", "Push", "100% Alice", "First", ""); err != nil {
+		t.Fatalf("UpsertContact: %v", err)
+	}
+	if err := db.UpsertContact("301@s.whatsapp.net", "301", "Push", "some_person", "First", ""); err != nil {
+		t.Fatalf("UpsertContact: %v", err)
+	}
+	if err := db.UpsertContact("302@s.whatsapp.net", "302", "Push", "Other", "First", ""); err != nil {
+		t.Fatalf("UpsertContact: %v", err)
+	}
+
+	t.Run("percent returns only exact match", func(t *testing.T) {
+		cs, err := db.SearchContacts("100%", 50)
+		if err != nil {
+			t.Fatalf("SearchContacts: %v", err)
+		}
+		if len(cs) != 1 || cs[0].JID != "300@s.whatsapp.net" {
+			t.Fatalf("expected only 300@s, got %d results: %v", len(cs), cs)
+		}
+	})
+
+	t.Run("underscore returns only exact match", func(t *testing.T) {
+		cs, err := db.SearchContacts("some_person", 50)
+		if err != nil {
+			t.Fatalf("SearchContacts: %v", err)
+		}
+		if len(cs) != 1 || cs[0].JID != "301@s.whatsapp.net" {
+			t.Fatalf("expected only 301@s, got %d results: %v", len(cs), cs)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- **Fix LIKE wildcard injection in 3 search functions**: `ListChats`, `ListGroups`, and `SearchContacts` built their SQL `LIKE` needles directly from user input (`"%" + query + "%"`) without escaping `%` and `_` wildcards. The `escapeLIKE()` helper already existed and was correctly used in `searchLIKE()`, but these three functions were missed. A user searching for `"100%"` would match any chat with `"100"` followed by any characters, rather than only chats literally containing `"100%"`.
- **Fix `truncate()` to handle multi-byte UTF-8 correctly**: The function used byte-based slicing (`len(s)`, `s[:max]`) which could split multi-byte characters (Chinese, emoji, etc.) and produce invalid UTF-8 output. Changed to rune-based slicing.

## Details

### LIKE wildcard escape
- `escapeLIKE()` is now applied in `ListChats`, `ListGroups`, and `SearchContacts` — same as `searchLIKE()`
- `ESCAPE '\'` clause added to all LIKE predicates for consistency
- This is consistent with the existing fix in #145 (`ff2d74d`) which fixed `searchLIKE`

### truncate UTF-8 fix
- `len(s)` → `len(runes)` where `runes = []rune(s)`
- `s[:max]` → `string(runes[:maxRunes])`
- Parameter renamed from `max` to `maxRunes` for clarity

## Test plan

- [x] Added `TestListChatsWildcardEscape` — verifies `%` and `_` in chat search queries are treated as literals
- [x] Added `TestListGroupsWildcardEscape` — verifies `%` and `_` in group search queries are treated as literals  
- [x] Added `TestSearchContactsWildcardEscape` — verifies `%` and `_` in contact search queries are treated as literals
- [x] All existing tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)