### PR TITLE
bug: recover per media job so a panic no longer kills the worker (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Media: recover panics per download job so one bad payload no longer drains the worker pool. (#179 — thanks @shaun0927)
 - Send: persist retry-message plaintext so linked devices can decrypt retried messages. (#186 — thanks @SimDamDev)
 
 ### Docs

--- a/internal/app/media.go
+++ b/internal/app/media.go
@@ -92,7 +92,10 @@ func (a *App) runMediaWorkers(ctx context.Context, jobs <-chan mediaJob, workers
 				select {
 				case <-ctx.Done():
 					return
-				case job := <-jobs:
+				case job, ok := <-jobs:
+					if !ok {
+						return
+					}
 					if strings.TrimSpace(job.chatJID) == "" || strings.TrimSpace(job.msgID) == "" {
 						continue
 					}

--- a/internal/app/media.go
+++ b/internal/app/media.go
@@ -7,6 +7,7 @@ import (
 	"mime"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -87,13 +88,6 @@ func (a *App) runMediaWorkers(ctx context.Context, jobs <-chan mediaJob, workers
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			// Recover from panics to prevent a bad media job from crashing
-			// the whole process (#52).
-			defer func() {
-				if r := recover(); r != nil {
-					fmt.Fprintf(os.Stderr, "media worker panic (recovered): %v\n", r)
-				}
-			}()
 			for {
 				select {
 				case <-ctx.Done():
@@ -102,9 +96,19 @@ func (a *App) runMediaWorkers(ctx context.Context, jobs <-chan mediaJob, workers
 					if strings.TrimSpace(job.chatJID) == "" || strings.TrimSpace(job.msgID) == "" {
 						continue
 					}
-					if err := a.downloadMediaJob(ctx, job); err != nil {
-						fmt.Fprintf(os.Stderr, "media download failed for %s/%s: %v\n", job.chatJID, job.msgID, err)
-					}
+					// Recover per job so a panic fails one download
+					// instead of killing the worker permanently (#52).
+					func() {
+						defer func() {
+							if r := recover(); r != nil {
+								fmt.Fprintf(os.Stderr, "media worker panic (recovered) for %s/%s: %v\n%s\n",
+									job.chatJID, job.msgID, r, debug.Stack())
+							}
+						}()
+						if err := a.downloadMediaJob(ctx, job); err != nil {
+							fmt.Fprintf(os.Stderr, "media download failed for %s/%s: %v\n", job.chatJID, job.msgID, err)
+						}
+					}()
 				}
 			}
 		}()

--- a/internal/app/media_panic_test.go
+++ b/internal/app/media_panic_test.go
@@ -1,0 +1,101 @@
+package app
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/steipete/wacli/internal/store"
+)
+
+// panicFirstWA wraps a fakeWA but panics on the first DownloadMediaToFile
+// call, mirroring the behavior of an unexpected media payload that
+// dereferences a nil field inside whatsmeow.
+type panicFirstWA struct {
+	*fakeWA
+	panics  atomic.Int32
+	allowed atomic.Int32
+}
+
+func (p *panicFirstWA) DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error) {
+	if p.panics.Add(1) == 1 {
+		panic("simulated bad media payload")
+	}
+	p.allowed.Add(1)
+	return p.fakeWA.DownloadMediaToFile(ctx, directPath, encFileHash, fileHash, mediaKey, fileLength, mediaType, mmsType, targetPath)
+}
+
+// TestMediaWorkerSurvivesPanic verifies that a panic in one media job does
+// not take down the worker goroutine: subsequent jobs enqueued on the same
+// channel must still be processed (#176, regression of #143).
+func TestMediaWorkerSurvivesPanic(t *testing.T) {
+	a := newTestApp(t)
+	pf := &panicFirstWA{fakeWA: newFakeWA()}
+	a.wa = pf
+
+	chat := "123@s.whatsapp.net"
+	if err := a.db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	for _, m := range []struct{ id string }{{"boom"}, {"ok"}} {
+		if err := a.db.UpsertMessage(store.UpsertMessageParams{
+			ChatJID:       chat,
+			MsgID:         m.id,
+			SenderJID:     chat,
+			SenderName:    "Alice",
+			Timestamp:     time.Now(),
+			MediaType:     "image",
+			Filename:      m.id + ".jpg",
+			MimeType:      "image/jpeg",
+			DirectPath:    "/direct/path",
+			MediaKey:      []byte{1, 2, 3},
+			FileSHA256:    []byte{4, 5},
+			FileEncSHA256: []byte{6, 7},
+			FileLength:    16,
+		}); err != nil {
+			t.Fatalf("UpsertMessage %s: %v", m.id, err)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	jobs := make(chan mediaJob, 2)
+	stop, err := a.runMediaWorkers(ctx, jobs, 1)
+	if err != nil {
+		t.Fatalf("runMediaWorkers: %v", err)
+	}
+
+	jobs <- mediaJob{chatJID: chat, msgID: "boom"}
+	jobs <- mediaJob{chatJID: chat, msgID: "ok"}
+
+	// Poll until the benign job is downloaded.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if pf.allowed.Load() >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if pf.panics.Load() != 2 {
+		// Add returns the new value, so 2 here means both jobs reached the
+		// download call (the first panicked, the second did not).
+		t.Fatalf("expected both jobs to reach the download call, got panics=%d", pf.panics.Load())
+	}
+	if pf.allowed.Load() != 1 {
+		t.Fatalf("benign job was not processed after panic: allowed=%d", pf.allowed.Load())
+	}
+
+	// Verify the benign job actually persisted a local path.
+	info, err := a.db.GetMediaDownloadInfo(chat, "ok")
+	if err != nil {
+		t.Fatalf("GetMediaDownloadInfo: %v", err)
+	}
+	if info.LocalPath == "" {
+		t.Fatalf("expected LocalPath for benign job to be set after panic survival")
+	}
+
+	stop()
+}


### PR DESCRIPTION
## Summary

PR #143 added `recover()` to the media worker goroutines, but the `defer` is registered at the goroutine top rather than per-job. A panic inside `downloadMediaJob` unwinds past the `for { select }` loop, fires the deferred recover, and the goroutine returns — so one bad payload permanently removes a worker from the pool. Under sustained malformed input the pool drains to zero and media downloads stall silently while the rest of the process keeps running.

## Changes

- Move the recover `defer` into an inner function that wraps each `downloadMediaJob` call so the `for { select }` loop continues to consume the queue after a panic.
- Include `chatJID`, `msgID`, and `runtime/debug.Stack()` in the recovered-panic log line so panics remain diagnosable.

## Testing

- New test `TestMediaWorkerSurvivesPanic` in `internal/app/media_panic_test.go` wraps `newFakeWA()` with a stub whose `DownloadMediaToFile` panics on the first invocation. It spawns a 1-worker pool, feeds it a panicking job followed by a benign one, and asserts both calls reached the download path and the benign job persisted a `LocalPath` — proving the worker survived the panic.
- Existing `TestDownloadMediaJobMarksDownloaded` still passes.
- `go test -tags sqlite_fts5 -race ./internal/app/ ./internal/wa/ ./internal/store/` is green.

Closes #176.
