### PR TITLE
fix: use DisplayText in messages context command

### DIFF
--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -311,7 +311,13 @@ func newMessagesContextCmd(flags *rootFlags) *cobra.Command {
 				if m.FromMe {
 					from = "me"
 				}
-				line := m.Text
+				line := strings.TrimSpace(m.DisplayText)
+				if line == "" {
+					line = strings.TrimSpace(m.Text)
+				}
+				if m.MediaType != "" && line == "" {
+					line = "Sent " + m.MediaType
+				}
 				if m.MsgID == id {
 					line = ">> " + line
 				}


### PR DESCRIPTION
## Fix for Issue #173

The `messages context` command was using `m.Text` directly, which shows blank for reactions, replies, and media messages where DisplayText should be used instead.

### Changes

Align `messages context` with `messages list` by using the same display-text priority:
1. Prefer `DisplayText` over `Text`
2. Fall back to `Text` if `DisplayText` is empty
3. Show "Sent <mediatype>" for media messages with no text

This matches the existing behavior in `messages list` and fixes the confusing output where context would show blank lines for reactions/replies.

Signed-off-by: fuleinist <fuleinist@outlook.com>