### PR TITLE
fix: resolve LID JIDs during live sync

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -26,6 +26,7 @@ type WAClient interface {
 	ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay time.Duration) error
 
 	ResolveChatName(ctx context.Context, chat types.JID, pushName string) string
+	ResolveLIDToPN(ctx context.Context, jid types.JID) types.JID
 	GetContact(ctx context.Context, jid types.JID) (types.ContactInfo, error)
 	GetAllContacts(ctx context.Context) (map[types.JID]types.ContactInfo, error)
 

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -125,6 +125,10 @@ func (f *fakeWA) ResolveChatName(ctx context.Context, chat types.JID, pushName s
 	return chat.String()
 }
 
+func (f *fakeWA) ResolveLIDToPN(ctx context.Context, jid types.JID) types.JID {
+	return jid
+}
+
 func (f *fakeWA) GetContact(ctx context.Context, jid types.JID) (types.ContactInfo, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -114,6 +114,10 @@ func chatKind(chat types.JID) string {
 }
 
 func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error {
+	// Resolve LID chat and sender JIDs to Phone Number JIDs so messages are stored
+	// under the canonical PN-based chat instead of a separate LID chat.
+	pm.Chat = a.wa.ResolveLIDToPN(ctx, pm.Chat)
+
 	chatJID := canonicalJIDString(pm.Chat)
 	chatName := a.wa.ResolveChatName(ctx, pm.Chat, pm.PushName)
 	if err := a.db.UpsertChat(chatJID, chatKind(pm.Chat), chatName, pm.Timestamp); err != nil {
@@ -144,6 +148,7 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 	senderJID := pm.SenderJID
 	if pm.SenderJID != "" {
 		if jid, err := types.ParseJID(pm.SenderJID); err == nil {
+			jid = a.wa.ResolveLIDToPN(ctx, jid)
 			contactJID := canonicalJID(jid)
 			senderJID = contactJID.String()
 			if info, err := a.wa.GetContact(ctx, contactJID); err == nil {

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -344,6 +344,25 @@ func (c *Client) Logout(ctx context.Context) error {
 	return cli.Logout(ctx)
 }
 
+// ResolveLIDToPN resolves a LID (Linked Identity) JID to a Phone Number JID.
+// Returns the original JID unchanged if it's not a LID or if resolution fails.
+func (c *Client) ResolveLIDToPN(ctx context.Context, jid types.JID) types.JID {
+	if jid.Server != types.HiddenUserServer {
+		return jid
+	}
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || cli.Store == nil || cli.Store.LIDs == nil {
+		return jid
+	}
+	pn, err := cli.Store.LIDs.GetPNForLID(ctx, jid.ToNonAD())
+	if err != nil || pn.IsEmpty() {
+		return jid
+	}
+	return pn
+}
+
 // Reconnect loop helper.
 func (c *Client) ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay time.Duration) error {
 	delay := minDelay


### PR DESCRIPTION
Resolves an issue where 1:1 direct chat messages received from a linked device (WhatsApp Web/Desktop) during Live Sync were split into a new conversation thread under the `@lid` JID instead of the canonical `@s.whatsapp.net` JID.

This PR mirrors the History Sync behavior by querying the local contact store during `storeParsedMessage` to resolve `@lid` JIDs back to their underlying phone numbers before saving to SQLite.

Fixes #196

*Targeting v0.8.0 to avoid schema/migration risks right before the 0.7.0 release.*