### PR TITLE
fix: use DisplayText in messages context command

### DIFF
--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -311,7 +311,13 @@ func newMessagesContextCmd(flags *rootFlags) *cobra.Command {
 				if m.FromMe {
 					from = "me"
 				}
-				line := m.Text
+				line := strings.TrimSpace(m.DisplayText)
+				if line == "" {
+					line = strings.TrimSpace(m.Text)
+				}
+				if m.MediaType != "" && line == "" {
+					line = "Sent " + m.MediaType
+				}
 				if m.MsgID == id {
 					line = ">> " + line
 				}


### PR DESCRIPTION
## Summary

`wacli messages context` was rendering each message with `m.Text` directly, which shows blank lines for reactions, reply-quote messages, and media messages whose `Text` field is empty.

`wacli messages list` already uses the correct priority (`DisplayText` → `Text` → `"Sent <type>"`). This PR aligns `messages context` to the same logic.

### Before
```go
line := m.Text
```

### After
```go
line := strings.TrimSpace(m.DisplayText)
if line == "" {
    line = strings.TrimSpace(m.Text)
}
if m.MediaType != "" && line == "" {
    line = "Sent " + m.MediaType
}
```

Closes #173

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>