### PR TITLE
feat(send): add --ptt flag to send audio as voice notes

### DIFF
--- a/cmd/wacli/send_file.go
+++ b/cmd/wacli/send_file.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steipete/wacli/internal/app"
 	"github.com/steipete/wacli/internal/store"
 	"github.com/steipete/wacli/internal/wa"
+	"go.mau.fi/whatsmeow"
 	waProto "go.mau.fi/whatsmeow/binary/proto"
 	"go.mau.fi/whatsmeow/types"
 	"google.golang.org/protobuf/proto"
@@ -23,7 +24,7 @@ const maxSendFileSize = 100 * 1024 * 1024
 func sendFile(ctx context.Context, a interface {
 	WA() app.WAClient
 	DB() *store.DB
-}, to types.JID, filePath, filename, caption, mimeOverride, replyTo, replyToSender string) (string, map[string]string, error) {
+}, to types.JID, filePath, filename, caption, mimeOverride string, ptt bool, replyTo, replyToSender string) (string, map[string]string, error) {
 	data, err := readSendFileData(filePath)
 	if err != nil {
 		return "", nil, err
@@ -54,61 +55,13 @@ func sendFile(ctx context.Context, a interface {
 		return "", nil, err
 	}
 
-	now := time.Now().UTC()
-	msg := &waProto.Message{}
 	replyContext, err := buildReplyContextInfo(a.DB(), to, replyTo, replyToSender)
 	if err != nil {
 		return "", nil, err
 	}
 
-	switch mediaType {
-	case "image":
-		msg.ImageMessage = &waProto.ImageMessage{
-			URL:           proto.String(up.URL),
-			DirectPath:    proto.String(up.DirectPath),
-			MediaKey:      up.MediaKey,
-			FileEncSHA256: up.FileEncSHA256,
-			FileSHA256:    up.FileSHA256,
-			FileLength:    proto.Uint64(up.FileLength),
-			Mimetype:      proto.String(mimeType),
-			Caption:       proto.String(caption),
-		}
-	case "video":
-		msg.VideoMessage = &waProto.VideoMessage{
-			URL:           proto.String(up.URL),
-			DirectPath:    proto.String(up.DirectPath),
-			MediaKey:      up.MediaKey,
-			FileEncSHA256: up.FileEncSHA256,
-			FileSHA256:    up.FileSHA256,
-			FileLength:    proto.Uint64(up.FileLength),
-			Mimetype:      proto.String(mimeType),
-			Caption:       proto.String(caption),
-		}
-	case "audio":
-		msg.AudioMessage = &waProto.AudioMessage{
-			URL:           proto.String(up.URL),
-			DirectPath:    proto.String(up.DirectPath),
-			MediaKey:      up.MediaKey,
-			FileEncSHA256: up.FileEncSHA256,
-			FileSHA256:    up.FileSHA256,
-			FileLength:    proto.Uint64(up.FileLength),
-			Mimetype:      proto.String(mimeType),
-			PTT:           proto.Bool(false),
-		}
-	default:
-		msg.DocumentMessage = &waProto.DocumentMessage{
-			URL:           proto.String(up.URL),
-			DirectPath:    proto.String(up.DirectPath),
-			MediaKey:      up.MediaKey,
-			FileEncSHA256: up.FileEncSHA256,
-			FileSHA256:    up.FileSHA256,
-			FileLength:    proto.Uint64(up.FileLength),
-			Mimetype:      proto.String(mimeType),
-			FileName:      proto.String(name),
-			Caption:       proto.String(caption),
-			Title:         proto.String(name),
-		}
-	}
+	now := time.Now().UTC()
+	msg := buildSendFileMessage(mediaType, up, mimeType, name, caption, ptt)
 	attachSendFileReplyContext(msg, replyContext)
 
 	id, err := a.WA().SendProtoMessage(ctx, to, msg)
@@ -144,6 +97,60 @@ func sendFile(ctx context.Context, a interface {
 		"mime_type": mimeType,
 		"media":     mediaType,
 	}, nil
+}
+
+func buildSendFileMessage(mediaType string, up whatsmeow.UploadResponse, mimeType, name, caption string, ptt bool) *waProto.Message {
+	msg := &waProto.Message{}
+
+	switch mediaType {
+	case "image":
+		msg.ImageMessage = &waProto.ImageMessage{
+			URL:           proto.String(up.URL),
+			DirectPath:    proto.String(up.DirectPath),
+			MediaKey:      up.MediaKey,
+			FileEncSHA256: up.FileEncSHA256,
+			FileSHA256:    up.FileSHA256,
+			FileLength:    proto.Uint64(up.FileLength),
+			Mimetype:      proto.String(mimeType),
+			Caption:       proto.String(caption),
+		}
+	case "video":
+		msg.VideoMessage = &waProto.VideoMessage{
+			URL:           proto.String(up.URL),
+			DirectPath:    proto.String(up.DirectPath),
+			MediaKey:      up.MediaKey,
+			FileEncSHA256: up.FileEncSHA256,
+			FileSHA256:    up.FileSHA256,
+			FileLength:    proto.Uint64(up.FileLength),
+			Mimetype:      proto.String(mimeType),
+			Caption:       proto.String(caption),
+		}
+	case "audio":
+		msg.AudioMessage = &waProto.AudioMessage{
+			URL:           proto.String(up.URL),
+			DirectPath:    proto.String(up.DirectPath),
+			MediaKey:      up.MediaKey,
+			FileEncSHA256: up.FileEncSHA256,
+			FileSHA256:    up.FileSHA256,
+			FileLength:    proto.Uint64(up.FileLength),
+			Mimetype:      proto.String(mimeType),
+			PTT:           proto.Bool(ptt),
+		}
+	default:
+		msg.DocumentMessage = &waProto.DocumentMessage{
+			URL:           proto.String(up.URL),
+			DirectPath:    proto.String(up.DirectPath),
+			MediaKey:      up.MediaKey,
+			FileEncSHA256: up.FileEncSHA256,
+			FileSHA256:    up.FileSHA256,
+			FileLength:    proto.Uint64(up.FileLength),
+			Mimetype:      proto.String(mimeType),
+			FileName:      proto.String(name),
+			Caption:       proto.String(caption),
+			Title:         proto.String(name),
+		}
+	}
+	return msg
 }
 
 func readSendFileData(filePath string) ([]byte, error) {

--- a/cmd/wacli/send_file_cmd.go
+++ b/cmd/wacli/send_file_cmd.go
@@ -17,6 +17,7 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 	var filename string
 	var caption string
 	var mimeOverride string
+	var ptt bool
 	var replyTo string
 	var replyToSender string
 
@@ -60,7 +61,7 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 				meta map[string]string
 			}
 			res, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (sendFileResult, error) {
-				msgID, meta, err := sendFile(ctx, a, toJID, filePath, filename, caption, mimeOverride, replyTo, replyToSender)
+				msgID, meta, err := sendFile(ctx, a, toJID, filePath, filename, caption, mimeOverride, ptt, replyTo, replyToSender)
 				if err != nil {
 					return sendFileResult{}, err
 				}
@@ -90,6 +91,7 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&filename, "filename", "", "display name for the file (defaults to basename of --file)")
 	cmd.Flags().StringVar(&caption, "caption", "", "caption (images/videos/documents)")
 	cmd.Flags().StringVar(&mimeOverride, "mime", "", "override detected mime type")
+	cmd.Flags().BoolVar(&ptt, "ptt", false, "send audio as a WhatsApp voice note")
 	cmd.Flags().StringVar(&replyTo, "reply-to", "", "message ID to quote/reply to")
 	cmd.Flags().StringVar(&replyToSender, "reply-to-sender", "", "sender JID of the quoted message (required for unsynced group replies)")
 	return cmd

--- a/cmd/wacli/send_file_test.go
+++ b/cmd/wacli/send_file_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"go.mau.fi/whatsmeow"
 	waProto "go.mau.fi/whatsmeow/binary/proto"
 	"google.golang.org/protobuf/proto"
 )
@@ -51,6 +52,50 @@ func TestSendFileCommandExposesReplyFlags(t *testing.T) {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Fatalf("missing --%s flag", name)
 		}
+	}
+}
+
+func TestSendFileCommandExposesPTTFlag(t *testing.T) {
+	cmd := newSendFileCmd(&rootFlags{})
+	flag := cmd.Flags().Lookup("ptt")
+	if flag == nil {
+		t.Fatalf("missing --ptt flag")
+	}
+	if flag.DefValue != "false" {
+		t.Fatalf("--ptt default = %q, want false", flag.DefValue)
+	}
+}
+
+func TestBuildSendFileMessageSetsAudioPTT(t *testing.T) {
+	up := whatsmeow.UploadResponse{
+		URL:           "https://example.invalid/audio",
+		DirectPath:    "/audio",
+		MediaKey:      []byte("media-key"),
+		FileEncSHA256: []byte("enc-sha"),
+		FileSHA256:    []byte("sha"),
+		FileLength:    123,
+	}
+
+	for _, tc := range []struct {
+		name string
+		ptt  bool
+	}{
+		{name: "regular audio", ptt: false},
+		{name: "voice note", ptt: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := buildSendFileMessage("audio", up, "audio/ogg; codecs=opus", "", "", tc.ptt)
+			audio := msg.GetAudioMessage()
+			if audio == nil {
+				t.Fatalf("expected audio message")
+			}
+			if audio.PTT == nil {
+				t.Fatalf("audio PTT field is nil")
+			}
+			if audio.GetPTT() != tc.ptt {
+				t.Fatalf("audio PTT = %v, want %v", audio.GetPTT(), tc.ptt)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Resolves #40.

Currently `wacli send file` hardcodes `PTT: proto.Bool(false)` for audio files. This adds a new `--ptt` flag (default: false) that toggles this behavior. 

When sending an audio file (e.g. an opus/ogg file) with `--ptt=true`, the receiver sees it as a native WhatsApp Voice Note (push-to-talk) complete with waveform visualization (handled natively by the client/receiver). 

### What changed
- Added `--ptt` boolean flag to `send file`.
- Plumbed the flag through to the `waProto.AudioMessage` construction.
- Added tests verifying the flag binding and the protobuf construction logic.