### PR TITLE
bug: repair FTS state safely after reopening the database

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -117,6 +117,10 @@ Approach:
   - media caption
   - document filename
   - (optionally) denormalized sender/chat names for convenience
+- Persist a small readiness marker once the FTS table, triggers, and initial backfill
+  have been built successfully.
+- On startup, if SQLite supports FTS5 but the readiness marker is missing or stale,
+  rebuild the FTS table and triggers once before enabling `MATCH` search.
 
 Query behavior:
 
@@ -127,6 +131,8 @@ Query behavior:
 Fallback:
 
 - If FTS5 is unavailable, fall back to `LIKE` with an explicit warning (slower).
+- If the FTS table is damaged or repair fails, keep the store usable and fall back
+  to `LIKE` instead of failing startup.
 
 ## CLI command surface (v1)
 

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -66,6 +66,16 @@ func (d *DB) ensureSchema() error {
 		}
 	}
 
+	// Detect FTS5 availability on every open, not just when the migration runs.
+	// The migration sets ftsEnabled only on first apply; subsequent opens need
+	// to re-check whether the FTS table exists and is usable.
+	if ftsOK, _ := d.tableExists("messages_fts"); ftsOK {
+		var version string
+		if err := d.sql.QueryRow(`SELECT fts5_source_id()`).Scan(&version); err == nil {
+			d.ftsEnabled = true
+		}
+	}
+
 	return nil
 }
 

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -20,15 +20,26 @@ var schemaMigrations = []migration{
 	{version: 3, name: "messages fts", up: migrateMessagesFTS},
 }
 
+const (
+	messagesFTSStateKey     = "messages_fts_state"
+	messagesFTSStateVersion = "display_text_v1"
+)
+
 func (d *DB) ensureSchema() error {
 	if _, err := d.sql.Exec(`
 		CREATE TABLE IF NOT EXISTS schema_migrations (
 			version INTEGER PRIMARY KEY,
 			name TEXT NOT NULL,
 			applied_at INTEGER NOT NULL
+		);
+
+		CREATE TABLE IF NOT EXISTS store_metadata (
+			key TEXT PRIMARY KEY,
+			value TEXT NOT NULL,
+			updated_at INTEGER NOT NULL
 		)
 	`); err != nil {
-		return fmt.Errorf("create schema_migrations table: %w", err)
+		return fmt.Errorf("create schema tables: %w", err)
 	}
 
 	applied := map[int]bool{}
@@ -66,17 +77,7 @@ func (d *DB) ensureSchema() error {
 		}
 	}
 
-	// Detect FTS5 availability on every open, not just when the migration runs.
-	// The migration sets ftsEnabled only on first apply; subsequent opens need
-	// to re-check whether the FTS table exists and is usable.
-	if ftsOK, _ := d.tableExists("messages_fts"); ftsOK {
-		var version string
-		if err := d.sql.QueryRow(`SELECT fts5_source_id()`).Scan(&version); err == nil {
-			d.ftsEnabled = true
-		}
-	}
-
-	return nil
+	return d.ensureMessagesFTS()
 }
 
 func migrateCoreSchema(d *DB) error {
@@ -177,44 +178,139 @@ func migrateMessagesDisplayText(d *DB) error {
 	return nil
 }
 
-func migrateMessagesFTS(d *DB) error {
-	ftsExists, err := d.tableExists("messages_fts")
+func migrateMessagesFTS(_ *DB) error {
+	// Historical schema marker. Runtime FTS setup is tracked separately so
+	// non-FTS builds still open and later FTS-capable builds can repair safely.
+	return nil
+}
+
+func (d *DB) ensureMessagesFTS() error {
+	d.ftsEnabled = false
+
+	if !d.sqliteSupportsFTS5() {
+		return nil
+	}
+
+	state, err := d.metadataValue(messagesFTSStateKey)
 	if err != nil {
 		return err
 	}
-	if ftsExists {
-		hasDisplay, err := d.tableHasColumn("messages_fts", "display_text")
+
+	if state == messagesFTSStateVersion {
+		healthy, err := d.messagesFTSHealthy()
 		if err != nil {
 			return err
 		}
-		if !hasDisplay {
-			if _, err := d.sql.Exec(`DROP TABLE IF EXISTS messages_fts`); err != nil {
-				return fmt.Errorf("drop messages_fts: %w", err)
-			}
-			ftsExists = false
-		}
-	}
-
-	created := false
-	if !ftsExists {
-		if _, err := d.sql.Exec(`
-			CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
-				text,
-				media_caption,
-				filename,
-				chat_name,
-				sender_name,
-				display_text
-			)
-		`); err != nil {
-			// Continue without FTS (fallback to LIKE).
-			d.ftsEnabled = false
+		if healthy {
+			d.ftsEnabled = true
 			return nil
 		}
-		created = true
 	}
 
-	// Ensure triggers match expected semantics.
+	if err := d.rebuildMessagesFTSState(); err != nil {
+		_ = d.deleteMetadata(messagesFTSStateKey)
+		d.ftsEnabled = false
+		return nil
+	}
+
+	if err := d.setMetadata(messagesFTSStateKey, messagesFTSStateVersion); err != nil {
+		// Keep FTS enabled for this process; a missing marker only forces a
+		// one-time rebuild on a later open.
+	}
+
+	d.ftsEnabled = true
+	return nil
+}
+
+func (d *DB) sqliteSupportsFTS5() bool {
+	var version string
+	return d.sql.QueryRow(`SELECT fts5_source_id()`).Scan(&version) == nil
+}
+
+func (d *DB) messagesFTSHealthy() (bool, error) {
+	ftsExists, err := d.tableExists("messages_fts")
+	if err != nil {
+		return false, err
+	}
+	if !ftsExists {
+		return false, nil
+	}
+
+	hasDisplay, err := d.tableHasColumn("messages_fts", "display_text")
+	if err != nil {
+		return false, err
+	}
+	if !hasDisplay {
+		return false, nil
+	}
+
+	triggersReady, err := d.messagesFTSTriggersReady()
+	if err != nil {
+		return false, err
+	}
+	if !triggersReady {
+		return false, nil
+	}
+
+	if err := d.probeMessagesFTS(); err != nil {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (d *DB) messagesFTSTriggersReady() (bool, error) {
+	for _, name := range []string{"messages_ai", "messages_ad", "messages_au"} {
+		ok, err := d.triggerExists(name)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (d *DB) rebuildMessagesFTSState() error {
+	d.resetMessagesFTS()
+
+	if err := d.createMessagesFTSTable(); err != nil {
+		return err
+	}
+	if err := d.createMessagesFTSTriggers(); err != nil {
+		d.resetMessagesFTS()
+		return err
+	}
+	if err := d.backfillMessagesFTS(); err != nil {
+		d.resetMessagesFTS()
+		return err
+	}
+	if err := d.probeMessagesFTS(); err != nil {
+		d.resetMessagesFTS()
+		return err
+	}
+
+	return nil
+}
+
+func (d *DB) createMessagesFTSTable() error {
+	if _, err := d.sql.Exec(`
+		CREATE VIRTUAL TABLE messages_fts USING fts5(
+			text,
+			media_caption,
+			filename,
+			chat_name,
+			sender_name,
+			display_text
+		)
+	`); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *DB) createMessagesFTSTriggers() error {
 	if _, err := d.sql.Exec(`
 		DROP TRIGGER IF EXISTS messages_ai;
 		DROP TRIGGER IF EXISTS messages_ad;
@@ -235,28 +331,109 @@ func migrateMessagesFTS(d *DB) error {
 			VALUES (new.rowid, COALESCE(new.text,''), COALESCE(new.media_caption,''), COALESCE(new.filename,''), COALESCE(new.chat_name,''), COALESCE(new.sender_name,''), COALESCE(new.display_text,''));
 		END;
 	`); err != nil {
-		d.ftsEnabled = false
-		return nil
+		return err
 	}
+	return nil
+}
 
-	if created {
-		if _, err := d.sql.Exec(`
-			INSERT INTO messages_fts(rowid, text, media_caption, filename, chat_name, sender_name, display_text)
-			SELECT rowid,
-			       COALESCE(text,''),
-			       COALESCE(media_caption,''),
-			       COALESCE(filename,''),
-			       COALESCE(chat_name,''),
-			       COALESCE(sender_name,''),
-			       COALESCE(display_text,'')
-			FROM messages
-		`); err != nil {
-			d.ftsEnabled = false
-			return nil
+func (d *DB) backfillMessagesFTS() error {
+	if _, err := d.sql.Exec(`
+		INSERT INTO messages_fts(rowid, text, media_caption, filename, chat_name, sender_name, display_text)
+		SELECT rowid,
+		       COALESCE(text,''),
+		       COALESCE(media_caption,''),
+		       COALESCE(filename,''),
+		       COALESCE(chat_name,''),
+		       COALESCE(sender_name,''),
+		       COALESCE(display_text,'')
+		FROM messages
+	`); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *DB) probeMessagesFTS() error {
+	rows, err := d.sql.Query(`SELECT rowid FROM messages_fts LIMIT 1`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var rowid int64
+		if err := rows.Scan(&rowid); err != nil {
+			return err
 		}
+		break
 	}
 
-	d.ftsEnabled = true
+	return rows.Err()
+}
+
+func (d *DB) resetMessagesFTS() {
+	_ = d.dropMessagesFTSTriggers()
+	for _, table := range []string{
+		"messages_fts",
+		"messages_fts_data",
+		"messages_fts_idx",
+		"messages_fts_docsize",
+		"messages_fts_config",
+		"messages_fts_content",
+	} {
+		_, _ = d.sql.Exec("DROP TABLE IF EXISTS " + table)
+	}
+}
+
+func (d *DB) dropMessagesFTSTriggers() error {
+	if _, err := d.sql.Exec(`
+		DROP TRIGGER IF EXISTS messages_ai;
+		DROP TRIGGER IF EXISTS messages_ad;
+		DROP TRIGGER IF EXISTS messages_au;
+	`); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *DB) triggerExists(trigger string) (bool, error) {
+	row := d.sql.QueryRow(`SELECT 1 FROM sqlite_master WHERE name = ? AND type = 'trigger'`, trigger)
+	var one int
+	if err := row.Scan(&one); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (d *DB) metadataValue(key string) (string, error) {
+	row := d.sql.QueryRow(`SELECT value FROM store_metadata WHERE key = ?`, key)
+	var value string
+	if err := row.Scan(&value); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	return value, nil
+}
+
+func (d *DB) setMetadata(key, value string) error {
+	if _, err := d.sql.Exec(`
+		INSERT INTO store_metadata(key, value, updated_at) VALUES(?, ?, ?)
+		ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at
+	`, key, value, time.Now().UTC().Unix()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *DB) deleteMetadata(key string) error {
+	if _, err := d.sql.Exec(`DELETE FROM store_metadata WHERE key = ?`, key); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/store/schema_test.go
+++ b/internal/store/schema_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -33,6 +34,14 @@ func TestOpenCreatesExpectedSchema(t *testing.T) {
 			t.Fatalf("expected messages column %q to exist", want)
 		}
 	}
+
+	metaExists, err := tableExists(db.sql, "store_metadata")
+	if err != nil {
+		t.Fatalf("tableExists(store_metadata): %v", err)
+	}
+	if !metaExists {
+		t.Fatalf("expected store_metadata table to exist")
+	}
 }
 
 func tableColumns(db *sql.DB, table string) (map[string]bool, error) {
@@ -56,4 +65,16 @@ func tableColumns(db *sql.DB, table string) (map[string]bool, error) {
 		cols[strings.ToLower(name)] = true
 	}
 	return cols, rows.Err()
+}
+
+func tableExists(db *sql.DB, table string) (bool, error) {
+	row := db.QueryRow(`SELECT 1 FROM sqlite_master WHERE name = ? AND type = 'table'`, table)
+	var one int
+	if err := row.Scan(&one); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }

--- a/internal/store/search_fts_test.go
+++ b/internal/store/search_fts_test.go
@@ -148,6 +148,13 @@ func TestHasFTSRemainsEnabledAfterReopen(t *testing.T) {
 	if !db.HasFTS() {
 		t.Fatalf("expected HasFTS=true on first open")
 	}
+	state, err := db.metadataValue(messagesFTSStateKey)
+	if err != nil {
+		t.Fatalf("metadataValue on first open: %v", err)
+	}
+	if state != messagesFTSStateVersion {
+		t.Fatalf("expected FTS state marker %q, got %q", messagesFTSStateVersion, state)
+	}
 	if err := db.Close(); err != nil {
 		t.Fatalf("Close first db: %v", err)
 	}
@@ -159,5 +166,134 @@ func TestHasFTSRemainsEnabledAfterReopen(t *testing.T) {
 	defer db.Close()
 	if !db.HasFTS() {
 		t.Fatalf("expected HasFTS=true after reopen")
+	}
+	state, err = db.metadataValue(messagesFTSStateKey)
+	if err != nil {
+		t.Fatalf("metadataValue after reopen: %v", err)
+	}
+	if state != messagesFTSStateVersion {
+		t.Fatalf("expected FTS state marker %q after reopen, got %q", messagesFTSStateVersion, state)
+	}
+}
+
+func TestEnsureMessagesFTSRepairsMissingTriggersAndBackfillAfterReopen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wacli.db")
+
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open first time: %v", err)
+	}
+
+	chat := "repair@s.whatsapp.net"
+	if err := db.UpsertChat(chat, "dm", "Repair", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:    chat,
+		ChatName:   "Repair",
+		MsgID:      "m1",
+		SenderJID:  chat,
+		SenderName: "Repair",
+		Timestamp:  time.Now(),
+		Text:       "first repair message",
+	}); err != nil {
+		t.Fatalf("UpsertMessage m1: %v", err)
+	}
+
+	if _, err := db.sql.Exec(`
+		DROP TRIGGER IF EXISTS messages_ai;
+		DROP TRIGGER IF EXISTS messages_ad;
+		DROP TRIGGER IF EXISTS messages_au;
+		DELETE FROM messages_fts;
+	`); err != nil {
+		t.Fatalf("break FTS state: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close first db: %v", err)
+	}
+
+	db, err = Open(path)
+	if err != nil {
+		t.Fatalf("Open second time: %v", err)
+	}
+	defer db.Close()
+	if !db.HasFTS() {
+		t.Fatalf("expected HasFTS=true after repair")
+	}
+
+	ms, err := db.SearchMessages(SearchMessagesParams{Query: "first", Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchMessages after repair: %v", err)
+	}
+	if len(ms) != 1 || ms[0].MsgID != "m1" {
+		t.Fatalf("expected rebuilt index to return m1, got %v", ms)
+	}
+
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:    chat,
+		ChatName:   "Repair",
+		MsgID:      "m2",
+		SenderJID:  chat,
+		SenderName: "Repair",
+		Timestamp:  time.Now().Add(time.Second),
+		Text:       "second repair message",
+	}); err != nil {
+		t.Fatalf("UpsertMessage m2: %v", err)
+	}
+
+	ms, err = db.SearchMessages(SearchMessagesParams{Query: "second", Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchMessages for new message: %v", err)
+	}
+	if len(ms) != 1 || ms[0].MsgID != "m2" {
+		t.Fatalf("expected recreated triggers to index m2, got %v", ms)
+	}
+}
+
+func TestEnsureMessagesFTSFallsBackOrRepairsDamagedShadowTables(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wacli.db")
+
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open first time: %v", err)
+	}
+
+	chat := "damaged@s.whatsapp.net"
+	if err := db.UpsertChat(chat, "dm", "Damaged", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:    chat,
+		ChatName:   "Damaged",
+		MsgID:      "m1",
+		SenderJID:  chat,
+		SenderName: "Damaged",
+		Timestamp:  time.Now(),
+		Text:       "damaged shadow table message",
+	}); err != nil {
+		t.Fatalf("UpsertMessage m1: %v", err)
+	}
+
+	if _, err := db.sql.Exec(`DROP TABLE messages_fts_data`); err != nil {
+		t.Fatalf("damage shadow table: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close first db: %v", err)
+	}
+
+	db, err = Open(path)
+	if err != nil {
+		t.Fatalf("Open after damage should fall back or repair, got: %v", err)
+	}
+	defer db.Close()
+
+	ms, err := db.SearchMessages(SearchMessagesParams{Query: "damaged", Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchMessages after damage: %v", err)
+	}
+	if len(ms) != 1 || ms[0].MsgID != "m1" {
+		t.Fatalf("expected search to keep working after damage, got %v", ms)
 	}
 }

--- a/internal/store/search_fts_test.go
+++ b/internal/store/search_fts_test.go
@@ -3,6 +3,7 @@
 package store
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -134,4 +135,29 @@ func TestFTSInjectionPrevented(t *testing.T) {
 			t.Errorf("expected m1 for 'hello world', got %v", ms)
 		}
 	})
+}
+
+func TestHasFTSRemainsEnabledAfterReopen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wacli.db")
+
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open first time: %v", err)
+	}
+	if !db.HasFTS() {
+		t.Fatalf("expected HasFTS=true on first open")
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close first db: %v", err)
+	}
+
+	db, err = Open(path)
+	if err != nil {
+		t.Fatalf("Open second time: %v", err)
+	}
+	defer db.Close()
+	if !db.HasFTS() {
+		t.Fatalf("expected HasFTS=true after reopen")
+	}
 }


### PR DESCRIPTION
## Summary

This PR started as a narrow fix for `ftsEnabled` being lost after the first database open. The updated version is broader and safer:

```text
before
first open   -> FTS5 on
later opens  -> FTS5 off

naive fix
later opens  -> FTS5 on
               but could trust a half-built/broken index

after
later opens  -> cheap health check
               if healthy: keep FTS5 on
               if stale/broken: rebuild once
               if rebuild fails: keep startup working and fall back to LIKE
```

The original bug is still fixed, but this version also avoids the two review concerns from the earlier draft:
- it does **not** scan all messages on every open
- it does **not** fail `Open()` when FTS shadow tables are damaged

## Changes

- add a small `store_metadata` table and persist an FTS readiness marker once table creation, trigger setup, and initial backfill succeed
- on reopen, use cheap health checks instead of full-table `COUNT(*)` scans
- if the marker is missing/stale, rebuild the FTS table, triggers, and backfill once
- if FTS shadow tables are damaged or repair fails, disable FTS for that process and keep the existing LIKE fallback working
- document the repaired startup/fallback behavior in `docs/spec.md`

## Why this is safer

The previous PR draft only re-enabled FTS based on table/function presence. That could incorrectly trust an incomplete or broken index.

This revision only keeps FTS enabled when:
- SQLite has FTS5 support
- the expected FTS table shape is present
- the FTS triggers exist
- a lightweight probe query succeeds

Otherwise it repairs the FTS state or falls back cleanly.

## Testing

- `go test ./...`
- `go test -tags sqlite_fts5 ./...`

Added regression coverage for:
- FTS remains enabled after reopen
- the readiness marker is written and preserved across reopen
- missing triggers + emptied FTS contents are rebuilt on reopen
- damaged FTS shadow tables do not break startup, and search still works afterward
- schema includes the new `store_metadata` table

## Notes

This remains separate from #160. That issue is about macOS release packaging missing the `sqlite_fts5` build tag. This PR fixes the runtime reopen/repair behavior for builds that already include FTS5.