### PR TITLE
security: reject '?' and '#' in StorePath for whatsmeow session store (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.6.1 - Unreleased
 
+### Security
+
+- Auth: reject `?` and `#` in whatsmeow session store paths to avoid SQLite URI parameter injection. (#180 — thanks @shaun0927)
+
 ### Fixed
 
 - Send: persist retry-message plaintext so linked devices can decrypt retried messages. (#186 — thanks @SimDamDev)

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -34,6 +34,10 @@ func New(opts Options) (*Client, error) {
 	if strings.TrimSpace(opts.StorePath) == "" {
 		return nil, fmt.Errorf("StorePath is required")
 	}
+	// Reject paths that could inject SQLite URI parameters (#177, mirror of #59).
+	if strings.ContainsAny(opts.StorePath, "?#") {
+		return nil, fmt.Errorf("StorePath must not contain '?' or '#'")
+	}
 	c := &Client{opts: opts}
 	if err := c.init(); err != nil {
 		return nil, err

--- a/internal/wa/client_uri_test.go
+++ b/internal/wa/client_uri_test.go
@@ -1,0 +1,27 @@
+package wa
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNewRejectsURISpecialCharsInStorePath verifies that a StorePath
+// containing '?' or '#' is rejected before it can reach the SQLite URI
+// parser inside whatsmeow's sqlstore (#177, mirror of #59).
+func TestNewRejectsURISpecialCharsInStorePath(t *testing.T) {
+	cases := []struct{ name, path string }{
+		{"question mark", "/tmp/session.db?mode=memory"},
+		{"hash", "/tmp/session.db#frag"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := New(Options{StorePath: tc.path})
+			if err == nil {
+				t.Fatalf("expected error for path %q, got nil", tc.path)
+			}
+			if !strings.Contains(err.Error(), "'?'") && !strings.Contains(err.Error(), "'#'") {
+				t.Fatalf("expected guard error mentioning '?' or '#', got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

PR #141 (closes #59) added `strings.ContainsAny(path, "?#")` before constructing the SQLite URI for the message store in `internal/store/db.go:24-26`. The whatsmeow session store in `internal/wa/client.go:49` uses the same `fmt.Sprintf("file:%s?_foreign_keys=on", path)` pattern and was left without that guard. A `--store` or `WACLI_STORE_DIR` value containing `?` (e.g. `/tmp/foo?mode=memory`) injects arbitrary SQLite URI parameters into the session DSN and can silently neutralize foreign keys or change the session store's isolation mode.

## Changes

- Apply the identical `ContainsAny(path, "?#")` guard inside `wa.New`, before `c.init()` is called, so both backing stores reject the injection path consistently.

## Testing

- New test `TestNewRejectsURISpecialCharsInStorePath` in `internal/wa/client_uri_test.go` covers both `?` and `#` variants and asserts the returned error mentions one of those characters.
- `go test -tags sqlite_fts5 -race ./internal/wa/...` is green.

Closes #177.
