### PR TITLE
feat: balanced improvements and webhook robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,20 @@
 
 ## 0.5.0 - Unreleased
 
+### Added
+
+- Messages: `messages export` now supports `--after`, `--before` time filters and `--json` output.
+- Messages: new `--format obsidian|plain-md` flag for `messages export` (default: `obsidian`).
+- Sync: support for HMAC-SHA256 webhook signatures via `--webhook-secret`.
+- Sync: configurable worker count for hook dispatch via `--hook-workers` (default: 4).
+
 ### Changed
 
 - Internal architecture: split store and groups command logic into focused modules for cleaner maintenance and safer follow-up changes.
+
+### Fixed
+
+- Out: YAML frontmatter injection vulnerability in Obsidian exporter (proper quoting/escaping).
 
 ### Build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Messages: `messages export` now supports `--after`, `--before` time filters and `--json` output.
 - Messages: new `--format obsidian|plain-md` flag for `messages export` (default: `obsidian`).
 - Sync: support for HMAC-SHA256 webhook signatures via `--webhook-secret`.
+- Sync: async retries with exponential backoff for webhooks via `--webhook-max-retries` and `--webhook-retry-delay`.
 - Sync: configurable worker count for hook dispatch via `--hook-workers` (default: 4).
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to wacli
+
+We love contributions! This project is designed to be agent-friendly. If you are using an AI agent (like Gemini CLI, Claude Code, or Cursor) to contribute, follow these guidelines to ensure high-quality code and context alignment.
+
+## Tech Stack
+- **Go 1.21+** (Generics, SQLite FTS5)
+- **Cobra** for CLI
+- **SQLite** for storage
+
+## Agentic Workflow (GSD Protocol)
+We recommend using the **GSD (Get Shit Done)** protocol for your contributions:
+1. **Spec-First**: Create a plan before writing code.
+2. **Atomic Commits**: Keep changes surgical and focused.
+3. **Verification**: Always include verification steps in your plan.
+
+## Adding New Features
+- If adding a new CLI command, register it in `cmd/wacli/`.
+- If modifying storage logic, update `internal/store/`.
+- Use `internal/out/` for output formatting logic.
+
+## Exporting to Obsidian (New Feature!)
+You can now export messages directly to Obsidian-flavored Markdown:
+```bash
+wacli messages export --chat [JID] --output my_chat.md
+```
+This follows the Project Note Protocol for seamless integration with AI agents using Obsidian as a knowledge base.
+
+## Submission
+1. Fork the repo.
+2. Create a feature branch.
+3. Submit a PR with a clear description of the "Core Value" added.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ pnpm wacli auth
 # 2) Keep syncing (never shows QR; requires prior auth)
 pnpm wacli sync --follow
 
-# Sync with webhook and HMAC-SHA256 signature
-pnpm wacli sync --webhook "https://example.com/hook" --webhook-secret "mysecret"
+# Sync with webhook, HMAC-SHA256 signature, and retries
+pnpm wacli sync --webhook "https://example.com/hook" --webhook-secret "mysecret" --webhook-max-retries 5 --webhook-retry-delay 2s
 
 # Diagnostics
 pnpm wacli doctor

--- a/README.md
+++ b/README.md
@@ -48,11 +48,20 @@ pnpm wacli auth
 # 2) Keep syncing (never shows QR; requires prior auth)
 pnpm wacli sync --follow
 
+# Sync with webhook and HMAC-SHA256 signature
+pnpm wacli sync --webhook "https://example.com/hook" --webhook-secret "mysecret"
+
 # Diagnostics
 pnpm wacli doctor
 
 # Search messages
 pnpm wacli messages search "meeting"
+
+# Export messages to Markdown (Obsidian format by default)
+pnpm wacli messages export --chat 1234567890@s.whatsapp.net --output chat.md
+
+# Export messages with time filters and plain Markdown format
+pnpm wacli messages export --chat 1234567890@s.whatsapp.net --after 2024-01-01 --format plain-md
 
 # Backfill older messages for a chat (best-effort; requires your primary device online)
 pnpm wacli history backfill --chat 1234567890@s.whatsapp.net --requests 10 --count 50

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -22,6 +23,7 @@ func newMessagesCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newMessagesSearchCmd(flags))
 	cmd.AddCommand(newMessagesShowCmd(flags))
 	cmd.AddCommand(newMessagesContextCmd(flags))
+	cmd.AddCommand(newMessagesExportCmd(flags))
 	return cmd
 }
 
@@ -330,5 +332,123 @@ func newMessagesContextCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&id, "id", "", "message ID")
 	cmd.Flags().IntVar(&before, "before", 5, "messages before")
 	cmd.Flags().IntVar(&after, "after", 5, "messages after")
+	return cmd
+}
+
+func newMessagesExportCmd(flags *rootFlags) *cobra.Command {
+	var chat string
+	var query string
+	var limit int
+	var output string
+	var format string
+	var afterStr string
+	var beforeStr string
+
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export messages to Markdown or JSON",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if chat == "" && query == "" {
+				return fmt.Errorf("either --chat or --query is required")
+			}
+			if format != "obsidian" && format != "plain-md" {
+				return fmt.Errorf("--format must be obsidian or plain-md, got %q", format)
+			}
+
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, false, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			var after *time.Time
+			var before *time.Time
+			if afterStr != "" {
+				t, err := parseTime(afterStr)
+				if err != nil {
+					return err
+				}
+				after = &t
+			}
+			if beforeStr != "" {
+				t, err := parseTime(beforeStr)
+				if err != nil {
+					return err
+				}
+				before = &t
+			}
+
+			var msgs []store.Message
+			var chatName string
+			var chatJID string
+
+			if query != "" {
+				msgs, err = a.DB().SearchMessages(store.SearchMessagesParams{
+					Query:   query,
+					ChatJID: chat,
+					Limit:   limit,
+					After:   after,
+					Before:  before,
+				})
+				chatName = "Search: " + query
+				chatJID = "search"
+			} else {
+				msgs, err = a.DB().ListMessages(store.ListMessagesParams{
+					ChatJID: chat,
+					Limit:   limit,
+					After:   after,
+					Before:  before,
+				})
+				chatJID = chat
+				if len(msgs) > 0 {
+					chatName = msgs[0].ChatName
+				}
+				if chatName == "" {
+					chatName = chat
+				}
+			}
+			if err != nil {
+				return err
+			}
+
+			// Sort chronologically for export (DB returns newest first)
+			for i, j := 0, len(msgs)-1; i < j; i, j = i+1, j-1 {
+				msgs[i], msgs[j] = msgs[j], msgs[i]
+			}
+
+			var w io.Writer = os.Stdout
+			if output != "" {
+				f, err := os.Create(output)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				w = f
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(w, map[string]any{
+					"messages": msgs,
+					"fts":      a.DB().HasFTS(),
+				})
+			}
+
+			if format == "plain-md" {
+				return out.WritePlainMarkdown(w, chatName, msgs)
+			}
+			return out.WriteObsidianMarkdown(w, chatName, chatJID, msgs)
+		},
+	}
+
+	cmd.Flags().StringVar(&chat, "chat", "", "chat JID to export")
+	cmd.Flags().StringVar(&query, "query", "", "search query to export results")
+	cmd.Flags().IntVar(&limit, "limit", 1000, "limit number of messages")
+	cmd.Flags().StringVar(&output, "output", "", "output file path (default: stdout)")
+	cmd.Flags().StringVar(&format, "format", "obsidian", "output format: obsidian|plain-md (ignored when --json is set)")
+	cmd.Flags().StringVar(&afterStr, "after", "", "only messages after time (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&beforeStr, "before", "", "only messages before time (RFC3339 or YYYY-MM-DD)")
 	return cmd
 }

--- a/cmd/wacli/sync.go
+++ b/cmd/wacli/sync.go
@@ -18,6 +18,10 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var downloadMedia bool
 	var refreshContacts bool
 	var refreshGroups bool
+	var execCommand string
+	var webhookURL string
+	var webhookSecret string
+	var hookWorkers int
 
 	cmd := &cobra.Command{
 		Use:   "sync",
@@ -34,6 +38,11 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 
 			if err := a.EnsureAuthed(); err != nil {
 				return err
+			}
+
+			// Start hook workers if a command or webhook is provided
+			if execCommand != "" || webhookURL != "" {
+				a.StartHookWorkers(ctx, hookWorkers)
 			}
 
 			mode := appPkg.SyncModeFollow
@@ -53,6 +62,9 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 				RefreshGroups:   refreshGroups,
 				IdleExit:        idleExit,
 				MaxReconnect:    maxReconnect,
+				ExecCommand:     execCommand,
+				WebhookURL:      webhookURL,
+				WebhookSecret:   webhookSecret,
 			})
 			if err != nil {
 				return err
@@ -76,5 +88,9 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().BoolVar(&downloadMedia, "download-media", false, "download media in the background during sync")
 	cmd.Flags().BoolVar(&refreshContacts, "refresh-contacts", false, "refresh contacts from session store into local DB")
 	cmd.Flags().BoolVar(&refreshGroups, "refresh-groups", false, "refresh joined groups (live) into local DB")
+	cmd.Flags().StringVar(&execCommand, "exec", "", "command to execute on new message (JSON passed via STDIN)")
+	cmd.Flags().StringVar(&webhookURL, "webhook", "", "URL to POST new message JSON")
+	cmd.Flags().StringVar(&webhookSecret, "webhook-secret", "", "HMAC-SHA256 secret for X-Wacli-Signature header")
+	cmd.Flags().IntVar(&hookWorkers, "hook-workers", 4, "number of parallel workers for hook dispatch")
 	return cmd
 }

--- a/cmd/wacli/sync.go
+++ b/cmd/wacli/sync.go
@@ -21,6 +21,8 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var execCommand string
 	var webhookURL string
 	var webhookSecret string
+	var webhookMaxRetries int
+	var webhookRetryDelay time.Duration
 	var hookWorkers int
 
 	cmd := &cobra.Command{
@@ -55,16 +57,18 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			res, err := a.Sync(ctx, appPkg.SyncOptions{
-				Mode:            mode,
-				AllowQR:         false,
-				DownloadMedia:   downloadMedia,
-				RefreshContacts: refreshContacts,
-				RefreshGroups:   refreshGroups,
-				IdleExit:        idleExit,
-				MaxReconnect:    maxReconnect,
-				ExecCommand:     execCommand,
-				WebhookURL:      webhookURL,
-				WebhookSecret:   webhookSecret,
+				Mode:              mode,
+				AllowQR:           false,
+				DownloadMedia:     downloadMedia,
+				RefreshContacts:   refreshContacts,
+				RefreshGroups:     refreshGroups,
+				IdleExit:          idleExit,
+				MaxReconnect:      maxReconnect,
+				ExecCommand:       execCommand,
+				WebhookURL:        webhookURL,
+				WebhookSecret:     webhookSecret,
+				WebhookMaxRetries: webhookMaxRetries,
+				WebhookRetryDelay: webhookRetryDelay,
 			})
 			if err != nil {
 				return err
@@ -91,6 +95,8 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&execCommand, "exec", "", "command to execute on new message (JSON passed via STDIN)")
 	cmd.Flags().StringVar(&webhookURL, "webhook", "", "URL to POST new message JSON")
 	cmd.Flags().StringVar(&webhookSecret, "webhook-secret", "", "HMAC-SHA256 secret for X-Wacli-Signature header")
+	cmd.Flags().IntVar(&webhookMaxRetries, "webhook-max-retries", 3, "maximum number of retry attempts for webhooks")
+	cmd.Flags().DurationVar(&webhookRetryDelay, "webhook-retry-delay", 5*time.Second, "initial delay for webhook retries")
 	cmd.Flags().IntVar(&hookWorkers, "hook-workers", 4, "number of parallel workers for hook dispatch")
 	return cmd
 }

--- a/docs/superpowers/plans/2026-04-14-wacli-balanced-improvements.md
+++ b/docs/superpowers/plans/2026-04-14-wacli-balanced-improvements.md
@@ -1,0 +1,914 @@
+# wacli Balanced Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix YAML corruption bug, add time filters + flexible format to `messages export`, add HMAC-SHA256 signatures to webhooks, and add full test coverage for all new and fixed code.
+
+**Architecture:** Six files across three packages. Changes are purely additive: new helper functions, new flags, new struct fields — no existing interfaces broken. TDD order: write failing tests first, then minimal implementation to pass them.
+
+**Tech Stack:** Go 1.21+, `crypto/hmac` + `crypto/sha256` + `encoding/hex` (stdlib), `net/http/httptest` (tests), Cobra (CLI flags), existing `store.DB` and `wa.ParsedMessage` types.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `internal/out/obsidian.go` | Modify | Add `yamlQuote`, extract `writeMessages`, add `WritePlainMarkdown` |
+| `internal/out/obsidian_test.go` | Create | 5 formatter tests |
+| `cmd/wacli/messages.go` | Modify | Add `--after`, `--before`, `--format` flags; wire `--json` in export |
+| `internal/app/sync.go` | Modify | Add `WebhookSecret` to `SyncOptions`; compute HMAC in `dispatchHooks` |
+| `cmd/wacli/sync.go` | Modify | Add `--webhook-secret` and `--hook-workers` flags |
+| `internal/app/sync_test.go` | Modify | Add 4 hook dispatch tests |
+
+---
+
+## Task 1: Write Obsidian Formatter Tests (TDD — red phase)
+
+**Files:**
+- Create: `internal/out/obsidian_test.go`
+
+- [ ] **Step 1: Create the test file**
+
+```go
+package out
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steipete/wacli/internal/store"
+)
+
+func makeMsg(text, mediaType string, ts time.Time, fromMe bool) store.Message {
+	return store.Message{
+		Text:      text,
+		MediaType: mediaType,
+		Timestamp: ts,
+		FromMe:    fromMe,
+		SenderJID: "123@s.whatsapp.net",
+	}
+}
+
+func TestWriteObsidianMarkdown_YAMLFrontmatter(t *testing.T) {
+	var buf bytes.Buffer
+	msgs := []store.Message{
+		makeMsg("hello", "", time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), false),
+	}
+
+	if err := WriteObsidianMarkdown(&buf, `Chat "with" quotes`, "123@g.us", msgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+
+	// Must open and close the YAML block
+	if !strings.Contains(out, "---\n") {
+		t.Error("missing YAML frontmatter delimiter ---")
+	}
+
+	// Must contain required keys
+	for _, key := range []string{"projeto:", "tipo:", "agente:", "data:", "status:", "tags:"} {
+		if !strings.Contains(out, key) {
+			t.Errorf("missing YAML key %q", key)
+		}
+	}
+
+	// Unescaped double-quotes in a YAML double-quoted string are invalid
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "projeto:") {
+			// Must NOT contain a bare " after the opening quote
+			// valid:   projeto: "Chat \"with\" quotes"
+			// invalid: projeto: "Chat "with" quotes"
+			inner := strings.TrimPrefix(line, "projeto: ")
+			inner = strings.Trim(inner, `"`)
+			if strings.Contains(inner, `"`) && !strings.Contains(inner, `\"`) {
+				t.Errorf("unescaped quotes in YAML projeto field: %q", line)
+			}
+		}
+	}
+}
+
+func TestWriteObsidianMarkdown_NewlineInChatName(t *testing.T) {
+	var buf bytes.Buffer
+	msgs := []store.Message{
+		makeMsg("hello", "", time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), false),
+	}
+
+	if err := WriteObsidianMarkdown(&buf, "Chat\nWith\nNewlines", "123@g.us", msgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The YAML block must contain exactly two --- delimiters
+	out := buf.String()
+	parts := strings.SplitN(out, "---\n", 3)
+	if len(parts) < 3 {
+		t.Errorf("YAML block corrupted by newline in chat name: got %d parts after splitting on ---", len(parts))
+	}
+}
+
+func TestWriteObsidianMarkdown_ChronologicalOrder(t *testing.T) {
+	var buf bytes.Buffer
+	base := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+	msgs := []store.Message{
+		makeMsg("first", "", base, false),
+		makeMsg("second", "", base.Add(time.Hour), false),
+		makeMsg("third", "", base.Add(2*time.Hour), false),
+	}
+
+	if err := WriteObsidianMarkdown(&buf, "Test", "123@g.us", msgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	i1, i2, i3 := strings.Index(out, "first"), strings.Index(out, "second"), strings.Index(out, "third")
+	if !(i1 < i2 && i2 < i3) {
+		t.Errorf("messages out of order: first=%d second=%d third=%d", i1, i2, i3)
+	}
+}
+
+func TestWriteObsidianMarkdown_MediaMessages(t *testing.T) {
+	var buf bytes.Buffer
+	msgs := []store.Message{
+		makeMsg("", "image", time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), false),
+	}
+
+	if err := WriteObsidianMarkdown(&buf, "Test", "123@g.us", msgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "_Sent image_") {
+		t.Error("media message should render as '_Sent image_'")
+	}
+}
+
+func TestWritePlainMarkdown_NoFrontmatter(t *testing.T) {
+	var buf bytes.Buffer
+	msgs := []store.Message{
+		makeMsg("hello", "", time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), false),
+	}
+
+	if err := WritePlainMarkdown(&buf, "Test Chat", msgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "---") {
+		t.Error("plain-md must not contain YAML frontmatter (---)")
+	}
+	if !strings.Contains(out, "# Test Chat") {
+		t.Error("expected H1 heading '# Test Chat'")
+	}
+}
+
+func TestWritePlainMarkdown_SameContent(t *testing.T) {
+	var obsidianBuf, plainBuf bytes.Buffer
+	base := time.Date(2024, 1, 1, 10, 30, 0, 0, time.UTC)
+	msgs := []store.Message{
+		makeMsg("hello world", "", base, true),
+		makeMsg("", "video", base.Add(time.Minute), false),
+	}
+
+	_ = WriteObsidianMarkdown(&obsidianBuf, "Chat", "123@g.us", msgs)
+	_ = WritePlainMarkdown(&plainBuf, "Chat", msgs)
+
+	// Strip the YAML frontmatter from the obsidian output
+	obsidianBody := obsidianBuf.String()
+	parts := strings.SplitN(obsidianBody, "---\n", 3)
+	if len(parts) == 3 {
+		obsidianBody = parts[2]
+	}
+
+	if strings.TrimSpace(obsidianBody) != strings.TrimSpace(plainBuf.String()) {
+		t.Errorf("body content mismatch:\nobsidian (after stripping frontmatter):\n%s\nplain:\n%s",
+			strings.TrimSpace(obsidianBody), strings.TrimSpace(plainBuf.String()))
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — expect failures**
+
+```bash
+cd /home/ghostwind/wacli-dev && go test ./internal/out/... -v -run "TestWrite"
+```
+
+Expected: `WritePlainMarkdown` compile error (not defined yet). YAML tests may pass or fail depending on current behavior. Fix after Task 2.
+
+---
+
+## Task 2: Fix YAML Quoting & Extract writeMessages
+
+**Files:**
+- Modify: `internal/out/obsidian.go`
+
+- [ ] **Step 1: Replace the file content**
+
+Full new content of `internal/out/obsidian.go`:
+
+```go
+package out
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/steipete/wacli/internal/store"
+)
+
+// yamlQuote returns s safely wrapped in YAML double-quoted scalar syntax.
+// Newlines become spaces; backslashes and double-quotes are escaped.
+func yamlQuote(s string) string {
+	s = strings.NewReplacer(
+		"\n", " ",
+		"\r", " ",
+		`\`, `\\`,
+		`"`, `\"`,
+	).Replace(s)
+	return `"` + s + `"`
+}
+
+// writeMessages writes the dated message list shared by both formatters.
+func writeMessages(w io.Writer, messages []store.Message) {
+	var lastDate string
+	for _, m := range messages {
+		date := m.Timestamp.Local().Format("2006-01-02")
+		if date != lastDate {
+			fmt.Fprintf(w, "## %s\n", date)
+			lastDate = date
+		}
+
+		from := m.SenderJID
+		if m.FromMe {
+			from = "me"
+		}
+
+		text := strings.TrimSpace(m.DisplayText)
+		if text == "" {
+			text = strings.TrimSpace(m.Text)
+		}
+		if m.MediaType != "" && text == "" {
+			text = "_Sent " + m.MediaType + "_"
+		}
+
+		fmt.Fprintf(w, "- **%s** (%s): %s\n",
+			from,
+			m.Timestamp.Local().Format("15:04:05"),
+			text,
+		)
+	}
+}
+
+// WriteObsidianMarkdown writes messages in Obsidian-flavored Markdown with YAML frontmatter.
+func WriteObsidianMarkdown(w io.Writer, chatName string, chatJID string, messages []store.Message) error {
+	exportDate := time.Now().Format("2006-01-02")
+	if len(messages) > 0 {
+		exportDate = messages[len(messages)-1].Timestamp.Local().Format("2006-01-02")
+	}
+
+	fmt.Fprintln(w, "---")
+	fmt.Fprintf(w, "projeto: %s\n", yamlQuote(chatName))
+	fmt.Fprintln(w, "tipo: WhatsApp Export")
+	fmt.Fprintln(w, "agente: wacli-bridge")
+	fmt.Fprintf(w, "data: %s\n", exportDate)
+	fmt.Fprintln(w, "status: archived")
+	fmt.Fprintf(w, "tags: [whatsapp, export, %s]\n", yamlQuote(strings.ReplaceAll(chatJID, "@", "_")))
+	fmt.Fprintln(w, "---")
+	fmt.Fprintln(w)
+
+	fmt.Fprintf(w, "# %s\n\n", chatName)
+	writeMessages(w, messages)
+	return nil
+}
+
+// WritePlainMarkdown writes messages as plain Markdown without YAML frontmatter.
+func WritePlainMarkdown(w io.Writer, chatName string, messages []store.Message) error {
+	fmt.Fprintf(w, "# %s\n\n", chatName)
+	writeMessages(w, messages)
+	return nil
+}
+```
+
+- [ ] **Step 2: Run tests — expect all passing**
+
+```bash
+go test ./internal/out/... -v -run "TestWrite"
+```
+
+Expected: all 6 tests PASS.
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: all existing tests still pass. No regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/out/obsidian.go internal/out/obsidian_test.go
+git commit -m "fix: correct YAML quoting in obsidian formatter and add plain-md format
+
+- Add yamlQuote helper that escapes backslashes, double-quotes, and newlines
+- Extract writeMessages to remove duplication between formatters
+- Add WritePlainMarkdown for frontmatter-free output
+- Add tests for YAML safety, chronological order, media messages"
+```
+
+---
+
+## Task 3: Write Hook Dispatch Tests (TDD — red phase)
+
+**Files:**
+- Modify: `internal/app/sync_test.go`
+
+- [ ] **Step 1: Add imports to sync_test.go**
+
+The existing imports block starts with `package app`. Add the new imports after the existing ones. The full updated imports block:
+
+```go
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/proto/waCommon"
+	"go.mau.fi/whatsmeow/proto/waHistorySync"
+	"go.mau.fi/whatsmeow/proto/waWeb"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/steipete/wacli/internal/wa"
+)
+```
+
+- [ ] **Step 2: Append the 4 new tests at the end of sync_test.go**
+
+```go
+func TestDispatchHooks_Exec(t *testing.T) {
+	tmp := t.TempDir()
+	outFile := filepath.Join(tmp, "out.json")
+
+	a := newTestApp(t)
+	pm := wa.ParsedMessage{
+		ID:   "exec-test-id",
+		Text: "exec hook payload",
+	}
+	opts := SyncOptions{
+		ExecCommand: "cat > " + outFile,
+	}
+
+	a.dispatchHooks(context.Background(), opts, pm)
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("exec hook did not create output file: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("exec hook output is not valid JSON: %v\noutput: %s", err, data)
+	}
+	if got["ID"] != "exec-test-id" {
+		t.Errorf("expected ID=exec-test-id, got %v", got["ID"])
+	}
+}
+
+func TestDispatchHooks_Webhook(t *testing.T) {
+	var (
+		gotContentType string
+		gotBody        []byte
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := newTestApp(t)
+	pm := wa.ParsedMessage{ID: "wh-test-id", Text: "webhook payload"}
+	opts := SyncOptions{WebhookURL: srv.URL}
+
+	a.dispatchHooks(context.Background(), opts, pm)
+
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type: got %q, want application/json", gotContentType)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(gotBody, &got); err != nil {
+		t.Fatalf("webhook body is not valid JSON: %v\nbody: %s", err, gotBody)
+	}
+	if got["ID"] != "wh-test-id" {
+		t.Errorf("expected ID=wh-test-id, got %v", got["ID"])
+	}
+}
+
+func TestDispatchHooks_WebhookHMAC(t *testing.T) {
+	var (
+		gotSig  string
+		gotBody []byte
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSig = r.Header.Get("X-Wacli-Signature")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := newTestApp(t)
+	pm := wa.ParsedMessage{ID: "hmac-test-id", Text: "signed payload"}
+	opts := SyncOptions{WebhookURL: srv.URL, WebhookSecret: "supersecret"}
+
+	a.dispatchHooks(context.Background(), opts, pm)
+
+	if gotSig == "" {
+		t.Fatal("X-Wacli-Signature header not present")
+	}
+
+	mac := hmac.New(sha256.New, []byte("supersecret"))
+	mac.Write(gotBody)
+	want := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	if gotSig != want {
+		t.Errorf("HMAC mismatch\ngot:  %s\nwant: %s", gotSig, want)
+	}
+}
+
+func TestDispatchHooks_WebhookTimeout(t *testing.T) {
+	// Server that blocks until the client disconnects.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	// Cancel the context immediately — dispatchHooks must not hang.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	a := newTestApp(t)
+	pm := wa.ParsedMessage{ID: "timeout-id"}
+	opts := SyncOptions{WebhookURL: srv.URL}
+
+	done := make(chan struct{})
+	go func() {
+		a.dispatchHooks(ctx, opts, pm)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// passed — returned without hanging
+	case <-time.After(5 * time.Second):
+		t.Fatal("dispatchHooks hung on a cancelled context")
+	}
+}
+```
+
+- [ ] **Step 3: Run tests — expect failures for HMAC test**
+
+```bash
+go test ./internal/app/... -v -run "TestDispatchHooks"
+```
+
+Expected: `TestDispatchHooks_Exec`, `TestDispatchHooks_Webhook`, `TestDispatchHooks_WebhookTimeout` PASS. `TestDispatchHooks_WebhookHMAC` FAIL with "X-Wacli-Signature header not present".
+
+---
+
+## Task 4: Add HMAC Signature to Webhook Dispatch
+
+**Files:**
+- Modify: `internal/app/sync.go`
+
+- [ ] **Step 1: Add `WebhookSecret` to `SyncOptions`**
+
+Find the `SyncOptions` struct (around line 22–38 of `internal/app/sync.go`) and add one field:
+
+```go
+type SyncOptions struct {
+	Mode            SyncMode
+	AllowQR         bool
+	OnQRCode        func(string)
+	AfterConnect    func(context.Context) error
+	DownloadMedia   bool
+	RefreshContacts bool
+	RefreshGroups   bool
+	IdleExit        time.Duration
+	MaxReconnect    time.Duration
+	Verbosity       int
+	ExecCommand     string
+	WebhookURL      string
+	WebhookSecret   string // signs payloads with HMAC-SHA256 when non-empty
+}
+```
+
+- [ ] **Step 2: Add HMAC imports to `internal/app/sync.go`**
+
+Add to the import block:
+```go
+"crypto/hmac"
+"crypto/sha256"
+"encoding/hex"
+```
+
+- [ ] **Step 3: Update `dispatchHooks` to compute the signature**
+
+Find the webhook block inside `dispatchHooks` (around line 490–510). Replace the existing webhook section with:
+
+```go
+// Webhook Hook
+if opts.WebhookURL != "" {
+    httpClient := &http.Client{
+        Timeout: 15 * time.Second,
+    }
+    req, err := http.NewRequestWithContext(ctx, "POST", opts.WebhookURL, bytes.NewReader(data))
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "\nWebhook request error: %v\n", err)
+        return
+    }
+    req.Header.Set("Content-Type", "application/json")
+    req.Header.Set("User-Agent", "wacli-bridge/"+a.Version())
+
+    if opts.WebhookSecret != "" {
+        mac := hmac.New(sha256.New, []byte(opts.WebhookSecret))
+        mac.Write(data)
+        req.Header.Set("X-Wacli-Signature", "sha256="+hex.EncodeToString(mac.Sum(nil)))
+    }
+
+    resp, err := httpClient.Do(req)
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "\nWebhook post error: %v\n", err)
+        return
+    }
+    defer resp.Body.Close()
+    if resp.StatusCode >= 400 {
+        fmt.Fprintf(os.Stderr, "\nWebhook returned status: %s\n", resp.Status)
+    }
+}
+```
+
+- [ ] **Step 4: Run HMAC test — expect green**
+
+```bash
+go test ./internal/app/... -v -run "TestDispatchHooks"
+```
+
+Expected: all 4 `TestDispatchHooks_*` tests PASS.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/app/sync.go internal/app/sync_test.go
+git commit -m "feat: add HMAC-SHA256 webhook signature support
+
+- Add WebhookSecret field to SyncOptions
+- Compute HMAC-SHA256 over JSON payload when secret is set
+- Emit X-Wacli-Signature: sha256=<hex> header (GitHub Webhooks convention)
+- Add dispatch tests: exec, webhook, HMAC verification, timeout safety"
+```
+
+---
+
+## Task 5: Add --after/--before/--format/--json to messages export
+
+**Files:**
+- Modify: `cmd/wacli/messages.go`
+
+- [ ] **Step 1: Update `newMessagesExportCmd`**
+
+Replace the entire `newMessagesExportCmd` function with:
+
+```go
+func newMessagesExportCmd(flags *rootFlags) *cobra.Command {
+	var chat string
+	var query string
+	var limit int
+	var output string
+	var format string
+	var afterStr string
+	var beforeStr string
+
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export messages to Markdown or JSON",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if chat == "" && query == "" {
+				return fmt.Errorf("either --chat or --query is required")
+			}
+			if format != "obsidian" && format != "plain-md" {
+				return fmt.Errorf("--format must be obsidian or plain-md, got %q", format)
+			}
+
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, false, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			var after *time.Time
+			var before *time.Time
+			if afterStr != "" {
+				t, err := parseTime(afterStr)
+				if err != nil {
+					return err
+				}
+				after = &t
+			}
+			if beforeStr != "" {
+				t, err := parseTime(beforeStr)
+				if err != nil {
+					return err
+				}
+				before = &t
+			}
+
+			var msgs []store.Message
+			var chatName string
+			var chatJID string
+
+			if query != "" {
+				msgs, err = a.DB().SearchMessages(store.SearchMessagesParams{
+					Query:   query,
+					ChatJID: chat,
+					Limit:   limit,
+					After:   after,
+					Before:  before,
+				})
+				chatName = "Search: " + query
+				chatJID = "search"
+			} else {
+				msgs, err = a.DB().ListMessages(store.ListMessagesParams{
+					ChatJID: chat,
+					Limit:   limit,
+					After:   after,
+					Before:  before,
+				})
+				chatJID = chat
+				if len(msgs) > 0 {
+					chatName = msgs[0].ChatName
+				}
+				if chatName == "" {
+					chatName = chat
+				}
+			}
+			if err != nil {
+				return err
+			}
+
+			// Sort chronologically for export (DB returns newest first)
+			for i, j := 0, len(msgs)-1; i < j; i, j = i+1, j-1 {
+				msgs[i], msgs[j] = msgs[j], msgs[i]
+			}
+
+			var w io.Writer = os.Stdout
+			if output != "" {
+				f, err := os.Create(output)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				w = f
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(w, map[string]any{
+					"messages": msgs,
+					"fts":      a.DB().HasFTS(),
+				})
+			}
+
+			if format == "plain-md" {
+				return out.WritePlainMarkdown(w, chatName, msgs)
+			}
+			return out.WriteObsidianMarkdown(w, chatName, chatJID, msgs)
+		},
+	}
+
+	cmd.Flags().StringVar(&chat, "chat", "", "chat JID to export")
+	cmd.Flags().StringVar(&query, "query", "", "search query to export results")
+	cmd.Flags().IntVar(&limit, "limit", 1000, "limit number of messages")
+	cmd.Flags().StringVar(&output, "output", "", "output file path (default: stdout)")
+	cmd.Flags().StringVar(&format, "format", "obsidian", "output format: obsidian|plain-md (ignored when --json is set)")
+	cmd.Flags().StringVar(&afterStr, "after", "", "only messages after time (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&beforeStr, "before", "", "only messages before time (RFC3339 or YYYY-MM-DD)")
+	return cmd
+}
+```
+
+- [ ] **Step 2: Build to verify no compile errors**
+
+```bash
+go build ./cmd/wacli/...
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Smoke test the new flags**
+
+```bash
+./wacli messages export --help
+```
+
+Expected output includes `--after`, `--before`, `--format`, `--json` (global).
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/wacli/messages.go
+git commit -m "feat: add --after/--before/--format/--json to messages export
+
+- --after and --before filter messages by time (mirrors messages list)
+- --format obsidian|plain-md selects Markdown variant (default: obsidian)
+- --json (global flag) outputs {messages, fts} envelope matching messages list
+- Validate --format value and return clear error for unknown formats"
+```
+
+---
+
+## Task 6: Add --webhook-secret and --hook-workers to sync
+
+**Files:**
+- Modify: `cmd/wacli/sync.go`
+
+- [ ] **Step 1: Update `newSyncCmd`**
+
+Replace the variable declarations block and the `StartHookWorkers` call and `SyncOptions` literal. Full updated function:
+
+```go
+func newSyncCmd(flags *rootFlags) *cobra.Command {
+	var once bool
+	var follow bool
+	var idleExit time.Duration
+	var maxReconnect time.Duration
+	var downloadMedia bool
+	var refreshContacts bool
+	var refreshGroups bool
+	var execCommand string
+	var webhookURL string
+	var webhookSecret string
+	var hookWorkers int
+
+	cmd := &cobra.Command{
+		Use:   "sync",
+		Short: "Sync messages (requires prior auth; never shows QR)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, stop := signalContext()
+			defer stop()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+
+			if execCommand != "" || webhookURL != "" {
+				a.StartHookWorkers(ctx, hookWorkers)
+			}
+
+			mode := appPkg.SyncModeFollow
+			if once {
+				mode = appPkg.SyncModeOnce
+			} else if follow {
+				mode = appPkg.SyncModeFollow
+			} else {
+				mode = appPkg.SyncModeOnce
+			}
+
+			res, err := a.Sync(ctx, appPkg.SyncOptions{
+				Mode:            mode,
+				AllowQR:         false,
+				DownloadMedia:   downloadMedia,
+				RefreshContacts: refreshContacts,
+				RefreshGroups:   refreshGroups,
+				IdleExit:        idleExit,
+				MaxReconnect:    maxReconnect,
+				ExecCommand:     execCommand,
+				WebhookURL:      webhookURL,
+				WebhookSecret:   webhookSecret,
+			})
+			if err != nil {
+				return err
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"synced":          true,
+					"messages_stored": res.MessagesStored,
+				})
+			}
+			fmt.Fprintf(os.Stdout, "Messages stored: %d\n", res.MessagesStored)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&once, "once", false, "sync until idle and exit")
+	cmd.Flags().BoolVar(&follow, "follow", true, "keep syncing until Ctrl+C")
+	cmd.Flags().DurationVar(&idleExit, "idle-exit", 30*time.Second, "exit after being idle (once mode)")
+	cmd.Flags().DurationVar(&maxReconnect, "max-reconnect", 5*time.Minute, "give up reconnecting after this duration (0 = unlimited)")
+	cmd.Flags().BoolVar(&downloadMedia, "download-media", false, "download media in the background during sync")
+	cmd.Flags().BoolVar(&refreshContacts, "refresh-contacts", false, "refresh contacts from session store into local DB")
+	cmd.Flags().BoolVar(&refreshGroups, "refresh-groups", false, "refresh joined groups (live) into local DB")
+	cmd.Flags().StringVar(&execCommand, "exec", "", "command to execute on new message (JSON passed via STDIN)")
+	cmd.Flags().StringVar(&webhookURL, "webhook", "", "URL to POST new message JSON")
+	cmd.Flags().StringVar(&webhookSecret, "webhook-secret", "", "HMAC-SHA256 secret for X-Wacli-Signature header")
+	cmd.Flags().IntVar(&hookWorkers, "hook-workers", 4, "number of parallel workers for hook dispatch")
+	return cmd
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+```bash
+go build ./cmd/wacli/...
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Verify flags appear in help**
+
+```bash
+./wacli sync --help
+```
+
+Expected: `--webhook-secret` and `--hook-workers` appear in flags list.
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/wacli/sync.go
+git commit -m "feat: add --webhook-secret and --hook-workers flags to sync
+
+- --webhook-secret passes HMAC secret to SyncOptions.WebhookSecret
+- --hook-workers configures worker pool size (default: 4)
+- Both flags no-op when --exec and --webhook are not set"
+```
+
+---
+
+## Self-Review Checklist
+
+After completing all tasks, verify the spec is fully covered:
+
+- [ ] **1.1 YAML bug** → Fixed in Task 2 (`yamlQuote`). Test: `TestWriteObsidianMarkdown_YAMLFrontmatter` + `TestWriteObsidianMarkdown_NewlineInChatName`.
+- [ ] **1.2 --after/--before on export** → Task 5. Verified via `--help` smoke test.
+- [ ] **1.3 --hook-workers configurable** → Task 6. Default 4 preserved.
+- [ ] **2.1 HMAC webhook** → Task 4 (SyncOptions field + dispatchHooks) + Task 6 (flag wiring). Test: `TestDispatchHooks_WebhookHMAC`.
+- [ ] **2.2 --format + --json on export** → Task 5. Both modes exercised, format validated.
+- [ ] **Tests 3.1** → Task 1+2: 6 tests in `obsidian_test.go`.
+- [ ] **Tests 3.2** → Task 3+4: 4 tests in `sync_test.go`.
+
+Run final check:
+
+```bash
+go test ./... && echo "ALL PASS"
+```

--- a/docs/superpowers/plans/2026-04-15-webhook-robustness.md
+++ b/docs/superpowers/plans/2026-04-15-webhook-robustness.md
@@ -1,0 +1,299 @@
+# Webhook Robustness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Improve webhook reliability by using a shared HTTP client and implementing async retries with exponential backoff.
+
+**Architecture:** Initialize a shared `*http.Client` in the `App` struct. Modify the hook worker loop to handle retry scheduling via a new `retryChan` and `time.AfterFunc`, ensuring non-blocking behavior for the main sync loop.
+
+**Tech Stack:** Go 1.21+, `net/http` (shared client), `time` (backoff), `crypto/hmac` (existing signature logic).
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `internal/app/app.go` | Modify | Add `httpClient` to `App` struct; initialize in `New` |
+| `internal/app/sync.go` | Modify | Update `dispatchHooks` to use shared client and handle retries; define `webhookJob` |
+| `internal/app/sync_test.go` | Modify | Add tests for retry logic and shared client usage |
+| `cmd/wacli/sync.go` | Modify | Add `--webhook-max-retries` and `--webhook-retry-delay` flags |
+
+---
+
+## Task 1: Shared HTTP Client
+
+**Files:**
+- Modify: `internal/app/app.go`
+
+- [ ] **Step 1: Add `httpClient` to `App` struct**
+
+Update `App` struct in `internal/app/app.go`:
+
+```go
+type App struct {
+	opts       Options
+	wa         WAClient
+	db         *store.DB
+	hookChan   chan parsedMessageJob
+	httpClient *http.Client // shared client for webhooks
+}
+```
+
+- [ ] **Step 2: Initialize `httpClient` in `New`**
+
+Update `New` function in `internal/app/app.go`:
+
+```go
+func New(opts Options) (*App, error) {
+	// ... existing code ...
+	return &App{
+		opts: opts,
+		db:   db,
+		httpClient: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+	}, nil
+}
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `/usr/local/go/bin/go build ./internal/app/...`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/app/app.go
+git commit -m "refactor: add shared http.Client to App struct"
+```
+
+---
+
+## Task 2: Refactor Hook Jobs and dispatchHooks
+
+**Files:**
+- Modify: `internal/app/sync.go`
+- Modify: `internal/app/app.go`
+
+- [ ] **Step 1: Update `parsedMessageJob` to include attempt count**
+
+Modify `internal/app/app.go`:
+
+```go
+type parsedMessageJob struct {
+	pm       wa.ParsedMessage
+	opts     SyncOptions
+	attempts int // number of previous failed attempts
+}
+```
+
+- [ ] **Step 2: Update `dispatchHooks` to use shared client**
+
+Modify `internal/app/sync.go` (around `dispatchHooks`):
+
+```go
+func (a *App) dispatchHooks(ctx context.Context, opts SyncOptions, pm wa.ParsedMessage, attempts int) {
+    // ... marshaling ...
+    
+    // Webhook Hook
+    if opts.WebhookURL != "" {
+        req, err := http.NewRequestWithContext(ctx, "POST", opts.WebhookURL, bytes.NewReader(data))
+        // ... headers ...
+        
+        resp, err := a.httpClient.Do(req) // Use shared client
+        // ... handle response ...
+    }
+}
+```
+
+- [ ] **Step 3: Update `StartHookWorkers` to pass 0 attempts**
+
+Modify `internal/app/app.go`:
+
+```go
+func (a *App) StartHookWorkers(ctx context.Context, numWorkers int) {
+    // ...
+    a.dispatchHooks(ctx, job.opts, job.pm, job.attempts)
+    // ...
+}
+```
+
+- [ ] **Step 4: Verify build**
+
+Run: `/usr/local/go/bin/go build ./internal/app/...`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/app/app.go internal/app/sync.go
+git commit -m "refactor: include attempts in parsedMessageJob and use shared client"
+```
+
+---
+
+## Task 3: Implement Async Retry with Backoff
+
+**Files:**
+- Modify: `internal/app/sync.go`
+- Test: `internal/app/sync_test.go`
+
+- [ ] **Step 1: Write failing test for retry**
+
+Add `TestDispatchWebhook_Retry` to `internal/app/sync_test.go`:
+
+```go
+func TestDispatchWebhook_Retry(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := attempts.Add(1)
+		if count < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a, _ := New(Options{StoreDir: t.TempDir()})
+	a.hookChan = make(chan parsedMessageJob, 10)
+	
+	opts := SyncOptions{
+		WebhookURL: srv.URL,
+		WebhookMaxRetries: 3,
+		WebhookRetryDelay: 10 * time.Millisecond,
+	}
+	pm := wa.ParsedMessage{ID: "retry-test"}
+
+	// First attempt
+	a.dispatchHooks(context.Background(), opts, pm, 0)
+
+	// Wait for retries
+	time.Sleep(100 * time.Millisecond)
+
+	if attempts.Load() != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts.Load())
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `/usr/local/go/bin/go test ./internal/app/... -v -run "TestDispatchWebhook_Retry"`
+Expected: FAIL (only 1 attempt made)
+
+- [ ] **Step 3: Update `SyncOptions` with retry fields**
+
+Modify `internal/app/sync.go`:
+
+```go
+type SyncOptions struct {
+    // ...
+    WebhookMaxRetries int
+    WebhookRetryDelay time.Duration
+}
+```
+
+- [ ] **Step 4: Implement retry logic in `dispatchHooks`**
+
+Modify `internal/app/sync.go`:
+
+```go
+func (a *App) dispatchHooks(ctx context.Context, opts SyncOptions, pm wa.ParsedMessage, attempts int) {
+    // ...
+    resp, err := a.httpClient.Do(req)
+    if err != nil || (resp != nil && resp.StatusCode >= 400) {
+        if attempts < opts.WebhookMaxRetries {
+            nextAttempt := attempts + 1
+            delay := opts.WebhookRetryDelay * time.Duration(1<<(nextAttempt-1))
+            fmt.Fprintf(os.Stderr, "\nWebhook failure (attempt %d/%d), retrying in %s...\n", nextAttempt, opts.WebhookMaxRetries, delay)
+            time.AfterFunc(delay, func() {
+                select {
+                case a.hookChan <- parsedMessageJob{pm: pm, opts: opts, attempts: nextAttempt}:
+                default:
+                    fmt.Fprintln(os.Stderr, "Warning: Hook queue full, skipping retry.")
+                }
+            })
+        } else {
+            fmt.Fprintf(os.Stderr, "\nWebhook failed after %d attempts.\n", attempts+1)
+        }
+        if resp != nil {
+            resp.Body.Close()
+        }
+        return
+    }
+    resp.Body.Close()
+}
+```
+
+- [ ] **Step 5: Run test to verify pass**
+
+Run: `/usr/local/go/bin/go test ./internal/app/... -v -run "TestDispatchWebhook_Retry"`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/app/sync.go internal/app/sync_test.go
+git commit -m "feat: implement async webhook retry with exponential backoff"
+```
+
+---
+
+## Task 4: Add CLI Flags
+
+**Files:**
+- Modify: `cmd/wacli/sync.go`
+
+- [ ] **Step 1: Add flags to `newSyncCmd`**
+
+Modify `cmd/wacli/sync.go`:
+
+```go
+func newSyncCmd(flags *rootFlags) *cobra.Command {
+    var webhookMaxRetries int
+    var webhookRetryDelay time.Duration
+    // ...
+    cmd.Flags().IntVar(&webhookMaxRetries, "webhook-max-retries", 3, "maximum number of retry attempts for webhooks")
+    cmd.Flags().DurationVar(&webhookRetryDelay, "webhook-retry-delay", 5*time.Second, "initial delay for webhook retries")
+    // ... pass to SyncOptions ...
+}
+```
+
+- [ ] **Step 2: Verify flags in help**
+
+Run: `/usr/local/go/bin/go run ./cmd/wacli/ sync --help`
+Expected: flags appear.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/wacli/sync.go
+git commit -m "feat: add --webhook-max-retries and --webhook-retry-delay flags"
+```
+
+---
+
+## Task 5: Final Polish and Documentation
+
+- [ ] **Step 1: Update `CHANGELOG.md`**
+
+Add entry under 0.5.0.
+
+- [ ] **Step 2: Update `README.md`**
+
+Add examples for retry flags.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `/usr/local/go/bin/go test ./...`
+Expected: ALL PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md README.md
+git commit -m "docs: document webhook retry features"
+```

--- a/docs/superpowers/specs/2026-04-14-wacli-improvements-design.md
+++ b/docs/superpowers/specs/2026-04-14-wacli-improvements-design.md
@@ -1,0 +1,127 @@
+# wacli Contribution — Balanced Improvements Design
+
+**Date:** 2026-04-14  
+**Approach:** B — Equilibrada  
+**Scope:** Bug fixes + test coverage + two new features (HMAC webhook, flexible export format)
+
+---
+
+## 1. Bug Fixes
+
+### 1.1 YAML Injection Fix (`internal/out/obsidian.go`)
+
+**Problem:** `fmt.Fprintf(w, "%q", value)` uses Go string quoting, which produces escape sequences (`\n`, `\t`) that are invalid inside YAML double-quoted strings. A group name containing a newline or backslash will corrupt the frontmatter.
+
+**Fix:** Introduce a local `yamlQuote(s string) string` helper that:
+1. Replaces `\n` and `\r` with a space
+2. Escapes `"` as `\"`
+3. Wraps the result in double quotes
+
+Apply to all string fields in the YAML header: `projeto`, `tags`.
+
+**Files:** `internal/out/obsidian.go`
+
+### 1.2 Time Filters for Export (`cmd/wacli/messages.go`)
+
+**Problem:** `messages export` lacks `--after` and `--before` flags present in `messages list` and `messages search`.
+
+**Fix:** Add `--after string` and `--before string` flags to `newMessagesExportCmd`, using the existing `parseTime()` helper and passing `*time.Time` pointers to `store.ListMessagesParams` — identical to the pattern in `newMessagesListCmd`.
+
+**Files:** `cmd/wacli/messages.go`
+
+### 1.3 Configurable Hook Worker Count (`cmd/wacli/sync.go`)
+
+**Problem:** Worker count is hardcoded as `4` in `sync.go:43`.
+
+**Fix:** Add `--hook-workers int` flag (default `4`). Pass the value to `a.StartHookWorkers(ctx, hookWorkers)`.
+
+**Files:** `cmd/wacli/sync.go`
+
+---
+
+## 2. New Features
+
+### 2.1 HMAC-SHA256 Webhook Signature
+
+**Purpose:** Allow webhook consumers (n8n, Make, custom endpoints) to verify that payloads originate from wacli and have not been tampered with. Follows the same convention as GitHub Webhooks (`X-Wacli-Signature: sha256=<hex>`).
+
+**Interface:**
+```
+wacli sync --webhook "https://n8n.example.com/hook" \
+           --webhook-secret "my-secret"
+```
+
+**Data flow:**
+1. New flag `--webhook-secret string` added to `newSyncCmd`
+2. Field `WebhookSecret string` added to `SyncOptions`
+3. In `dispatchHooks`, when `opts.WebhookSecret != ""`:
+   - Compute `hmac.New(sha256.New, []byte(secret))` over the JSON payload
+   - Set header `X-Wacli-Signature: sha256=<hex.EncodeToString(mac.Sum(nil))>`
+4. When secret is empty, header is omitted — zero overhead
+
+**Files:** `cmd/wacli/sync.go`, `internal/app/sync.go`
+
+### 2.2 Flexible Export Format
+
+**Purpose:** Make `messages export` consistent with the rest of the CLI and enable machine-to-machine use (AI agents reading JSON) alongside human/Obsidian use (Markdown).
+
+**Flags:**
+- `--json` (global flag, already exists via `flags.asJSON`): outputs `{"messages": msgs, "fts": a.DB().HasFTS()}` wrapped in the standard `{"success":true,"data":{...}}` envelope via `out.WriteJSON` — matches the shape of `messages list --json`
+- `--format obsidian|plain-md` (default: `obsidian`): selects the Markdown variant
+  - `obsidian`: current behavior — YAML frontmatter + dated sections
+  - `plain-md`: no YAML block, just the `# ChatName` heading and dated sections
+
+**Precedence:** `--json` takes priority over `--format`. If both are set, JSON wins.
+
+**New function:** `WritePlainMarkdown(w io.Writer, chatName string, messages []store.Message) error` in `internal/out/obsidian.go`. Reuses the same message-rendering loop, skips the `---` frontmatter block.
+
+**Files:** `cmd/wacli/messages.go`, `internal/out/obsidian.go`
+
+---
+
+## 3. Tests
+
+### 3.1 `internal/out/obsidian_test.go` (new file)
+
+| Test | What it verifies |
+|------|-----------------|
+| `TestWriteObsidianMarkdown_YAMLFrontmatter` | Output contains `---`, required YAML keys, and that `"` / newline in chat name does not break structure |
+| `TestWriteObsidianMarkdown_ChronologicalOrder` | Messages with reversed input are written oldest-first |
+| `TestWriteObsidianMarkdown_MediaMessages` | Media-only messages render as `_Sent image_` etc. |
+| `TestWritePlainMarkdown_NoFrontmatter` | Output does not contain `---` block |
+| `TestWritePlainMarkdown_SameContent` | Body content identical to obsidian variant minus frontmatter |
+
+### 3.2 `internal/app/sync_test.go` (extensions)
+
+| Test | What it verifies |
+|------|-----------------|
+| `TestDispatchHooks_Exec` | `--exec` writes message JSON to a temp file via shell; file exists and is valid JSON after dispatch |
+| `TestDispatchHooks_Webhook` | `httptest.NewServer` receives POST with `Content-Type: application/json` and valid message payload |
+| `TestDispatchHooks_WebhookHMAC` | Same server receives `X-Wacli-Signature` header; value matches independently computed HMAC-SHA256 |
+| `TestDispatchHooks_WebhookTimeout` | Server that blocks forever + context cancelled immediately; dispatch returns without panic and without hanging goroutines |
+
+### 3.3 Out of scope
+
+Unit tests for the worker pool goroutines (`StartHookWorkers`) — covered indirectly by the dispatch tests above.
+
+---
+
+## 4. File Change Summary
+
+| File | Type | What changes |
+|------|------|-------------|
+| `internal/out/obsidian.go` | Modified | `yamlQuote` helper, `WritePlainMarkdown` function |
+| `internal/out/obsidian_test.go` | New | 5 tests for formatter |
+| `cmd/wacli/messages.go` | Modified | `--after`/`--before`/`--format` flags + `--json` support in export |
+| `cmd/wacli/sync.go` | Modified | `--webhook-secret` and `--hook-workers` flags |
+| `internal/app/sync.go` | Modified | HMAC computation in `dispatchHooks`, `WebhookSecret` in `SyncOptions` |
+| `internal/app/sync_test.go` | Modified | 4 new hook dispatch tests |
+
+---
+
+## 5. What is NOT in scope
+
+- Webhook retry/backoff (separate PR, higher complexity)
+- Export to multiple files (one file per chat)
+- `--format json` alias (redundant with global `--json`)
+- Changes to history sync, media download, or auth flows

--- a/docs/superpowers/specs/2026-04-15-webhook-robustness-design.md
+++ b/docs/superpowers/specs/2026-04-15-webhook-robustness-design.md
@@ -1,0 +1,75 @@
+# wacli Webhook Robustness — Async Retry Design
+
+**Date:** 2026-04-15  
+**Goal:** Improve webhook delivery reliability by reusing HTTP clients and implementing asynchronous retries with exponential backoff.
+
+---
+
+## 1. Internal Changes
+
+### 1.1 Shared HTTP Client (`internal/app/app.go`)
+
+**Problem:** `dispatchHooks` creates a new `http.Client` for every single message, which is inefficient and doesn't take advantage of connection pooling (Keep-Alive).
+
+**Fix:** Add `httpClient *http.Client` to the `App` struct. Initialize it in `New` with a reasonable default timeout (15s).
+
+### 1.2 Async Retry Logic (`internal/app/sync.go`)
+
+**Problem:** Webhook failures are currently permanent and silent.
+
+**Fix:**
+1. Introduce `webhookJob` struct to hold message, options, and attempt count.
+2. Update `dispatchHooks` to use the shared client.
+3. If a webhook fails (network error or status >= 400), and `Attempts < MaxRetries`:
+   - Calculate backoff delay: `baseDelay * (2 ^ attempt)`.
+   - Use `time.AfterFunc` to re-enqueue the job into `a.hookChan` or a dedicated `retryChan` after the delay.
+4. If `Attempts == MaxRetries`, log the final failure to stderr.
+
+### 1.3 Ordered vs. Unordered
+This implementation is **unordered**. If message A fails and message B succeeds immediately after, B will arrive at the webhook before A's retry. This is acceptable for the requested "Async Retry" behavior.
+
+---
+
+## 2. CLI Interface
+
+### 2.1 New Flags (`cmd/wacli/sync.go`)
+
+- `--webhook-max-retries int` (default `3`): Maximum number of retry attempts after the first failure.
+- `--webhook-retry-delay duration` (default `5s`): Initial delay for the first retry.
+
+---
+
+## 3. Data Flow
+
+1. **Sync Loop**: Receives message -> sends to `a.hookChan`.
+2. **Hook Worker**: 
+   - Pops from `a.hookChan`.
+   - Calls `a.dispatchWebhook(job)`.
+3. **Dispatch Webhook**:
+   - Computes HMAC (if secret set).
+   - POSTs via `a.httpClient`.
+   - **Success**: done.
+   - **Failure**: 
+     - Checks `job.Attempts < MaxRetries`.
+     - Schedules `time.AfterFunc(delay, func() { a.hookChan <- job })`.
+     - Logs attempt to stderr.
+
+---
+
+## 4. Test Plan
+
+### 4.1 `internal/app/sync_test.go` extensions
+
+| Test | What it verifies |
+|------|-----------------|
+| `TestDispatchWebhook_Retry` | Server returns 500 twice, then 200. Verify the message is eventually delivered and 3 total attempts were made. |
+| `TestDispatchWebhook_MaxRetries` | Server always returns 500. Verify it stops after the max attempts. |
+| `TestDispatchWebhook_SharedClient` | (Internal) Verify multiple calls use the same client instance. |
+
+---
+
+## 5. What is NOT in scope
+
+- Persistence: Retries are lost if the process exits.
+- Ordered retries: A retry might be delivered after a newer message.
+- Per-command timeout configuration (global timeout used).

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -55,9 +55,15 @@ type Options struct {
 }
 
 type App struct {
-	opts Options
-	wa   WAClient
-	db   *store.DB
+	opts     Options
+	wa       WAClient
+	db       *store.DB
+	hookChan chan parsedMessageJob
+}
+
+type parsedMessageJob struct {
+	pm   wa.ParsedMessage
+	opts SyncOptions
 }
 
 func New(opts Options) (*App, error) {
@@ -127,4 +133,26 @@ func (a *App) Connect(ctx context.Context, allowQR bool, qrWriter func(string)) 
 		AllowQR:  allowQR,
 		OnQRCode: qrWriter,
 	})
+}
+
+func (a *App) StartHookWorkers(ctx context.Context, numWorkers int) {
+	if a.hookChan != nil {
+		return
+	}
+	a.hookChan = make(chan parsedMessageJob, 100)
+	for i := 0; i < numWorkers; i++ {
+		go func() {
+			for {
+				select {
+				case job, ok := <-a.hookChan:
+					if !ok {
+						return
+					}
+					a.dispatchHooks(ctx, job.opts, job.pm)
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -55,10 +56,11 @@ type Options struct {
 }
 
 type App struct {
-	opts     Options
-	wa       WAClient
-	db       *store.DB
-	hookChan chan parsedMessageJob
+	opts       Options
+	wa         WAClient
+	db         *store.DB
+	hookChan   chan parsedMessageJob
+	httpClient *http.Client
 }
 
 type parsedMessageJob struct {
@@ -81,7 +83,13 @@ func New(opts Options) (*App, error) {
 		return nil, err
 	}
 
-	return &App{opts: opts, db: db}, nil
+	return &App{
+		opts: opts,
+		db:   db,
+		httpClient: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+	}, nil
 }
 
 func (a *App) OpenWA() error {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -64,8 +64,9 @@ type App struct {
 }
 
 type parsedMessageJob struct {
-	pm   wa.ParsedMessage
-	opts SyncOptions
+	pm       wa.ParsedMessage
+	opts     SyncOptions
+	attempts int
 }
 
 func New(opts Options) (*App, error) {
@@ -156,7 +157,7 @@ func (a *App) StartHookWorkers(ctx context.Context, numWorkers int) {
 					if !ok {
 						return
 					}
-					a.dispatchHooks(ctx, job.opts, job.pm)
+					a.dispatchHooks(ctx, job.opts, job.pm, job.attempts)
 				case <-ctx.Done():
 					return
 				}

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -43,6 +43,8 @@ type SyncOptions struct {
 	ExecCommand     string        // command to execute on new message
 	WebhookURL      string        // URL to POST new message JSON
 	WebhookSecret   string        // secret for HMAC-SHA256 X-Wacli-Signature header
+	WebhookMaxRetries int         // maximum number of retry attempts
+	WebhookRetryDelay time.Duration // initial delay for retries
 }
 
 type SyncResult struct {
@@ -507,14 +509,31 @@ func (a *App) dispatchHooks(ctx context.Context, opts SyncOptions, pm wa.ParsedM
 		}
 
 		resp, err := a.httpClient.Do(req)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "\nWebhook post error: %v\n", err)
+		if err != nil || (resp != nil && resp.StatusCode >= 400) {
+			if attempts < opts.WebhookMaxRetries {
+				nextAttempt := attempts + 1
+				delay := opts.WebhookRetryDelay * time.Duration(1<<(nextAttempt-1))
+				fmt.Fprintf(os.Stderr, "\nWebhook failure (attempt %d/%d), retrying in %s...\n", nextAttempt, opts.WebhookMaxRetries, delay)
+				time.AfterFunc(delay, func() {
+					select {
+					case a.hookChan <- parsedMessageJob{pm: pm, opts: opts, attempts: nextAttempt}:
+					default:
+						fmt.Fprintln(os.Stderr, "Warning: Hook queue full, skipping retry.")
+					}
+				})
+			} else {
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "\nWebhook failed after %d attempts: %v\n", attempts+1, err)
+				} else {
+					fmt.Fprintf(os.Stderr, "\nWebhook failed after %d attempts: %s\n", attempts+1, resp.Status)
+				}
+			}
+			if resp != nil {
+				resp.Body.Close()
+			}
 			return
 		}
-		defer resp.Body.Close()
-		if resp.StatusCode >= 400 {
-			fmt.Fprintf(os.Stderr, "\nWebhook returned status: %s\n", resp.Status)
-		}
+		resp.Body.Close()
 	}
 }
 

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -1,9 +1,16 @@
 package app
 
 import (
+	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
+	"os/exec"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -33,6 +40,9 @@ type SyncOptions struct {
 	IdleExit        time.Duration // only used for bootstrap/once
 	MaxReconnect    time.Duration // max time to attempt reconnection before giving up (0 = unlimited)
 	Verbosity       int           // future
+	ExecCommand     string        // command to execute on new message
+	WebhookURL      string        // URL to POST new message JSON
+	WebhookSecret   string        // secret for HMAC-SHA256 X-Wacli-Signature header
 }
 
 type SyncResult struct {
@@ -105,6 +115,14 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 			}
 			if err := a.storeParsedMessage(ctx, pm); err == nil {
 				messagesStored.Add(1)
+				// Dispatch hooks via worker pool
+				if a.hookChan != nil && (opts.ExecCommand != "" || opts.WebhookURL != "") {
+					select {
+					case a.hookChan <- parsedMessageJob{pm: pm, opts: opts}:
+					default:
+						fmt.Fprintln(os.Stderr, "\nWarning: Hook queue full, skipping message.")
+					}
+				}
 			}
 			if opts.DownloadMedia && pm.Media != nil && pm.ID != "" {
 				enqueueMedia(pm.Chat.String(), pm.ID)
@@ -449,5 +467,56 @@ func mediaLabel(mediaType string) string {
 		return "message"
 	default:
 		return mt
+	}
+}
+
+func (a *App) dispatchHooks(ctx context.Context, opts SyncOptions, pm wa.ParsedMessage) {
+	data, err := json.Marshal(pm)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\nError marshaling message for hooks: %v\n", err)
+		return
+	}
+
+	// Exec Hook
+	if opts.ExecCommand != "" {
+		cmd := exec.CommandContext(ctx, "sh", "-c", opts.ExecCommand)
+		cmd.Stdin = bytes.NewReader(data)
+		cmd.Env = append(os.Environ(), 
+			"WACLI_MSG_ID="+pm.ID,
+			"WACLI_CHAT_JID="+pm.Chat.String(),
+			"WACLI_SENDER_JID="+pm.SenderJID,
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			fmt.Fprintf(os.Stderr, "\nExec hook error: %v (output: %s)\n", err, string(out))
+		}
+	}
+
+	// Webhook Hook
+	if opts.WebhookURL != "" {
+		httpClient := &http.Client{
+			Timeout: 15 * time.Second,
+		}
+		req, err := http.NewRequestWithContext(ctx, "POST", opts.WebhookURL, bytes.NewReader(data))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "\nWebhook request error: %v\n", err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", "wacli-bridge/"+a.Version())
+		if opts.WebhookSecret != "" {
+			mac := hmac.New(sha256.New, []byte(opts.WebhookSecret))
+			mac.Write(data)
+			req.Header.Set("X-Wacli-Signature", "sha256="+hex.EncodeToString(mac.Sum(nil)))
+		}
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "\nWebhook post error: %v\n", err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			fmt.Fprintf(os.Stderr, "\nWebhook returned status: %s\n", resp.Status)
+		}
 	}
 }

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -470,7 +470,7 @@ func mediaLabel(mediaType string) string {
 	}
 }
 
-func (a *App) dispatchHooks(ctx context.Context, opts SyncOptions, pm wa.ParsedMessage) {
+func (a *App) dispatchHooks(ctx context.Context, opts SyncOptions, pm wa.ParsedMessage, attempts int) {
 	data, err := json.Marshal(pm)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\nError marshaling message for hooks: %v\n", err)
@@ -481,7 +481,7 @@ func (a *App) dispatchHooks(ctx context.Context, opts SyncOptions, pm wa.ParsedM
 	if opts.ExecCommand != "" {
 		cmd := exec.CommandContext(ctx, "sh", "-c", opts.ExecCommand)
 		cmd.Stdin = bytes.NewReader(data)
-		cmd.Env = append(os.Environ(), 
+		cmd.Env = append(os.Environ(),
 			"WACLI_MSG_ID="+pm.ID,
 			"WACLI_CHAT_JID="+pm.Chat.String(),
 			"WACLI_SENDER_JID="+pm.SenderJID,
@@ -493,9 +493,6 @@ func (a *App) dispatchHooks(ctx context.Context, opts SyncOptions, pm wa.ParsedM
 
 	// Webhook Hook
 	if opts.WebhookURL != "" {
-		httpClient := &http.Client{
-			Timeout: 15 * time.Second,
-		}
 		req, err := http.NewRequestWithContext(ctx, "POST", opts.WebhookURL, bytes.NewReader(data))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "\nWebhook request error: %v\n", err)
@@ -509,7 +506,7 @@ func (a *App) dispatchHooks(ctx context.Context, opts SyncOptions, pm wa.ParsedM
 			req.Header.Set("X-Wacli-Signature", "sha256="+hex.EncodeToString(mac.Sum(nil)))
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := a.httpClient.Do(req)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "\nWebhook post error: %v\n", err)
 			return
@@ -520,3 +517,4 @@ func (a *App) dispatchHooks(ctx context.Context, opts SyncOptions, pm wa.ParsedM
 		}
 	}
 }
+

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -276,7 +276,7 @@ func TestDispatchHooks_Exec(t *testing.T) {
 	pm := wa.ParsedMessage{ID: "exec-test-id", Text: "exec hook payload"}
 	opts := SyncOptions{ExecCommand: "cat > " + outFile}
 
-	a.dispatchHooks(context.Background(), opts, pm)
+	a.dispatchHooks(context.Background(), opts, pm, 0)
 
 	data, err := os.ReadFile(outFile)
 	if err != nil {
@@ -306,7 +306,7 @@ func TestDispatchHooks_Webhook(t *testing.T) {
 	pm := wa.ParsedMessage{ID: "wh-test-id", Text: "webhook payload"}
 	opts := SyncOptions{WebhookURL: srv.URL}
 
-	a.dispatchHooks(context.Background(), opts, pm)
+	a.dispatchHooks(context.Background(), opts, pm, 0)
 
 	if gotContentType != "application/json" {
 		t.Errorf("Content-Type: got %q, want application/json", gotContentType)
@@ -335,7 +335,7 @@ func TestDispatchHooks_WebhookHMAC(t *testing.T) {
 	pm := wa.ParsedMessage{ID: "hmac-test-id", Text: "signed payload"}
 	opts := SyncOptions{WebhookURL: srv.URL, WebhookSecret: "supersecret"}
 
-	a.dispatchHooks(context.Background(), opts, pm)
+	a.dispatchHooks(context.Background(), opts, pm, 0)
 
 	if gotSig == "" {
 		t.Fatal("X-Wacli-Signature header not present")
@@ -363,7 +363,7 @@ func TestDispatchHooks_WebhookTimeout(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		a.dispatchHooks(ctx, opts, pm)
+		a.dispatchHooks(ctx, opts, pm, 0)
 		close(done)
 	}()
 

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -371,5 +372,93 @@ func TestDispatchHooks_WebhookTimeout(t *testing.T) {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("dispatchHooks hung on a cancelled context")
+	}
+}
+
+func TestDispatchWebhook_Retry(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := attempts.Add(1)
+		if count < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a, _ := New(Options{StoreDir: t.TempDir()})
+	a.hookChan = make(chan parsedMessageJob, 10)
+	
+	// Start a worker to consume retries
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		for {
+			select {
+			case job := <-a.hookChan:
+				a.dispatchHooks(ctx, job.opts, job.pm, job.attempts)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	opts := SyncOptions{
+		WebhookURL: srv.URL,
+		WebhookMaxRetries: 3,
+		WebhookRetryDelay: 10 * time.Millisecond,
+	}
+	pm := wa.ParsedMessage{ID: "retry-test"}
+
+	// First attempt
+	a.dispatchHooks(context.Background(), opts, pm, 0)
+
+	// Wait for retries
+	time.Sleep(200 * time.Millisecond)
+
+	if attempts.Load() != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts.Load())
+	}
+}
+
+func TestDispatchWebhook_MaxRetries(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	a, _ := New(Options{StoreDir: t.TempDir()})
+	a.hookChan = make(chan parsedMessageJob, 10)
+	
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		for {
+			select {
+			case job := <-a.hookChan:
+				a.dispatchHooks(ctx, job.opts, job.pm, job.attempts)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	opts := SyncOptions{
+		WebhookURL: srv.URL,
+		WebhookMaxRetries: 2,
+		WebhookRetryDelay: 5 * time.Millisecond,
+	}
+	pm := wa.ParsedMessage{ID: "max-retry-test"}
+
+	a.dispatchHooks(context.Background(), opts, pm, 0)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Initial (0) + Retry (1) + Retry (2) = 3 attempts total
+	if attempts.Load() != 3 {
+		t.Errorf("expected 3 total attempts (initial + 2 retries), got %d", attempts.Load())
 	}
 }

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -2,6 +2,15 @@ package app
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -12,6 +21,8 @@ import (
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/steipete/wacli/internal/wa"
 )
 
 func TestSyncStoresLiveAndHistoryMessages(t *testing.T) {
@@ -254,5 +265,111 @@ func TestSyncOnceIdleExit(t *testing.T) {
 	}
 	if time.Since(start) > 1500*time.Millisecond {
 		t.Fatalf("expected to exit quickly on idle, took %s", time.Since(start))
+	}
+}
+
+func TestDispatchHooks_Exec(t *testing.T) {
+	tmp := t.TempDir()
+	outFile := filepath.Join(tmp, "out.json")
+
+	a := newTestApp(t)
+	pm := wa.ParsedMessage{ID: "exec-test-id", Text: "exec hook payload"}
+	opts := SyncOptions{ExecCommand: "cat > " + outFile}
+
+	a.dispatchHooks(context.Background(), opts, pm)
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("exec hook did not create output file: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("exec hook output is not valid JSON: %v\noutput: %s", err, data)
+	}
+	if got["ID"] != "exec-test-id" {
+		t.Errorf("expected ID=exec-test-id, got %v", got["ID"])
+	}
+}
+
+func TestDispatchHooks_Webhook(t *testing.T) {
+	var gotContentType string
+	var gotBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := newTestApp(t)
+	pm := wa.ParsedMessage{ID: "wh-test-id", Text: "webhook payload"}
+	opts := SyncOptions{WebhookURL: srv.URL}
+
+	a.dispatchHooks(context.Background(), opts, pm)
+
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type: got %q, want application/json", gotContentType)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(gotBody, &got); err != nil {
+		t.Fatalf("webhook body is not valid JSON: %v", err)
+	}
+	if got["ID"] != "wh-test-id" {
+		t.Errorf("expected ID=wh-test-id, got %v", got["ID"])
+	}
+}
+
+func TestDispatchHooks_WebhookHMAC(t *testing.T) {
+	var gotSig string
+	var gotBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSig = r.Header.Get("X-Wacli-Signature")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := newTestApp(t)
+	pm := wa.ParsedMessage{ID: "hmac-test-id", Text: "signed payload"}
+	opts := SyncOptions{WebhookURL: srv.URL, WebhookSecret: "supersecret"}
+
+	a.dispatchHooks(context.Background(), opts, pm)
+
+	if gotSig == "" {
+		t.Fatal("X-Wacli-Signature header not present")
+	}
+	mac := hmac.New(sha256.New, []byte("supersecret"))
+	mac.Write(gotBody)
+	want := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if gotSig != want {
+		t.Errorf("HMAC mismatch\ngot:  %s\nwant: %s", gotSig, want)
+	}
+}
+
+func TestDispatchHooks_WebhookTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	a := newTestApp(t)
+	pm := wa.ParsedMessage{ID: "timeout-id"}
+	opts := SyncOptions{WebhookURL: srv.URL}
+
+	done := make(chan struct{})
+	go func() {
+		a.dispatchHooks(ctx, opts, pm)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("dispatchHooks hung on a cancelled context")
 	}
 }

--- a/internal/out/obsidian.go
+++ b/internal/out/obsidian.go
@@ -1,0 +1,82 @@
+package out
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/steipete/wacli/internal/store"
+)
+
+// yamlQuote returns s safely wrapped in YAML double-quoted scalar syntax.
+// Newlines become spaces; backslashes and double-quotes are escaped.
+func yamlQuote(s string) string {
+	s = strings.NewReplacer(
+		"\n", " ",
+		"\r", " ",
+		`\`, `\\`,
+		`"`, `\"`,
+	).Replace(s)
+	return `"` + s + `"`
+}
+
+// writeMessages writes the dated message list shared by both formatters.
+func writeMessages(w io.Writer, messages []store.Message) {
+	var lastDate string
+	for _, m := range messages {
+		date := m.Timestamp.Local().Format("2006-01-02")
+		if date != lastDate {
+			fmt.Fprintf(w, "## %s\n", date)
+			lastDate = date
+		}
+
+		from := m.SenderJID
+		if m.FromMe {
+			from = "me"
+		}
+
+		text := strings.TrimSpace(m.DisplayText)
+		if text == "" {
+			text = strings.TrimSpace(m.Text)
+		}
+		if m.MediaType != "" && text == "" {
+			text = "_Sent " + m.MediaType + "_"
+		}
+
+		fmt.Fprintf(w, "- **%s** (%s): %s\n",
+			from,
+			m.Timestamp.Local().Format("15:04:05"),
+			text,
+		)
+	}
+}
+
+// WriteObsidianMarkdown writes messages in Obsidian-flavored Markdown with YAML frontmatter.
+func WriteObsidianMarkdown(w io.Writer, chatName string, chatJID string, messages []store.Message) error {
+	exportDate := time.Now().Format("2006-01-02")
+	if len(messages) > 0 {
+		exportDate = messages[len(messages)-1].Timestamp.Local().Format("2006-01-02")
+	}
+
+	fmt.Fprintln(w, "---")
+	fmt.Fprintf(w, "projeto: %s\n", yamlQuote(chatName))
+	fmt.Fprintln(w, "tipo: WhatsApp Export")
+	fmt.Fprintln(w, "agente: wacli-bridge")
+	fmt.Fprintf(w, "data: %s\n", exportDate)
+	fmt.Fprintln(w, "status: archived")
+	fmt.Fprintf(w, "tags: [whatsapp, export, %s]\n", yamlQuote(strings.ReplaceAll(chatJID, "@", "_")))
+	fmt.Fprintln(w, "---")
+	fmt.Fprintln(w)
+
+	fmt.Fprintf(w, "# %s\n\n", chatName)
+	writeMessages(w, messages)
+	return nil
+}
+
+// WritePlainMarkdown writes messages as plain Markdown without YAML frontmatter.
+func WritePlainMarkdown(w io.Writer, chatName string, messages []store.Message) error {
+	fmt.Fprintf(w, "# %s\n\n", chatName)
+	writeMessages(w, messages)
+	return nil
+}

--- a/internal/out/obsidian_test.go
+++ b/internal/out/obsidian_test.go
@@ -31,18 +31,24 @@ func TestWriteObsidianMarkdown_YAMLFrontmatter(t *testing.T) {
 
 	out := buf.String()
 
+	// Must open and close the YAML block
 	if !strings.Contains(out, "---\n") {
 		t.Error("missing YAML frontmatter delimiter ---")
 	}
 
+	// Must contain required keys
 	for _, key := range []string{"projeto:", "tipo:", "agente:", "data:", "status:", "tags:"} {
 		if !strings.Contains(out, key) {
 			t.Errorf("missing YAML key %q", key)
 		}
 	}
 
+	// Unescaped double-quotes in a YAML double-quoted string are invalid
 	for _, line := range strings.Split(out, "\n") {
 		if strings.HasPrefix(line, "projeto:") {
+			// Must NOT contain a bare " after the opening quote
+			// valid:   projeto: "Chat \"with\" quotes"
+			// invalid: projeto: "Chat "with" quotes"
 			inner := strings.TrimPrefix(line, "projeto: ")
 			inner = strings.Trim(inner, `"`)
 			if strings.Contains(inner, `"`) && !strings.Contains(inner, `\"`) {
@@ -62,10 +68,11 @@ func TestWriteObsidianMarkdown_NewlineInChatName(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	// The YAML block must contain exactly two --- delimiters
 	out := buf.String()
 	parts := strings.SplitN(out, "---\n", 3)
 	if len(parts) < 3 {
-		t.Errorf("YAML block corrupted by newline in chat name: got %d parts", len(parts))
+		t.Errorf("YAML block corrupted by newline in chat name: got %d parts after splitting on ---", len(parts))
 	}
 }
 
@@ -134,6 +141,7 @@ func TestWritePlainMarkdown_SameContent(t *testing.T) {
 	_ = WriteObsidianMarkdown(&obsidianBuf, "Chat", "123@g.us", msgs)
 	_ = WritePlainMarkdown(&plainBuf, "Chat", msgs)
 
+	// Strip the YAML frontmatter from the obsidian output
 	obsidianBody := obsidianBuf.String()
 	parts := strings.SplitN(obsidianBody, "---\n", 3)
 	if len(parts) == 3 {

--- a/internal/out/obsidian_test.go
+++ b/internal/out/obsidian_test.go
@@ -1,0 +1,147 @@
+package out
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steipete/wacli/internal/store"
+)
+
+func makeMsg(text, mediaType string, ts time.Time, fromMe bool) store.Message {
+	return store.Message{
+		Text:      text,
+		MediaType: mediaType,
+		Timestamp: ts,
+		FromMe:    fromMe,
+		SenderJID: "123@s.whatsapp.net",
+	}
+}
+
+func TestWriteObsidianMarkdown_YAMLFrontmatter(t *testing.T) {
+	var buf bytes.Buffer
+	msgs := []store.Message{
+		makeMsg("hello", "", time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), false),
+	}
+
+	if err := WriteObsidianMarkdown(&buf, `Chat "with" quotes`, "123@g.us", msgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+
+	if !strings.Contains(out, "---\n") {
+		t.Error("missing YAML frontmatter delimiter ---")
+	}
+
+	for _, key := range []string{"projeto:", "tipo:", "agente:", "data:", "status:", "tags:"} {
+		if !strings.Contains(out, key) {
+			t.Errorf("missing YAML key %q", key)
+		}
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "projeto:") {
+			inner := strings.TrimPrefix(line, "projeto: ")
+			inner = strings.Trim(inner, `"`)
+			if strings.Contains(inner, `"`) && !strings.Contains(inner, `\"`) {
+				t.Errorf("unescaped quotes in YAML projeto field: %q", line)
+			}
+		}
+	}
+}
+
+func TestWriteObsidianMarkdown_NewlineInChatName(t *testing.T) {
+	var buf bytes.Buffer
+	msgs := []store.Message{
+		makeMsg("hello", "", time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), false),
+	}
+
+	if err := WriteObsidianMarkdown(&buf, "Chat\nWith\nNewlines", "123@g.us", msgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	parts := strings.SplitN(out, "---\n", 3)
+	if len(parts) < 3 {
+		t.Errorf("YAML block corrupted by newline in chat name: got %d parts", len(parts))
+	}
+}
+
+func TestWriteObsidianMarkdown_ChronologicalOrder(t *testing.T) {
+	var buf bytes.Buffer
+	base := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+	msgs := []store.Message{
+		makeMsg("first", "", base, false),
+		makeMsg("second", "", base.Add(time.Hour), false),
+		makeMsg("third", "", base.Add(2*time.Hour), false),
+	}
+
+	if err := WriteObsidianMarkdown(&buf, "Test", "123@g.us", msgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	i1, i2, i3 := strings.Index(out, "first"), strings.Index(out, "second"), strings.Index(out, "third")
+	if !(i1 < i2 && i2 < i3) {
+		t.Errorf("messages out of order: first=%d second=%d third=%d", i1, i2, i3)
+	}
+}
+
+func TestWriteObsidianMarkdown_MediaMessages(t *testing.T) {
+	var buf bytes.Buffer
+	msgs := []store.Message{
+		makeMsg("", "image", time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), false),
+	}
+
+	if err := WriteObsidianMarkdown(&buf, "Test", "123@g.us", msgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "_Sent image_") {
+		t.Error("media message should render as '_Sent image_'")
+	}
+}
+
+func TestWritePlainMarkdown_NoFrontmatter(t *testing.T) {
+	var buf bytes.Buffer
+	msgs := []store.Message{
+		makeMsg("hello", "", time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), false),
+	}
+
+	if err := WritePlainMarkdown(&buf, "Test Chat", msgs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "---") {
+		t.Error("plain-md must not contain YAML frontmatter (---)")
+	}
+	if !strings.Contains(out, "# Test Chat") {
+		t.Error("expected H1 heading '# Test Chat'")
+	}
+}
+
+func TestWritePlainMarkdown_SameContent(t *testing.T) {
+	var obsidianBuf, plainBuf bytes.Buffer
+	base := time.Date(2024, 1, 1, 10, 30, 0, 0, time.UTC)
+	msgs := []store.Message{
+		makeMsg("hello world", "", base, true),
+		makeMsg("", "video", base.Add(time.Minute), false),
+	}
+
+	_ = WriteObsidianMarkdown(&obsidianBuf, "Chat", "123@g.us", msgs)
+	_ = WritePlainMarkdown(&plainBuf, "Chat", msgs)
+
+	obsidianBody := obsidianBuf.String()
+	parts := strings.SplitN(obsidianBody, "---\n", 3)
+	if len(parts) == 3 {
+		obsidianBody = parts[2]
+	}
+
+	if strings.TrimSpace(obsidianBody) != strings.TrimSpace(plainBuf.String()) {
+		t.Errorf("body content mismatch:\nobsidian (after stripping frontmatter):\n%s\nplain:\n%s",
+			strings.TrimSpace(obsidianBody), strings.TrimSpace(plainBuf.String()))
+	}
+}


### PR DESCRIPTION
## Summary
- Fixed YAML corruption in export
- Added `--after`, `--before`, `--format`, and `--json` to `messages export`
- Implemented async retry with exponential backoff for webhooks
- Added HMAC-SHA256 signatures for webhooks (`--webhook-secret`)

## Test Plan
- [x] Obsidian export tests pass
- [x] Sync webhook integration tests pass