### PR TITLE
fix: detect FTS5 on existing databases after migration already applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Media: recover panics per download job so one bad payload no longer drains the worker pool. (#179 — thanks @shaun0927)
 - Messages: show display text for replies, reactions, and media in `messages context`. (#183 — thanks @fuleinist)
+- Search: keep FTS5 enabled after reopening existing databases with already-applied migrations. (#185 — thanks @iamhitarth)
 - Send: persist retry-message plaintext so linked devices can decrypt retried messages. (#186 — thanks @SimDamDev)
 - Sync: include event type, stack trace, and recovery count when logging recovered event-handler panics. (#181 — thanks @shaun0927)
 

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -55,5 +55,21 @@ func (d *DB) init() error {
 	_, _ = d.sql.Exec("PRAGMA temp_store=MEMORY;")
 	_, _ = d.sql.Exec("PRAGMA foreign_keys=ON;")
 
-	return d.ensureSchema()
+	if err := d.ensureSchema(); err != nil {
+		return err
+	}
+
+	// Detect FTS5 availability independently of migration state.
+	// The migration sets ftsEnabled only on first run; subsequent
+	// opens skip the migration and leave ftsEnabled as false.
+	if !d.ftsEnabled {
+		if ok, _ := d.tableExists("messages_fts"); ok {
+			var n int
+			if err := d.sql.QueryRow("SELECT 1 FROM messages_fts LIMIT 1").Scan(&n); err == nil {
+				d.ftsEnabled = true
+			}
+		}
+	}
+
+	return nil
 }

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -59,17 +59,24 @@ func (d *DB) init() error {
 		return err
 	}
 
-	// Detect FTS5 availability independently of migration state.
-	// The migration sets ftsEnabled only on first run; subsequent
-	// opens skip the migration and leave ftsEnabled as false.
+	// Detect FTS5 availability independently of migration state. The migration
+	// sets ftsEnabled only on first run; subsequent opens skip the migration.
 	if !d.ftsEnabled {
-		if ok, _ := d.tableExists("messages_fts"); ok {
-			var n int
-			if err := d.sql.QueryRow("SELECT 1 FROM messages_fts LIMIT 1").Scan(&n); err == nil {
-				d.ftsEnabled = true
-			}
-		}
+		d.ftsEnabled = d.detectMessagesFTS()
 	}
 
 	return nil
+}
+
+func (d *DB) detectMessagesFTS() bool {
+	ok, err := d.tableExists("messages_fts")
+	if err != nil || !ok {
+		return false
+	}
+	hasDisplayText, err := d.tableHasColumn("messages_fts", "display_text")
+	if err != nil || !hasDisplayText {
+		return false
+	}
+	var n int
+	return d.sql.QueryRow("SELECT count(*) FROM messages_fts").Scan(&n) == nil
 }

--- a/internal/store/search_fts_test.go
+++ b/internal/store/search_fts_test.go
@@ -3,6 +3,7 @@
 package store
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -39,6 +40,30 @@ func TestSearchMessagesUsesFTSWhenEnabled(t *testing.T) {
 	}
 	if ms[0].Snippet == "" {
 		t.Fatalf("expected snippet for FTS search, got empty")
+	}
+}
+
+func TestExistingEmptyFTSTableDetectedOnReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.db")
+
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if !db.HasFTS() {
+		t.Fatalf("expected initial FTS migration to enable FTS")
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	db, err = Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer db.Close()
+	if !db.HasFTS() {
+		t.Fatalf("expected existing empty FTS table to enable FTS after reopen")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes FTS5 detection on databases where migration 3 (`messages fts`) has already been applied
- `doctor` incorrectly reports `FTS5 false` and `messages search` falls back to slow `LIKE` scanning, even when the `messages_fts` table and triggers are fully functional

## Root cause

`migrateMessagesFTS()` sets `d.ftsEnabled = true` only when migration 3 **first runs**. On subsequent DB opens, `ensureSchema()` sees migration 3 is already applied and skips it — so `ftsEnabled` stays at its zero value (`false`).

## Fix

Add a post-migration probe in `init()` that checks if `messages_fts` exists and is queryable, setting `ftsEnabled = true` independently of migration state.

## Related

Partially addresses #160 — the build-tag issue in release binaries is separate, but this fixes the detection logic so that databases which already have FTS5 tables work correctly even after the build-tag fix is applied.

## Test plan

- [x] Verified on existing database with migration 3 already applied: `doctor` now reports `FTS5 true`
- [x] `messages search` uses FTS5 index (shows `[match]` highlighting instead of `Note: FTS5 not enabled`)
- [x] Clean database still works (migration 3 creates table and sets flag as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)