### PR TITLE
enhance: log stack trace, event type, and counter when recovering sync panics (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Media: recover panics per download job so one bad payload no longer drains the worker pool. (#179 — thanks @shaun0927)
 - Send: persist retry-message plaintext so linked devices can decrypt retried messages. (#186 — thanks @SimDamDev)
+- Sync: include event type, stack trace, and recovery count when logging recovered event-handler panics. (#181 — thanks @shaun0927)
 
 ### Docs
 

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -80,12 +81,17 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 		}
 	}
 
+	var panicCount atomic.Int64
 	handlerID := a.wa.AddEventHandler(func(evt interface{}) {
 		// Recover from panics so unexpected message structures do not
-		// crash the entire process (#52).
+		// crash the entire process (#52). Log a stack trace, the event
+		// type, and a running counter so recoveries do not go silently
+		// unnoticed (#178).
 		defer func() {
 			if r := recover(); r != nil {
-				fmt.Fprintf(os.Stderr, "\nevent handler panic (recovered): %v\n", r)
+				n := panicCount.Add(1)
+				fmt.Fprintf(os.Stderr, "\nevent handler panic (recovered, total=%d) event=%T: %v\n%s\n",
+					n, evt, r, debug.Stack())
 			}
 		}()
 		lastEvent.Store(time.Now().UTC().UnixNano())

--- a/internal/app/sync_panic_test.go
+++ b/internal/app/sync_panic_test.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+// captureStderr swaps os.Stderr for the duration of fn and returns everything
+// written to it. This lets tests observe the panic-recovery log emitted by
+// the Sync event handler without touching production code.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+	_ = w.Close()
+	return <-done
+}
+
+// TestSyncEventHandlerPanicHasStackAndCounter exercises the event handler
+// recovery path by emitting a typed-nil *events.Message (which forces
+// wa.ParseLiveMessage to dereference a nil receiver and panic), then
+// asserts the recovery log contains the event type, a running counter,
+// and a stack trace (#178).
+func TestSyncEventHandlerPanicHasStackAndCounter(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	// Two typed-nil *events.Message values panic deep in ParseLiveMessage
+	// when the handler reaches its first dereference. Emitting them while
+	// Sync is running forces the handler to recover twice, so we can check
+	// the counter increments.
+	var nilMsg *events.Message
+	f.connectEvents = []interface{}{nilMsg, nilMsg}
+
+	out := captureStderr(t, func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			cancel()
+		}()
+		if _, err := a.Sync(ctx, SyncOptions{Mode: SyncModeFollow, AllowQR: false}); err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "event handler panic (recovered, total=1)") {
+		t.Fatalf("expected recovery log for first panic with counter=1, got:\n%s", out)
+	}
+	if !strings.Contains(out, "event handler panic (recovered, total=2)") {
+		t.Fatalf("expected counter to increment to 2 on the second panic, got:\n%s", out)
+	}
+	if !strings.Contains(out, "event=*events.Message") {
+		t.Fatalf("expected event type annotation in recovery log, got:\n%s", out)
+	}
+	if !strings.Contains(out, "runtime/debug.Stack") && !strings.Contains(out, "sync.go") {
+		t.Fatalf("expected stack trace in recovery log, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

The event-handler recovery added in #143 logs only the bare recover value at `internal/app/sync.go:86-89`:

```go
fmt.Fprintf(os.Stderr, "\nevent handler panic (recovered): %v\n", r)
```

In practice this is indistinguishable from a silent swallow — no stack trace, no event context, no way to tell a one-off bad payload from a pathological loop that recovers thousands of times per minute. Because wacli's threat model explicitly puts malformed WhatsApp payloads in scope (that is exactly why #143 was added), recoveries need to carry enough information for maintainers to act on.

This PR adds three pieces of telemetry to the existing recovery block:

- `runtime/debug.Stack()` so the panic location is always attached to the log line.
- `%T` of the event so the event class (e.g. `*events.Message`, `*events.HistorySync`) is visible without parsing the stack.
- A per-`Sync` `atomic.Int64` counter appended to the log line (`total=N`) so operators can tell whether recoveries are rare or continuous.

The counter is scoped to each `Sync` invocation on purpose — it doesn't need to be process-global and keeping it in the closure avoids leaking state between sync sessions.

## Changes

- `internal/app/sync.go`: capture `runtime/debug.Stack()`, `%T`, and an `atomic.Int64` counter inside the existing `defer recover()` block. No change to behavior on the happy path.

## Testing

- New test `TestSyncEventHandlerPanicHasStackAndCounter` in `internal/app/sync_panic_test.go` captures `os.Stderr`, emits two typed-nil `*events.Message` values (which force `wa.ParseLiveMessage` to panic on the first dereference), runs a short `Sync`, and asserts the recovery log contains `total=1`, `total=2`, `event=*events.Message`, and a stack frame.
- `go test -tags sqlite_fts5 -race ./internal/app/ ./internal/wa/ ./internal/store/` is green.

This PR is intentionally scoped to `sync.go` because the sibling recover in `internal/app/media.go` is already being reworked in PR #179 (media worker pool regression). Mirroring the same telemetry into `media.go` can follow once #179 lands, to avoid conflicting diffs.

Closes #178.
