### PR TITLE
feat: add cross-platform file locking and Windows CI build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Send: persist retry-message plaintext so linked devices can decrypt retried messages. (#186 — thanks @SimDamDev)
 - Sync: start `sync --once` idle timing after the `Connected` event. (#171 — thanks @fuleinist)
 - Sync: include event type, stack trace, and recovery count when logging recovered event-handler panics. (#181 — thanks @shaun0927)
+- Windows: split store locking by platform so the lock package compiles on Windows. (#188 — thanks @dinakars777)
 
 ### Docs
 
@@ -22,6 +23,7 @@
 
 ### Chore
 
+- CI: compile-test the Windows lock package to catch platform regressions. (#188 — thanks @dinakars777)
 - Dependencies: update Go modules including `whatsmeow`, `go-sqlite3`, `x/*`, and related runtime libs.
 
 ## 0.6.0 - 2026-04-14

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -24,7 +23,7 @@ func Acquire(storeDir string) (*Lock, error) {
 		return nil, fmt.Errorf("open lock file: %w", err)
 	}
 
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+	if err := lockFile(f); err != nil {
 		_, _ = f.Seek(0, 0)
 		b, _ := os.ReadFile(path)
 		_ = f.Close()
@@ -47,7 +46,7 @@ func (l *Lock) Release() error {
 	if l == nil || l.f == nil {
 		return nil
 	}
-	_ = syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+	_ = unlockFile(l.f)
 	err := l.f.Close()
 	l.f = nil
 	return err

--- a/internal/lock/lock_unix.go
+++ b/internal/lock/lock_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package lock
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+}
+
+func unlockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/internal/lock/lock_windows.go
+++ b/internal/lock/lock_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package lock
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFile(f *os.File) error {
+	var ol windows.Overlapped
+	return windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		&ol,
+	)
+}
+
+func unlockFile(f *os.File) error {
+	var ol windows.Overlapped
+	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, &ol)
+}

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
     "wacli": "bash -lc 'pnpm -s build >/dev/null && exec ./dist/wacli \"$@\"' _",
     "build": "mkdir -p dist && CGO_CFLAGS=\"${CGO_CFLAGS:+$CGO_CFLAGS }-Wno-error=missing-braces\" go build -tags sqlite_fts5 -o dist/wacli ./cmd/wacli",
     "start": "pnpm -s build && ./dist/wacli",
-    "test": "pnpm -s test:go && pnpm -s test:fts",
+    "test": "pnpm -s test:go && pnpm -s test:fts && pnpm -s test:windows-lock",
     "test:go": "go test ./...",
     "test:fts": "go test -tags sqlite_fts5 ./...",
+    "test:windows-lock": "bash -lc 'tmp=\"${TMPDIR:-/tmp}/wacli-lock-windows.test.exe\"; GOOS=windows GOARCH=amd64 go test -c ./internal/lock -o \"$tmp\"; rm -f \"$tmp\"'",
     "lint": "go vet ./...",
     "format": "gofmt -w .",
     "format:check": "bash -lc 'out=$(gofmt -l .); if [ -n \"$out\" ]; then echo \"$out\"; exit 1; fi'"


### PR DESCRIPTION
## Summary
- Split file locking into Unix (`syscall.Flock`) and Windows (`LockFileEx`/`UnlockFileEx`) implementations
- Fixes Windows compilation by abstracting Unix-only `syscall.Flock` behind a platform-specific abstraction
- Add `build-windows.yml` workflow for on-demand Windows builds

## Changes

| File | Change |
|------|--------|
| `internal/lock/lock.go` | Remove `syscall` import, use abstracted `lockFile()`/`unlockFile()` |
| `internal/lock/lock_unix.go` | New — `syscall.Flock` behind `*os.File` API |
| `internal/lock/lock_windows.go` | New — `LockFileEx`/`UnlockFileEx` via `golang.org/x/sys/windows` |
| `.github/workflows/build-windows.yml` | New — Windows CI workflow (workflow_dispatch) |

## Why
- Closes #36 (wacli fails to compile on Windows due to `syscall.Flock`)
- Enables single-instance locking enforcement on Windows

## Testing
- `go vet ./internal/lock/` passes