### PR TITLE
feat(sync): add webhook signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Auth: add `auth --phone` for WhatsApp's phone-number pairing flow on headless systems. (#148, #184 — thanks @giovanninibarbosa and @KillerSnails)
 - Auth: auto-detect a readable linked-device label and default linked-device platform to desktop. (#100 — thanks @pmatheus)
 - Profile: add `profile set-picture` to update the authenticated account profile picture from JPEG or PNG input. (#198 — thanks @gado-ships-it)
+- Sync: add signed live-message webhooks with `--webhook` and `--webhook-secret`. (#203 — thanks @dinakars777 and @Melostack)
 - Send: add `send react` to add or clear reactions, with group sender validation. (#151 — thanks @draix)
 - Send: add `send file --reply-to` for quoted media/document replies. (#68 — thanks @vlassance)
 - Send: add repeatable `send text --mention` for WhatsApp user mentions in group messages. (#16 — thanks @nicozefrench and @sheepworrier)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ pnpm wacli auth
 
 # 2) Keep syncing (never shows QR; requires prior auth)
 pnpm wacli sync --follow
+# Optionally POST live messages to a signed webhook
+pnpm wacli sync --follow --webhook https://example.com/wacli --webhook-secret "$WACLI_WEBHOOK_SECRET"
 
 # Diagnostics
 pnpm wacli doctor
@@ -169,7 +171,7 @@ Full command docs live under [docs/overview.md](docs/overview.md). Quick referen
 - `wacli auth [--follow] [--idle-exit 30s] [--download-media] [--qr-format terminal|text] [--phone PHONE]`
 - `wacli auth status`
 - `wacli auth logout`
-- `wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--max-messages N] [--max-db-size SIZE] [--download-media] [--refresh-contacts] [--refresh-groups]`
+- `wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--max-messages N] [--max-db-size SIZE] [--download-media] [--refresh-contacts] [--refresh-groups] [--webhook URL] [--webhook-secret SECRET]`
 - `wacli messages list [--chat JID] [--sender JID] [--from-me|--from-them] [--asc] [--limit N] [--after DATE] [--before DATE] [--forwarded] [--starred]`
 - `wacli messages search <query> [--chat JID] [--from JID] [--has-media] [--type text|image|video|audio|document] [--forwarded] [--starred]`
 - `wacli messages starred [--chat JID] [--limit N] [--after DATE] [--before DATE] [--asc]`

--- a/cmd/wacli/sync.go
+++ b/cmd/wacli/sync.go
@@ -19,6 +19,8 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var downloadMedia bool
 	var refreshContacts bool
 	var refreshGroups bool
+	var webhookURL string
+	var webhookSecret string
 	var storage syncStorageLimitFlags
 
 	cmd := &cobra.Command{
@@ -31,6 +33,9 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 			maxMessages, maxDBSize, err := resolveSyncStorageLimits(storage)
 			if err != nil {
 				return err
+			}
+			if webhookSecret != "" && webhookURL == "" {
+				return fmt.Errorf("--webhook-secret requires --webhook")
 			}
 			ctx, stop := signalContextWithEvents(out.NewEventWriter(os.Stderr, flags.events))
 			defer stop()
@@ -84,6 +89,8 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 				MaxMessages:     maxMessages,
 				MaxDBSizeBytes:  maxDBSize,
 				WarnNoLimits:    true,
+				WebhookURL:      webhookURL,
+				WebhookSecret:   webhookSecret,
 			})
 			if err != nil {
 				return err
@@ -107,6 +114,8 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().BoolVar(&downloadMedia, "download-media", false, "download media in the background during sync")
 	cmd.Flags().BoolVar(&refreshContacts, "refresh-contacts", false, "refresh contacts from session store into local DB")
 	cmd.Flags().BoolVar(&refreshGroups, "refresh-groups", false, "refresh joined groups (live) into local DB")
+	cmd.Flags().StringVar(&webhookURL, "webhook", "", "URL to POST live message JSON")
+	cmd.Flags().StringVar(&webhookSecret, "webhook-secret", "", "HMAC-SHA256 secret for X-Wacli-Signature header")
 	cmd.Flags().Int64Var(&storage.maxMessages, "max-messages", 0, "maximum total messages to keep in the local DB before sync stops (0 = unlimited, or WACLI_SYNC_MAX_MESSAGES)")
 	cmd.Flags().StringVar(&storage.maxDBSize, "max-db-size", "", "maximum wacli.db disk usage before sync stops, e.g. 500MB or 2GB (default: WACLI_SYNC_MAX_DB_SIZE or unlimited)")
 	return cmd

--- a/cmd/wacli/sync_test.go
+++ b/cmd/wacli/sync_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSyncCommandExposesWebhookFlags(t *testing.T) {
+	cmd := newSyncCmd(&rootFlags{})
+	for _, name := range []string{"webhook", "webhook-secret"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Fatalf("missing --%s flag", name)
+		}
+	}
+}
+
+func TestSyncCommandRequiresWebhookForSecret(t *testing.T) {
+	cmd := newSyncCmd(&rootFlags{})
+	cmd.SetArgs([]string{"--webhook-secret", "secret"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--webhook-secret requires --webhook") {
+		t.Fatalf("expected webhook-secret validation error, got %v", err)
+	}
+}

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -154,12 +154,15 @@ Global flags:
 
 ### Sync
 
-- `wacli sync [--once] [--follow] [--download-media]`
+- `wacli sync [--once] [--follow] [--download-media] [--webhook URL] [--webhook-secret SECRET]`
 
 Notes:
 
 - `sync` errors if not authenticated (never prints QR).
 - `--download-media` runs a bounded/concurrent media downloader for messages that contain downloadable media metadata.
+- `--webhook` posts live message JSON after successful local storage on a bounded background worker.
+- `--webhook-secret` adds an HMAC-SHA256 `X-Wacli-Signature` header and requires `--webhook`.
+- Webhook failures and full-queue drops emit warnings but do not fail sync.
 
 ### History backfill (best-effort)
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -7,7 +7,7 @@ Read when: running continuous capture, one-shot sync, contact/group refresh, or 
 ## Command
 
 ```bash
-wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--max-messages N] [--max-db-size SIZE] [--download-media] [--refresh-contacts] [--refresh-groups] [--events]
+wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--max-messages N] [--max-db-size SIZE] [--download-media] [--refresh-contacts] [--refresh-groups] [--events] [--webhook URL] [--webhook-secret SECRET]
 ```
 
 ## Modes
@@ -21,6 +21,9 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--max-mes
 - `--download-media` runs a bounded media downloader for sync events.
 - `--refresh-contacts` imports contacts from the session store.
 - `--refresh-groups` fetches joined groups live and updates the local DB.
+- `--webhook URL` posts successfully stored live message events as JSON on a bounded background worker.
+- `--webhook-secret SECRET` signs webhook payloads with `X-Wacli-Signature: sha256=<hmac>`.
+- Webhook delivery is best-effort: failures and full-queue drops are logged as warnings and do not stop sync. Retries/backoff are intentionally out of scope for this flag.
 - If neither storage cap is configured, sync prints one warning because WhatsApp history can grow the local database substantially.
 - `WACLI_SYNC_MAX_MESSAGES` and `WACLI_SYNC_MAX_DB_SIZE` apply the same caps to `auth` bootstrap sync and `sync`.
 - While `sync --follow` is running, `send text`, `send file`, `send sticker`, `send voice`, and `send react` commands for the same store are delegated to the running sync process so they do not fail on the store lock.
@@ -36,4 +39,5 @@ wacli sync --follow --max-messages 250000 --max-db-size 2GB
 wacli sync --once --refresh-contacts --refresh-groups
 wacli sync --follow --download-media
 wacli sync --once --events 2>events.ndjson
+wacli sync --follow --webhook https://example.com/wacli --webhook-secret "$WACLI_WEBHOOK_SECRET"
 ```

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -40,6 +40,8 @@ type SyncOptions struct {
 	MaxMessages     int64         // 0 = unlimited
 	MaxDBSizeBytes  int64         // 0 = unlimited
 	WarnNoLimits    bool
+	WebhookURL      string
+	WebhookSecret   string
 	Verbosity       int // future
 }
 
@@ -87,9 +89,6 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 		enqueueMedia = newMediaEnqueuer(syncCtx, mediaJobs)
 	}
 
-	handlerID := a.addSyncEventHandler(syncCtx, opts, &messagesStored, &lastEvent, disconnected, enqueueMedia, limits)
-	defer a.wa.RemoveEventHandler(handlerID)
-
 	if opts.DownloadMedia {
 		var err error
 		stopMedia, err = a.runMediaWorkers(syncCtx, mediaJobs, 4)
@@ -98,6 +97,19 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 		}
 		defer stopMedia()
 	}
+
+	var stopWebhook func()
+	var webhookJobs chan wa.ParsedMessage
+	enqueueWebhook := func(wa.ParsedMessage) {}
+	if syncWebhookEnabled(opts) {
+		webhookJobs = make(chan wa.ParsedMessage, 512)
+		enqueueWebhook = a.newSyncWebhookEnqueuer(syncCtx, webhookJobs)
+		stopWebhook = a.runSyncWebhookWorker(syncCtx, opts, webhookJobs)
+		defer stopWebhook()
+	}
+
+	handlerID := a.addSyncEventHandler(syncCtx, opts, &messagesStored, &lastEvent, disconnected, enqueueMedia, enqueueWebhook, limits)
+	defer a.wa.RemoveEventHandler(handlerID)
 
 	if err := a.connectForSync(syncCtx, opts); err != nil {
 		return SyncResult{}, err

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -30,7 +30,7 @@ func newMediaEnqueuer(ctx context.Context, jobs chan<- mediaJob) func(chatJID, m
 	}
 }
 
-func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, messagesStored, lastEvent *atomic.Int64, disconnected chan<- struct{}, enqueueMedia func(string, string), limits *syncStorageLimits) uint32 {
+func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, messagesStored, lastEvent *atomic.Int64, disconnected chan<- struct{}, enqueueMedia func(string, string), enqueueWebhook func(wa.ParsedMessage), limits *syncStorageLimits) uint32 {
 	var panicCount atomic.Int64
 	var appStateRecoveries sync.Map
 	return a.wa.AddEventHandler(func(evt interface{}) {
@@ -55,7 +55,7 @@ func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, message
 		switch v := evt.(type) {
 		case *events.Message:
 			lastEvent.Store(nowUTC().UnixNano())
-			a.handleLiveSyncMessage(ctx, opts, v, messagesStored, enqueueMedia, limits)
+			a.handleLiveSyncMessage(ctx, opts, v, messagesStored, enqueueMedia, enqueueWebhook, limits)
 		case *events.HistorySync:
 			lastEvent.Store(nowUTC().UnixNano())
 			a.handleHistorySync(ctx, opts, v, messagesStored, lastEvent, enqueueMedia, limits)
@@ -140,7 +140,7 @@ func (a *App) handleAppStateSyncError(ctx context.Context, evt *events.AppStateS
 	}()
 }
 
-func (a *App) handleLiveSyncMessage(ctx context.Context, opts SyncOptions, v *events.Message, messagesStored *atomic.Int64, enqueueMedia func(string, string), limits ...*syncStorageLimits) {
+func (a *App) handleLiveSyncMessage(ctx context.Context, opts SyncOptions, v *events.Message, messagesStored *atomic.Int64, enqueueMedia func(string, string), enqueueWebhook func(wa.ParsedMessage), limits ...*syncStorageLimits) {
 	if historySyncNotificationFromMessage(v) != nil {
 		return
 	}
@@ -150,6 +150,9 @@ func (a *App) handleLiveSyncMessage(ctx context.Context, opts SyncOptions, v *ev
 	}
 	if err := a.storeParsedMessageForSync(ctx, pm, limits...); err == nil {
 		a.emitSyncProgress(messagesStored.Add(1))
+		if enqueueWebhook != nil {
+			enqueueWebhook(pm)
+		}
 	}
 	if opts.DownloadMedia && pm.Media != nil && pm.ID != "" {
 		enqueueMedia(pm.Chat.String(), pm.ID)

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -52,7 +52,7 @@ func TestLiveSyncWarnsOnEncryptedReactionDecryptFailure(t *testing.T) {
 
 	var messagesStored atomic.Int64
 	out := captureStderr(t, func() {
-		a.handleLiveSyncMessage(context.Background(), SyncOptions{}, reactionMsg, &messagesStored, func(string, string) {})
+		a.handleLiveSyncMessage(context.Background(), SyncOptions{}, reactionMsg, &messagesStored, func(string, string) {}, nil)
 	})
 
 	if !strings.Contains(out, "warning: failed to decrypt reaction message m-enc-react: not supported") {
@@ -183,7 +183,7 @@ func TestLiveSyncIgnoresHistorySyncProtocolMessage(t *testing.T) {
 	}
 
 	var messagesStored atomic.Int64
-	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, evt, &messagesStored, func(string, string) {})
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, evt, &messagesStored, func(string, string) {}, nil)
 
 	if messagesStored.Load() != 0 {
 		t.Fatalf("history sync protocol message stored count = %d, want 0", messagesStored.Load())

--- a/internal/app/webhook.go
+++ b/internal/app/webhook.go
@@ -1,0 +1,132 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/steipete/wacli/internal/wa"
+)
+
+var syncWebhookHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+func syncWebhookEnabled(opts SyncOptions) bool {
+	return strings.TrimSpace(opts.WebhookURL) != ""
+}
+
+func (a *App) newSyncWebhookEnqueuer(ctx context.Context, jobs chan<- wa.ParsedMessage) func(wa.ParsedMessage) {
+	return func(pm wa.ParsedMessage) {
+		if strings.TrimSpace(pm.ID) == "" {
+			return
+		}
+		select {
+		case jobs <- pm:
+		case <-ctx.Done():
+		default:
+			a.emitWarning(
+				"sync_webhook_dropped",
+				fmt.Sprintf("warning: sync webhook queue full; dropping message %s", pm.ID),
+				map[string]any{"message_id": pm.ID},
+			)
+		}
+	}
+}
+
+func (a *App) runSyncWebhookWorker(ctx context.Context, opts SyncOptions, jobs <-chan wa.ParsedMessage) func() {
+	if jobs == nil {
+		return func() {}
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case pm, ok := <-jobs:
+				if !ok {
+					return
+				}
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							stack := debug.Stack()
+							a.emitWarning(
+								"sync_webhook_panic",
+								fmt.Sprintf("sync webhook worker panic (recovered) for %s: %v\n%s", pm.ID, r, stack),
+								map[string]any{"message_id": pm.ID, "panic": fmt.Sprint(r), "stack": string(stack)},
+							)
+						}
+					}()
+					if err := a.postSyncWebhook(ctx, opts, pm); err != nil {
+						a.emitWarning(
+							"sync_webhook_failed",
+							fmt.Sprintf("warning: sync webhook failed for message %s: %v", pm.ID, err),
+							map[string]any{"message_id": pm.ID, "error": err.Error()},
+						)
+					}
+				}()
+			}
+		}
+	}()
+	return func() {
+		cancel()
+		wg.Wait()
+	}
+}
+
+func (a *App) postSyncWebhook(ctx context.Context, opts SyncOptions, pm wa.ParsedMessage) error {
+	webhookURL := strings.TrimSpace(opts.WebhookURL)
+	if webhookURL == "" {
+		return nil
+	}
+	payload, err := json.Marshal(pm)
+	if err != nil {
+		return fmt.Errorf("marshal webhook payload: %w", err)
+	}
+	req, err := newSyncWebhookRequest(ctx, webhookURL, opts.WebhookSecret, a.Version(), payload)
+	if err != nil {
+		return err
+	}
+	resp, err := syncWebhookHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("post webhook: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("post webhook: %s", resp.Status)
+	}
+	return nil
+}
+
+func newSyncWebhookRequest(ctx context.Context, webhookURL, secret, version string, payload []byte) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("create webhook request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "wacli/"+version)
+	if strings.TrimSpace(secret) != "" {
+		req.Header.Set("X-Wacli-Signature", syncWebhookSignature(secret, payload))
+	}
+	return req, nil
+}
+
+func syncWebhookSignature(secret string, payload []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(payload)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}

--- a/internal/app/webhook_test.go
+++ b/internal/app/webhook_test.go
@@ -1,0 +1,150 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/steipete/wacli/internal/wa"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestHandleLiveSyncMessagePostsSignedWebhook(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	type requestInfo struct {
+		body        []byte
+		signature   string
+		contentType string
+	}
+	gotReq := make(chan requestInfo, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		gotReq <- requestInfo{
+			body:        body,
+			signature:   r.Header.Get("X-Wacli-Signature"),
+			contentType: r.Header.Get("Content-Type"),
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	chat := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     chat,
+				Sender:   chat,
+				IsFromMe: false,
+				IsGroup:  false,
+			},
+			ID:        "m-live",
+			Timestamp: time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC),
+			PushName:  "Alice",
+		},
+		Message: &waProto.Message{Conversation: proto.String("hello")},
+	}
+
+	var messagesStored atomic.Int64
+	jobs := make(chan wa.ParsedMessage, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stopWebhook := a.runSyncWebhookWorker(ctx, SyncOptions{
+		WebhookURL:    srv.URL,
+		WebhookSecret: "supersecret",
+	}, jobs)
+	defer stopWebhook()
+
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{
+		WebhookURL:    srv.URL,
+		WebhookSecret: "supersecret",
+	}, evt, &messagesStored, func(string, string) {}, a.newSyncWebhookEnqueuer(ctx, jobs))
+
+	if messagesStored.Load() != 1 {
+		t.Fatalf("messages stored = %d, want 1", messagesStored.Load())
+	}
+
+	var got requestInfo
+	select {
+	case got = <-gotReq:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook request")
+	}
+	if got.contentType != "application/json" {
+		t.Fatalf("content type = %q", got.contentType)
+	}
+	if got.signature != syncWebhookSignature("supersecret", got.body) {
+		t.Fatalf("signature = %q, want %q", got.signature, syncWebhookSignature("supersecret", got.body))
+	}
+	for _, want := range [][]byte{[]byte(`"ID":"m-live"`), []byte(`"Text":"hello"`)} {
+		if !bytes.Contains(got.body, want) {
+			t.Fatalf("webhook body missing %s: %s", want, got.body)
+		}
+	}
+}
+
+func TestHandleLiveSyncMessageDoesNotBlockOnWebhookDelivery(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	jobs := make(chan wa.ParsedMessage, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stopWebhook := a.runSyncWebhookWorker(ctx, SyncOptions{WebhookURL: srv.URL}, jobs)
+	defer stopWebhook()
+
+	chat := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat},
+			ID:            "m-slow-webhook",
+			Timestamp:     time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{Conversation: proto.String("hello")},
+	}
+
+	var messagesStored atomic.Int64
+	returned := make(chan struct{})
+	go func() {
+		a.handleLiveSyncMessage(context.Background(), SyncOptions{WebhookURL: srv.URL}, evt, &messagesStored, func(string, string) {}, a.newSyncWebhookEnqueuer(ctx, jobs))
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("live message handler blocked on webhook delivery")
+	}
+	if messagesStored.Load() != 1 {
+		t.Fatalf("messages stored = %d, want 1", messagesStored.Load())
+	}
+	select {
+	case <-requestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook worker request")
+	}
+	close(releaseRequest)
+}


### PR DESCRIPTION
## Summary

- add `sync --webhook` for posting successfully stored live-message JSON
- add `sync --webhook-secret` to sign payloads with `X-Wacli-Signature: sha256=<hmac>`
- deliver webhooks on a bounded background worker so slow endpoints do not block whatsmeow event dispatch
- validate that a secret is only accepted when a webhook URL is configured
- log delivery failures and full-queue drops without failing sync
- document the flags and best-effort delivery semantics

## Scope

This is a clean, narrow port of the webhook-signature slice from #166. It intentionally leaves retries/backoff, exec hooks, and export formatting for separate PRs.

## Tests

- `go test ./cmd/wacli -run 'TestSyncCommand'`
- `go test ./internal/app -run 'TestHandleLiveSyncMessagePostsSignedWebhook|TestHandleLiveSyncMessageDoesNotBlockOnWebhookDelivery|TestLiveSyncWarnsOnEncryptedReactionDecryptFailure|TestLiveSyncIgnoresHistorySyncProtocolMessage'`
- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `git diff --check`
- CI: https://github.com/openclaw/wacli/actions/runs/25371217269
