### PR TITLE
ci: sync the Homebrew tap on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,23 @@ jobs:
             -f repository=steipete/wacli \
             -f macos_artifact=wacli-macos-universal.tar.gz
 
+          run_id=""
+          until [ -n "$run_id" ]; do
+            run_id=$(gh run list \
+              --repo steipete/homebrew-tap \
+              --workflow update-formula.yml \
+              --branch main \
+              --event workflow_dispatch \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId')
+          done
+
+          gh run watch "$run_id" \
+            --repo steipete/homebrew-tap \
+            --exit-status \
+            --interval 10
+
   goreleaser-linux-windows:
     runs-on: ubuntu-latest
     needs: goreleaser-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,25 +68,38 @@ jobs:
             exit 1
           fi
 
+          request_id="wacli-${RELEASE_TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          expected_title="Update wacli for ${RELEASE_TAG} (${request_id})"
+
           gh workflow run update-formula.yml \
             --repo steipete/homebrew-tap \
             --ref main \
             -f formula=wacli \
             -f tag="$RELEASE_TAG" \
             -f repository=steipete/wacli \
-            -f macos_artifact=wacli-macos-universal.tar.gz
+            -f macos_artifact=wacli-macos-universal.tar.gz \
+            -f request_id="$request_id"
 
           run_id=""
-          until [ -n "$run_id" ]; do
+          for _ in {1..30}; do
             run_id=$(gh run list \
               --repo steipete/homebrew-tap \
               --workflow update-formula.yml \
               --branch main \
               --event workflow_dispatch \
-              --limit 1 \
-              --json databaseId \
-              --jq '.[0].databaseId')
+              --limit 20 \
+              --json databaseId,displayTitle \
+              --jq ".[] | select(.displayTitle == \"$expected_title\") | .databaseId" | head -n1)
+            if [ -n "$run_id" ]; then
+              break
+            fi
+            sleep 5
           done
+
+          if [ -z "$run_id" ]; then
+            echo "::error::Could not find tap workflow run with title: $expected_title"
+            exit 1
+          fi
 
           gh run watch "$run_id" \
             --repo steipete/homebrew-tap \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,35 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  update-homebrew-tap:
+    runs-on: ubuntu-latest
+    needs: goreleaser-darwin
+    steps:
+      - name: Resolve release tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "RELEASE_TAG=${{ inputs.tag }}" >> $GITHUB_ENV
+          else
+            echo "RELEASE_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
+          fi
+
+      - name: Dispatch tap formula update
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::Set HOMEBREW_TAP_TOKEN with workflow access to steipete/homebrew-tap"
+            exit 1
+          fi
+
+          gh workflow run update-formula.yml \
+            --repo steipete/homebrew-tap \
+            --ref main \
+            -f formula=wacli \
+            -f tag="$RELEASE_TAG" \
+            -f repository=steipete/wacli \
+            -f macos_artifact=wacli-macos-universal.tar.gz
+
   goreleaser-linux-windows:
     runs-on: ubuntu-latest
     needs: goreleaser-darwin

--- a/docs/release.md
+++ b/docs/release.md
@@ -24,10 +24,10 @@ Other artifacts:
 
 ## Homebrew Tap
 
-The tap formula lives in `../homebrew-tap/Formula/wacli.rb`.
+The release workflow dispatches the `Update Formula` workflow in `steipete/homebrew-tap` after the macOS artifact is published. The tap workflow owns the formula-editing logic and updates both the macOS artifact SHA256 and the Linux source archive SHA256 in `Formula/wacli.rb`.
 
-Once a release exists, update the tap formula by running the `Update Formula` workflow in the tap repo with:
+Required repository secret:
 
-- `formula`: `wacli`
-- `tag`: `vX.Y.Z`
-- `repository`: `steipete/wacli`
+- `HOMEBREW_TAP_TOKEN`: token with permission to run workflows in `steipete/homebrew-tap`
+
+To backfill an existing release, rerun the `release` workflow manually with `tag: vX.Y.Z`.


### PR DESCRIPTION
## Problem

- the release workflow publishes GitHub artifacts but leaves `steipete/homebrew-tap` stale
- `brew install steipete/tap/wacli` can lag behind tagged releases
- the release workflow should fail if the downstream tap update fails

## Solution

- dispatch the tap repo's `Update Formula` workflow after the macOS artifact is published
- pass the `wacli` formula name, release tag, source repo, macOS artifact name, and a unique `request_id` to the tap workflow
- wait for the exact tap workflow run whose title contains that `request_id`, then gate the release on `gh run watch --exit-status`
- keep formula editing logic in `steipete/homebrew-tap` instead of this repo
- document the `HOMEBREW_TAP_TOKEN` secret and the backfill workflow

## Maintainer setup

- merge steipete/homebrew-tap#29 first
- create a token that can dispatch workflows in `steipete/homebrew-tap`
  - classic PAT: `repo` + `workflow`
  - fine-grained PAT: repository access to `steipete/homebrew-tap` with Actions/workflow permission
- add it to `steipete/wacli` as the `HOMEBREW_TAP_TOKEN` repository secret
- no extra tap secret is needed; the tap workflow commits with its repo-local `GITHUB_TOKEN`

## Review

- the new job only depends on the macOS publish step because the tap workflow can update the macOS artifact SHA256 and Linux source archive SHA256 from the tag
- the job now waits for the exact dispatched tap workflow run, avoiding races with concurrent/manual tap updates
- rerunning `release` with an existing tag backfills the tap for older releases
- merge after the companion tap workflow PR: steipete/homebrew-tap#29

<sub>
📎 Related: steipete/homebrew-tap#29
</sub>
