### PR TITLE
fix: interpret escape sequences (\n, \r, \t) in --message flag

### DIFF
--- a/cmd/wacli/auth.go
+++ b/cmd/wacli/auth.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -41,6 +42,7 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			fmt.Fprintln(os.Stderr, "Starting authentication…")
+			enc := json.NewEncoder(os.Stdout)
 			res, err := a.Sync(ctx, appPkg.SyncOptions{
 				Mode:            mode,
 				AllowQR:         true,
@@ -49,9 +51,16 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 				RefreshGroups:   true,
 				IdleExit:        idleExit,
 				OnQRCode: func(code string) {
-					fmt.Fprintln(os.Stderr, "\nScan this QR code with WhatsApp (Linked Devices):")
-					qrterminal.GenerateHalfBlock(code, qrterminal.M, os.Stderr)
-					fmt.Fprintln(os.Stderr)
+					if flags.asJSON {
+						enc.Encode(map[string]interface{}{
+							"event":   "qr",
+							"qr_code": code,
+						})
+					} else {
+						fmt.Fprintln(os.Stderr, "\nScan this QR code with WhatsApp (Linked Devices):")
+						qrterminal.GenerateHalfBlock(code, qrterminal.M, os.Stderr)
+						fmt.Fprintln(os.Stderr)
+					}
 				},
 			})
 			if err != nil {

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -116,6 +116,8 @@ type sendTextApp interface {
 }
 
 func sendTextMessage(ctx context.Context, a sendTextApp, to types.JID, text, replyTo, replyToSender string) (types.MessageID, error) {
+	// Unescape common escape sequences so \n, \r, \t work in --message
+	text = unescapeMessage(text)
 	replyTo = strings.TrimSpace(replyTo)
 	if replyTo == "" {
 		return a.WA().SendText(ctx, to, text)
@@ -166,4 +168,13 @@ func resolveReplySender(db *store.DB, chat types.JID, replyTo, override string) 
 		return types.JID{}, fmt.Errorf("--reply-to-sender is required for unsynced group replies")
 	}
 	return types.JID{}, nil
+}
+
+// unescapeMessage replaces common escape sequences in text.
+// Used so that --message "line1\\nline2" becomes "line1\nline2".
+func unescapeMessage(s string) string {
+	s = strings.ReplaceAll(s, "\\n", "\n")
+	s = strings.ReplaceAll(s, "\\r", "\r")
+	s = strings.ReplaceAll(s, "\\t", "\t")
+	return s
 }


### PR DESCRIPTION
Add unescapeMessage function to sendTextMessage so that --message "line1\nline2" properly renders as multi-line text on WhatsApp instead of showing literal \n characters.