### PR TITLE
ci: add Dependabot for Go modules and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
 Adds weekly grouped Dependabot updates for `gomod` and `github-actions`.

  This eliminates the recurring manual cycle where an old client version is deprecated, users start hitting 405 errors (#106, #189), and someone has to manually spot the whatsmeow fix and ship a release. Dependabot will open a PR within a week of any whatsmeow update — dinakars777 reviews, CI runs the gate, one-click merge.