### PR TITLE
fix: add warning log for dropped EncReactionMessage

### DIFF
--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -58,7 +58,10 @@ func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, message
 func (a *App) handleLiveSyncMessage(ctx context.Context, opts SyncOptions, v *events.Message, messagesStored *atomic.Int64, enqueueMedia func(string, string)) {
 	pm := wa.ParseLiveMessage(v)
 	if pm.ReactionToID != "" && pm.ReactionEmoji == "" && v.Message != nil && v.Message.GetEncReactionMessage() != nil {
-		if reaction, err := a.wa.DecryptReaction(ctx, v); err == nil && reaction != nil {
+		reaction, err := a.wa.DecryptReaction(ctx, v)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "\rwarning: failed to decrypt reaction message %s: %v\n", pm.ID, err)
+		} else if reaction != nil {
 			pm.ReactionEmoji = reaction.GetText()
 			if pm.ReactionToID == "" {
 				if key := reaction.GetKey(); key != nil {


### PR DESCRIPTION
Resolves #192. 

As identified by @matrixise and @fuleinist, if a sync is interrupted, incoming `EncReactionMessage` updates can fail to decrypt on subsequent syncs and get dropped silently. This PR adds a clear warning log to stderr when decryption fails, eliminating the silent failure and making it obvious to the user that an event was missed.