### PR TITLE
fix(config): use XDG state dir on Linux by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,4 +52,6 @@
 - Groups: list/refresh/info/rename; participants add/remove/promote/demote; invite link get/revoke; join/leave.
 - Diagnostics: `wacli doctor` for store path, lock status/info, auth/connection check, and FTS status.
 - CLI UX: human-readable output by default with `--json`, global `--store`/`--timeout`, plus `wacli version`.
-- Storage: default `~/.wacli`, lock file for single-instance safety, SQLite DB with FTS5, WhatsApp session store, and media directory.
+- Storage: default `${XDG_STATE_HOME:-~/.local/state}/wacli` on Linux and
+  `~/.wacli` elsewhere, plus a lock file for single-instance safety, SQLite DB
+  with FTS5, WhatsApp session store, and media directory.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Run (local build only):
 
 ## Quick start
 
-Default store directory is `~/.wacli` (override with `--store DIR`).
+Default store directory is `${XDG_STATE_HOME:-~/.local/state}/wacli` on Linux and
+`~/.wacli` elsewhere (override with `--store DIR` or `WACLI_STORE_DIR`).
 
 ```bash
 # 1) Authenticate (shows QR), then bootstrap sync
@@ -87,7 +88,8 @@ This project is heavily inspired by (and learns from) the excellent `whatsapp-cl
 
 ## Storage
 
-Defaults to `~/.wacli` (override with `--store DIR`).
+Defaults to `${XDG_STATE_HOME:-~/.local/state}/wacli` on Linux and `~/.wacli`
+elsewhere (override with `--store DIR` or `WACLI_STORE_DIR`).
 
 ## Environment overrides
 

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -34,7 +34,7 @@ func execute(args []string) error {
 	}
 	rootCmd.SetVersionTemplate("wacli {{.Version}}\n")
 
-	rootCmd.PersistentFlags().StringVar(&flags.storeDir, "store", "", "store directory (default: $WACLI_STORE_DIR or ~/.wacli)")
+	rootCmd.PersistentFlags().StringVar(&flags.storeDir, "store", "", "store directory (default: $WACLI_STORE_DIR or XDG state dir on Linux, ~/.wacli elsewhere)")
 	rootCmd.PersistentFlags().BoolVar(&flags.asJSON, "json", false, "output JSON instead of human-readable text")
 	rootCmd.PersistentFlags().DurationVar(&flags.timeout, "timeout", 5*time.Minute, "command timeout (non-sync commands)")
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -21,18 +21,20 @@ This document defines the v1 plan for `wacli`: a WhatsApp CLI that syncs message
 ## Terminology
 
 - **JID**: WhatsApp Jabber ID, e.g. `1234567890@s.whatsapp.net` (user) or `123456789@g.us` (group).
-- **Store directory**: directory containing all local state, default `~/.wacli`.
+- **Store directory**: directory containing all local state, default
+  `${XDG_STATE_HOME:-~/.local/state}/wacli` on Linux and `~/.wacli` elsewhere.
 
 ## Storage layout
 
-Default store: `~/.wacli` (override with `--store DIR`).
+Default store: `${XDG_STATE_HOME:-~/.local/state}/wacli` on Linux and `~/.wacli`
+elsewhere (override with `--store DIR` or `WACLI_STORE_DIR`).
 
 Proposed files:
 
-- `~/.wacli/session.db` — `whatsmeow` SQL store (device identity, keys, app-state).
-- `~/.wacli/wacli.db` — our SQLite DB (messages/chats, FTS, local metadata).
-- `~/.wacli/media/...` — downloaded media (optional, on-demand or background).
-- `~/.wacli/LOCK` — store lock to prevent concurrent access.
+- `<store>/session.db` — `whatsmeow` SQL store (device identity, keys, app-state).
+- `<store>/wacli.db` — our SQLite DB (messages/chats, FTS, local metadata).
+- `<store>/media/...` — downloaded media (optional, on-demand or background).
+- `<store>/LOCK` — store lock to prevent concurrent access.
 
 Rationale for two SQLite files: reduce coupling and keep the `whatsmeow`-owned schema separate from `wacli`’s local schema. It’s still “one store directory” for the user.
 
@@ -132,7 +134,7 @@ Fallback:
 
 Global flags:
 
-- `--store DIR` (default `~/.wacli`)
+- `--store DIR` (default `${XDG_STATE_HOME:-~/.local/state}/wacli` on Linux, `~/.wacli` elsewhere)
 - `--json` (default: human text)
 - `--timeout DURATION` (non-sync commands; e.g. `5m`)
 - `--version` (prints version and exits)
@@ -234,7 +236,8 @@ Recommendation:
 - `sync` (non-interactive, follow mode)
 - `messages list/search` with FTS5
 - `send text`
-- store locking, default `~/.wacli`
+- store locking, default `${XDG_STATE_HOME:-~/.local/state}/wacli` on Linux and
+  `~/.wacli` elsewhere
 
 ### v0.2
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 // EnvStoreDir is the environment variable that overrides the default store
@@ -12,14 +13,27 @@ import (
 const EnvStoreDir = "WACLI_STORE_DIR"
 
 // DefaultStoreDir returns the store directory to use when --store is not
-// supplied. It checks WACLI_STORE_DIR first, then falls back to ~/.wacli.
+// supplied. It checks WACLI_STORE_DIR first, then falls back to an XDG state
+// directory on Linux or ~/.wacli on other platforms.
 func DefaultStoreDir() string {
 	if dir := os.Getenv(EnvStoreDir); dir != "" {
 		return dir
 	}
+
+	if runtime.GOOS == "linux" {
+		if stateHome := os.Getenv("XDG_STATE_HOME"); stateHome != "" {
+			return filepath.Join(stateHome, "wacli")
+		}
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		return ".wacli"
 	}
+
+	if runtime.GOOS == "linux" {
+		return filepath.Join(home, ".local", "state", "wacli")
+	}
+
 	return filepath.Join(home, ".wacli")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -15,11 +16,30 @@ func TestDefaultStoreDir(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to ~/.wacli when env unset", func(t *testing.T) {
+	t.Run("uses XDG state dir on linux when env unset", func(t *testing.T) {
 		t.Setenv(EnvStoreDir, "")
+		t.Setenv("XDG_STATE_HOME", "")
 		got := DefaultStoreDir()
 		home, _ := os.UserHomeDir()
 		want := filepath.Join(home, ".wacli")
+		if runtime.GOOS == "linux" {
+			want = filepath.Join(home, ".local", "state", "wacli")
+		}
+		if got != want {
+			t.Errorf("DefaultStoreDir() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("uses XDG_STATE_HOME on linux", func(t *testing.T) {
+		t.Setenv(EnvStoreDir, "")
+		t.Setenv("XDG_STATE_HOME", "/tmp/xdg-state")
+
+		got := DefaultStoreDir()
+		want := filepath.Join("/tmp/xdg-state", "wacli")
+		if runtime.GOOS != "linux" {
+			home, _ := os.UserHomeDir()
+			want = filepath.Join(home, ".wacli")
+		}
 		if got != want {
 			t.Errorf("DefaultStoreDir() = %q, want %q", got, want)
 		}


### PR DESCRIPTION
Closes #164

## Summary
- use `${XDG_STATE_HOME}/wacli` or `~/.local/state/wacli` as the default store on Linux
- keep `WACLI_STORE_DIR` and `--store` as explicit overrides
- update help text, tests, and docs to match the new default path

## Testing
- `go test ./internal/config ./cmd/wacli`
- `go test ./...`
