### PR TITLE
feat(auth): add --phone flag for remote pairing without QR code

### DIFF
--- a/cmd/wacli/auth.go
+++ b/cmd/wacli/auth.go
@@ -16,10 +16,11 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 	var follow bool
 	var idleExit time.Duration
 	var downloadMedia bool
+	var phone string
 
 	cmd := &cobra.Command{
 		Use:   "auth",
-		Short: "Authenticate with WhatsApp (QR) and bootstrap sync",
+		Short: "Authenticate with WhatsApp (QR or phone number) and bootstrap sync",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, stop := signalContext()
 			defer stop()
@@ -30,6 +31,52 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
+			// Phone number pairing flow (no QR needed).
+			if phone != "" {
+				fmt.Fprintln(os.Stderr, "Starting phone number pairing…")
+				if err := a.OpenWA(); err != nil {
+					return err
+				}
+				code, err := a.WA().PairPhone(ctx, phone)
+				if err != nil {
+					return fmt.Errorf("phone pairing failed: %w", err)
+				}
+				fmt.Fprintf(os.Stderr, "\n========================================\n")
+				fmt.Fprintf(os.Stderr, "  Pairing code: %s\n", code)
+				fmt.Fprintf(os.Stderr, "========================================\n\n")
+				fmt.Fprintln(os.Stderr, "On the phone, go to:")
+				fmt.Fprintln(os.Stderr, "  WhatsApp → Settings → Linked Devices → Link a Device")
+				fmt.Fprintln(os.Stderr, "  → \"Link with phone number instead\"")
+				fmt.Fprintf(os.Stderr, "  → Enter the code: %s\n\n", code)
+				fmt.Fprintln(os.Stderr, "Waiting for pairing to complete…")
+
+				// Wait for the pairing to succeed by polling auth status.
+				ticker := time.NewTicker(2 * time.Second)
+				defer ticker.Stop()
+				timeout := time.After(5 * time.Minute)
+				for {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-timeout:
+						return fmt.Errorf("pairing timed out after 5 minutes")
+					case <-ticker.C:
+						if a.WA().IsAuthed() {
+							fmt.Fprintln(os.Stderr, "Paired successfully!")
+							if flags.asJSON {
+								return out.WriteJSON(os.Stdout, map[string]interface{}{
+									"authenticated": true,
+									"method":        "phone",
+								})
+							}
+							fmt.Fprintln(os.Stdout, "Authenticated via phone number pairing.")
+							return nil
+						}
+					}
+				}
+			}
+
+			// Standard QR code flow.
 			mode := appPkg.SyncModeBootstrap
 			if follow {
 				mode = appPkg.SyncModeFollow
@@ -68,6 +115,7 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().BoolVar(&follow, "follow", false, "keep syncing after auth")
 	cmd.Flags().DurationVar(&idleExit, "idle-exit", 30*time.Second, "exit after being idle (bootstrap/once modes)")
 	cmd.Flags().BoolVar(&downloadMedia, "download-media", false, "download media in the background during sync")
+	cmd.Flags().StringVar(&phone, "phone", "", "pair using phone number instead of QR (e.g. +521234567890)")
 
 	cmd.AddCommand(newAuthStatusCmd(flags))
 	cmd.AddCommand(newAuthLogoutCmd(flags))

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -45,6 +45,7 @@ type WAClient interface {
 	DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error)
 	RequestHistorySyncOnDemand(ctx context.Context, lastKnown types.MessageInfo, count int) (types.MessageID, error)
 	Logout(ctx context.Context) error
+	PairPhone(ctx context.Context, phone string) (string, error)
 }
 
 type Options struct {

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -250,3 +250,7 @@ func (f *fakeWA) Logout(ctx context.Context) error {
 	f.authed = false
 	return nil
 }
+
+func (f *fakeWA) PairPhone(ctx context.Context, phone string) (string, error) {
+	return "TESTCODE", nil
+}

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -349,6 +349,27 @@ func (c *Client) Logout(ctx context.Context) error {
 	return cli.Logout(ctx)
 }
 
+// PairPhone links this device using a phone number instead of QR code.
+// Returns an 8-digit pairing code the user enters on their phone.
+func (c *Client) PairPhone(ctx context.Context, phone string) (string, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil {
+		return "", fmt.Errorf("whatsapp client is not initialized")
+	}
+
+	if err := cli.ConnectContext(ctx); err != nil {
+		return "", fmt.Errorf("connect: %w", err)
+	}
+
+	code, err := cli.PairPhone(ctx, phone, true, whatsmeow.PairClientChrome, "Chrome (Linux)")
+	if err != nil {
+		return "", fmt.Errorf("pair phone: %w", err)
+	}
+	return code, nil
+}
+
 // Reconnect loop helper.
 func (c *Client) ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay time.Duration) error {
 	delay := minDelay


### PR DESCRIPTION
## Problem

`wacli auth` currently only supports QR-code pairing, which requires a terminal that can render a QR image and a phone with a camera pointed at it. This makes `wacli` hard to bootstrap on headless boxes (droplets, CI runners, agent infrastructure) where you only have SSH access.

## Change

Adds a `--phone` flag that uses whatsmeow's `PairPhone` API instead of the QR channel:

```
wacli auth --phone +521234567890
```

The CLI prints an 8-digit code. On the phone, the user opens WhatsApp → Settings → Linked Devices → Link a Device → "Link with phone number instead" and enters the code. The command then polls `IsAuthed()` every 2s for up to 5 minutes and prints success (JSON-aware under ` --json`).

Zero change to the existing QR flow — `wacli auth` with no flag behaves exactly as before.

## Why

I've been running ` wacli` on a remote droplet to back a WhatsApp agent and there was no reasonable way to pair it short of port-forwarding a terminal. This has been in production on my fork for about a week without issues.

## Files

- ` cmd/wacli/auth.go` — new ` --phone` path in the auth command
- ` internal/wa/client.go` — ` Client.PairPhone` method wrapping ` whatsmeow.PairPhone`
- ` internal/app/app.go` — ` PairPhone` added to the ` WAClient` interface
- ` internal/app/fake_wa_test.go` — stub for the new interface method so the app tests keep compiling

## Tests

` go vet ./...`  and ` go test ./...` pass. The new code is a thin wrapper around whatsmeow's own ` PairPhone`, which is already battle-tested upstream.

Made with [Cursor](https://cursor.com)