### PR TITLE
feat(messages): add JSON export date filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Diagnostics: show linked JID and local store counts in `auth status` and `doctor`. (#149 — thanks @draix)
 - Messages: add `messages list --sender`, `--from-me`, `--from-them`, and `--asc` filters. (#153 — thanks @draix)
 - Messages: add `messages search --has-media`, `--type text`, case-insensitive media types, and validation for contradictory filters. (#128 — thanks @ImLukeF and @Mansehej)
+- Messages: add JSON export with `messages export --after` and `--before` filters.
 - Messages: extract searchable/display text from WhatsApp Business templates, buttons, interactive messages, and list replies. (#79 — thanks @terry-li-hm)
 - Auth: add `auth --qr-format text` to print the raw WhatsApp QR payload for external renderers. (#22 — thanks @teren-papercutlabs)
 - Auth: add `auth --phone` for WhatsApp's phone-number pairing flow on headless systems. (#148, #184 — thanks @giovanninibarbosa and @KillerSnails)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ pnpm wacli messages list --chat 1234567890@s.whatsapp.net --asc
 # Show context around a message
 pnpm wacli messages context --chat 1234567890@s.whatsapp.net --id <message-id>
 
+# Export messages to JSON with a time window
+pnpm wacli messages export --chat 1234567890@s.whatsapp.net --after 2024-01-01 --before 2024-02-01 --output messages.json
+
 # Backfill older messages for a chat (best-effort; requires your primary device online)
 pnpm wacli history backfill --chat 1234567890@s.whatsapp.net --requests 10 --count 50
 
@@ -158,6 +161,7 @@ Full command docs live under [docs/overview.md](docs/overview.md). Quick referen
 - `wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--max-messages N] [--max-db-size SIZE] [--download-media] [--refresh-contacts] [--refresh-groups]`
 - `wacli messages list [--chat JID] [--sender JID] [--from-me|--from-them] [--asc] [--limit N] [--after DATE] [--before DATE] [--forwarded]`
 - `wacli messages search <query> [--chat JID] [--from JID] [--has-media] [--type text|image|video|audio|document] [--forwarded]`
+- `wacli messages export [--chat JID] [--limit N] [--after DATE] [--before DATE] [--output PATH]`
 - `wacli messages show --chat JID --id MSG_ID`
 - `wacli messages context --chat JID --id MSG_ID [--before N] [--after N]`
 - `wacli send text --to RECIPIENT --message TEXT [--pick N] [--no-preview] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]`

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -27,6 +27,7 @@ func newMessagesCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newMessagesSearchCmd(flags))
 	cmd.AddCommand(newMessagesShowCmd(flags))
 	cmd.AddCommand(newMessagesContextCmd(flags))
+	cmd.AddCommand(newMessagesExportCmd(flags))
 	return cmd
 }
 
@@ -433,6 +434,85 @@ func newMessagesContextCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&id, "id", "", "message ID")
 	cmd.Flags().IntVar(&before, "before", 5, "messages before")
 	cmd.Flags().IntVar(&after, "after", 5, "messages after")
+	return cmd
+}
+
+func newMessagesExportCmd(flags *rootFlags) *cobra.Command {
+	var chat string
+	var limit int
+	var afterStr string
+	var beforeStr string
+	var output string
+
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export messages as JSON",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, false, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			var after *time.Time
+			var before *time.Time
+			if afterStr != "" {
+				t, err := parseTime(afterStr)
+				if err != nil {
+					return err
+				}
+				after = &t
+			}
+			if beforeStr != "" {
+				t, err := parseTime(beforeStr)
+				if err != nil {
+					return err
+				}
+				before = &t
+			}
+
+			chatJIDs, err := messageChatJIDFilter(ctx, a, chat)
+			if err != nil {
+				return err
+			}
+
+			msgs, err := a.DB().ListMessages(store.ListMessagesParams{
+				ChatJIDs: chatJIDs,
+				Limit:    limit,
+				After:    after,
+				Before:   before,
+				Asc:      true,
+			})
+			if err != nil {
+				return err
+			}
+			msgs = resolveMessageSenderNames(ctx, a, msgs)
+
+			dst := os.Stdout
+			if output != "" {
+				f, err := os.Create(output)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				dst = f
+			}
+
+			return out.WriteJSON(dst, map[string]any{
+				"messages": msgs,
+				"fts":      a.DB().HasFTS(),
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&chat, "chat", "", "filter by chat JID")
+	cmd.Flags().IntVar(&limit, "limit", 1000, "max number of messages to export")
+	cmd.Flags().StringVar(&afterStr, "after", "", "only messages after time (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&beforeStr, "before", "", "only messages before time (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&output, "output", "", "write JSON export to file instead of stdout")
 	return cmd
 }
 

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -493,7 +493,7 @@ func newMessagesExportCmd(flags *rootFlags) *cobra.Command {
 
 			dst := os.Stdout
 			if output != "" {
-				f, err := os.Create(output)
+				f, err := os.OpenFile(output, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 				if err != nil {
 					return err
 				}

--- a/cmd/wacli/messages_test.go
+++ b/cmd/wacli/messages_test.go
@@ -228,6 +228,13 @@ func TestMessagesExportCommandAppliesDateFilters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
+	info, err := os.Stat(output)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("output mode = %04o, want 0600", got)
+	}
 	var got struct {
 		Success bool `json:"success"`
 		Data    struct {

--- a/cmd/wacli/messages_test.go
+++ b/cmd/wacli/messages_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -175,6 +177,74 @@ func TestMessagesListCommandExposesForwardedFilter(t *testing.T) {
 	}
 }
 
+func TestMessagesExportCommandExposesDateFilters(t *testing.T) {
+	cmd := newMessagesExportCmd(&rootFlags{})
+	for _, name := range []string{"after", "before", "output"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Fatalf("expected --%s flag", name)
+		}
+	}
+}
+
+func TestMessagesExportCommandAppliesDateFilters(t *testing.T) {
+	storeDir := t.TempDir()
+	db, err := store.Open(filepath.Join(storeDir, "wacli.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	chat := "chat@s.whatsapp.net"
+	base := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+	if err := db.UpsertChat(chat, "dm", "Alice", base); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	for _, row := range []store.UpsertMessageParams{
+		{ChatJID: chat, MsgID: "before", SenderJID: chat, Timestamp: base, Text: "before"},
+		{ChatJID: chat, MsgID: "inside-1", SenderJID: chat, Timestamp: base.Add(time.Second), Text: "inside 1"},
+		{ChatJID: chat, MsgID: "inside-2", SenderJID: chat, Timestamp: base.Add(2 * time.Second), Text: "inside 2"},
+		{ChatJID: chat, MsgID: "after", SenderJID: chat, Timestamp: base.Add(3 * time.Second), Text: "after"},
+	} {
+		if err := db.UpsertMessage(row); err != nil {
+			t.Fatalf("UpsertMessage %s: %v", row.MsgID, err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	output := filepath.Join(storeDir, "export.json")
+	cmd := newMessagesExportCmd(&rootFlags{storeDir: storeDir, timeout: time.Minute})
+	cmd.SetArgs([]string{
+		"--chat", chat,
+		"--after", base.Format(time.RFC3339),
+		"--before", base.Add(3 * time.Second).Format(time.RFC3339),
+		"--output", output,
+		"--limit", "10",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("messages export: %v", err)
+	}
+
+	raw, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var got struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Messages []store.Message `json:"messages"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("Unmarshal export: %v\n%s", err, string(raw))
+	}
+	if !got.Success {
+		t.Fatalf("success = false")
+	}
+	if gotIDs := messageIDs(got.Data.Messages); gotIDs != "inside-1,inside-2" {
+		t.Fatalf("exported ids = %s", gotIDs)
+	}
+}
+
 func TestWriteMessageShowIncludesForwardedMetadata(t *testing.T) {
 	msg := store.Message{
 		ChatJID:         "chat@s.whatsapp.net",
@@ -289,4 +359,12 @@ func mustParseJID(t *testing.T, s string) types.JID {
 		t.Fatalf("ParseJID(%q): %v", s, err)
 	}
 	return jid
+}
+
+func messageIDs(msgs []store.Message) string {
+	ids := make([]string, 0, len(msgs))
+	for _, msg := range msgs {
+		ids = append(ids, msg.MsgID)
+	}
+	return strings.Join(ids, ",")
 }

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -1,6 +1,6 @@
 # messages
 
-Read when: listing, searching, showing, or inspecting local message context.
+Read when: listing, searching, exporting, showing, or inspecting local message context.
 
 `wacli messages` reads from the local store. It does not connect to WhatsApp unless a display path needs session-backed LID mapping.
 
@@ -9,6 +9,7 @@ Read when: listing, searching, showing, or inspecting local message context.
 ```bash
 wacli messages list [--chat JID] [--sender JID] [--from-me|--from-them] [--asc] [--limit N] [--after DATE] [--before DATE] [--forwarded]
 wacli messages search <query> [--chat JID] [--from JID] [--has-media] [--type text|image|video|audio|document] [--forwarded] [--limit N] [--after DATE] [--before DATE]
+wacli messages export [--chat JID] [--limit N] [--after DATE] [--before DATE] [--output PATH]
 wacli messages show --chat JID --id MSG_ID
 wacli messages context --chat JID --id MSG_ID [--before N] [--after N]
 ```
@@ -20,6 +21,13 @@ wacli messages context --chat JID --id MSG_ID [--before N] [--after N]
 - `--type` accepts `text`, `image`, `video`, `audio`, or `document`.
 - Time filters accept RFC3339 or `YYYY-MM-DD`.
 
+## Export
+
+- `messages export` writes a JSON export envelope with messages ordered oldest first.
+- Use `--chat` to export one chat, or omit it to export recent messages across chats.
+- Use `--after` and `--before` to bound the exported time window.
+- Use `--output` to write the JSON export to a file.
+
 ## LID mapping
 
 When a phone-number chat JID maps to a stored `@lid` row, list/search/show/context include the mapped rows so historical LID splits do not hide messages.
@@ -30,6 +38,7 @@ When a phone-number chat JID maps to a stored `@lid` row, list/search/show/conte
 wacli messages list --chat 1234567890@s.whatsapp.net --asc
 wacli messages list --from-me --limit 20
 wacli messages search "invoice" --has-media --type document
+wacli messages export --chat 1234567890@s.whatsapp.net --after 2024-01-01 --before 2024-02-01 --output messages.json
 wacli messages show --chat 1234567890@s.whatsapp.net --id ABC123
 wacli messages context --chat 1234567890@s.whatsapp.net --id ABC123 --before 3 --after 3
 ```

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -173,6 +173,7 @@ WhatsApp Web history is best-effort. If you want to try fetching *older* message
 
 - `wacli messages list [--chat JID] [--sender JID] [--from-me|--from-them] [--asc] [--limit N] [--before TS] [--after TS]`
 - `wacli messages search <query> [--chat JID] [--from JID] [--limit N] [--before TS] [--after TS] [--type text|image|video|audio|document]`
+- `wacli messages export [--chat JID] [--limit N] [--before TS] [--after TS] [--output PATH]`
 - `wacli messages show --chat JID --id MSG_ID`
 - `wacli messages context --chat JID --id MSG_ID [--before N] [--after N]`
 


### PR DESCRIPTION
## Summary

- add a focused `messages export` command that writes the existing JSON envelope
- support `--after` and `--before` using the existing RFC3339 / `YYYY-MM-DD` parser
- support optional `--chat`, `--limit`, and `--output`, with exports ordered oldest first
- document the new command and add regression coverage for date-filtered export output

## Scope

This is a clean, narrow port of the export-date-filter slice from #166. It intentionally leaves Markdown/Obsidian formatting, webhook dispatch, and retry/backoff behavior for separate PRs.

## Tests

- `go test ./cmd/wacli -run 'TestMessagesExport|TestListMessages'`
- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `git diff --check`