### PR TITLE
fix: reset idle timer on Connected event in sync --once mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Messages: show display text for replies, reactions, and media in `messages context`. (#183 — thanks @fuleinist)
 - Search: keep FTS5 enabled after reopening existing databases with already-applied migrations. (#185 — thanks @iamhitarth)
 - Send: persist retry-message plaintext so linked devices can decrypt retried messages. (#186 — thanks @SimDamDev)
+- Sync: start `sync --once` idle timing after the `Connected` event. (#171 — thanks @fuleinist)
 - Sync: include event type, stack trace, and recovery count when logging recovered event-handler panics. (#181 — thanks @shaun0927)
 
 ### Docs

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -25,6 +25,7 @@ type fakeWA struct {
 	handlers      map[uint32]func(interface{})
 
 	connectEvents []interface{}
+	connectDelay  time.Duration
 
 	contacts map[types.JID]types.ContactInfo
 	groups   map[types.JID]*types.GroupInfo
@@ -72,6 +73,13 @@ func (f *fakeWA) Connect(ctx context.Context, opts wa.ConnectOptions) error {
 
 	if !authed && !opts.AllowQR {
 		return fmt.Errorf("not authenticated; run `wacli auth`")
+	}
+	if f.connectDelay > 0 {
+		select {
+		case <-time.After(f.connectDelay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 	f.emit(&events.Connected{})
 	for _, e := range eventsToEmit {

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -256,3 +256,26 @@ func TestSyncOnceIdleExit(t *testing.T) {
 		t.Fatalf("expected to exit quickly on idle, took %s", time.Since(start))
 	}
 }
+
+func TestSyncOnceIdleExitStartsAfterConnected(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	f.connectDelay = 400 * time.Millisecond
+	a.wa = f
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err := a.Sync(ctx, SyncOptions{
+		Mode:     SyncModeOnce,
+		AllowQR:  false,
+		IdleExit: 600 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < f.connectDelay+600*time.Millisecond {
+		t.Fatalf("expected idle timer to start after connect, exited after %s", elapsed)
+	}
+}


### PR DESCRIPTION
## Problem

When running `wacli sync --once`, the process hangs indefinitely on subsequent syncs when no new messages arrive after connection.

The root cause: the idle timer (`--idle-exit`) was only reset when events like `Message` or `HistorySync` were received. On already-synced accounts, no such events arrive after `Connected`, so the timer incorrectly uses the time when `Sync()` was called instead of when the connection was established.

This is tracked in:
- Issue #87: sync --once hangs indefinitely at "Connected." when no history sync event is received
- Issue #169: sync --once hangs indefinitely when no events are received after connect

## Solution

Explicitly reset `lastEvent` when the `Connected` event is received:

```go
case *events.Connected:
    fmt.Fprintln(os.Stderr, "\nConnected.")
    lastEvent.Store(time.Now().UTC().UnixNano())
```

This ensures the idle timer correctly counts from connection time, not from when the sync process started.

## Testing

- First sync: `Connected` then `HistorySync` arrives - timer reset correctly by HistorySync (no regression)
- Subsequent syncs: `Connected` but no new events - timer now correctly starts from connection time
