### PR TITLE
feat: persist community hierarchy metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Auth: auto-detect a readable linked-device label and default linked-device platform to desktop. (#100 — thanks @pmatheus)
 - Chats: add archive/unarchive, pin/unpin, mute/unmute, and mark-read/mark-unread commands, plus list/show state fields. (#46 — thanks @decodiver22)
 - Profile: add `profile set-picture` to update the authenticated account profile picture from JPEG or PNG input. (#198 — thanks @gado-ships-it)
+- Groups: persist WhatsApp Community parent/subgroup metadata from group refresh/info. (#39 — thanks @TheMazzle)
 - Sync: add signed live-message webhooks with `--webhook` and `--webhook-secret`. (#203 — thanks @dinakars777 and @Melostack)
 - Send: add `send react` to add or clear reactions, with group sender validation. (#151 — thanks @draix)
 - Send: add opt-in `send text --message-escapes` for `\n`, `\r`, `\t`, `\\`, and `\"` in `--message`. (#206 — thanks @slaveofcode)

--- a/cmd/wacli/groups_info_rename.go
+++ b/cmd/wacli/groups_info_rename.go
@@ -56,13 +56,17 @@ func newGroupsInfoCmd(flags *rootFlags) *cobra.Command {
 				return out.WriteJSON(os.Stdout, info)
 			}
 
-			fmt.Fprintf(os.Stdout, "JID: %s\nName: %s\nOwner: %s\nCreated: %s\nParticipants: %d\n",
+			fmt.Fprintf(os.Stdout, "JID: %s\nName: %s\nOwner: %s\nCreated: %s\nType: %s\n",
 				info.JID.String(),
 				info.GroupName.Name,
 				info.OwnerJID.String(),
 				info.GroupCreated.Local().Format(time.RFC3339),
-				len(info.Participants),
+				groupKindLabel(info.IsParent, info.LinkedParentJID.String()),
 			)
+			if !info.LinkedParentJID.IsEmpty() {
+				fmt.Fprintf(os.Stdout, "Parent: %s\n", info.LinkedParentJID.String())
+			}
+			fmt.Fprintf(os.Stdout, "Participants: %d\n", len(info.Participants))
 			return nil
 		},
 	}

--- a/cmd/wacli/groups_persist.go
+++ b/cmd/wacli/groups_persist.go
@@ -16,7 +16,7 @@ func persistGroupInfo(db *store.DB, info *types.GroupInfo) error {
 	if info == nil {
 		return nil
 	}
-	if err := db.UpsertGroup(info.JID.String(), info.GroupName.Name, info.OwnerJID.String(), info.GroupCreated); err != nil {
+	if err := db.UpsertGroupWithHierarchy(info.JID.String(), info.GroupName.Name, info.OwnerJID.String(), info.GroupCreated, info.IsParent, info.LinkedParentJID.String()); err != nil {
 		return err
 	}
 	var ps []store.GroupParticipant
@@ -34,4 +34,14 @@ func persistGroupInfo(db *store.DB, info *types.GroupInfo) error {
 		})
 	}
 	return db.ReplaceGroupParticipants(info.JID.String(), ps)
+}
+
+func groupKindLabel(isParent bool, linkedParentJID string) string {
+	if isParent {
+		return "community"
+	}
+	if linkedParentJID != "" {
+		return "subgroup"
+	}
+	return "group"
 }

--- a/cmd/wacli/groups_refresh_list.go
+++ b/cmd/wacli/groups_refresh_list.go
@@ -88,13 +88,17 @@ func newGroupsListCmd(flags *rootFlags) *cobra.Command {
 
 			fullOutput := fullTableOutput(flags.fullOutput)
 			w := newTableWriter(os.Stdout)
-			fmt.Fprintln(w, "NAME\tJID\tCREATED")
+			fmt.Fprintln(w, "NAME\tJID\tTYPE\tPARENT\tCREATED")
 			for _, g := range gs {
 				name := g.Name
 				if name == "" {
 					name = g.JID
 				}
-				fmt.Fprintf(w, "%s\t%s\t%s\n", tableCell(name, 40, fullOutput), g.JID, g.CreatedAt.Local().Format("2006-01-02"))
+				parent := g.LinkedParentJID
+				if parent == "" {
+					parent = "-"
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", tableCell(name, 40, fullOutput), g.JID, groupKindLabel(g.IsParent, g.LinkedParentJID), parent, g.CreatedAt.Local().Format("2006-01-02"))
 			}
 			_ = w.Flush()
 			return nil

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -25,8 +25,9 @@ wacli groups join --code INVITE_CODE
 
 - Group JIDs use the `...@g.us` server.
 - `list` reads local rows and hides groups marked left.
-- `refresh` fetches joined groups live and updates local rows.
-- `info` fetches one group live and persists it.
+- `refresh` fetches joined groups live and updates local rows, including WhatsApp Community parent/subgroup metadata.
+- `info` fetches one group live and persists it, including Community metadata when WhatsApp reports it.
+- `list --json` includes `IsParent` and `LinkedParentJID` for Community-aware consumers.
 - `leave` marks the group left locally after WhatsApp confirms.
 - Participant users accept phone numbers with common formatting or JIDs.
 - Invite `revoke` resets the invite link.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -231,6 +231,8 @@ or writing unexpectedly large payloads in one command.
 - `wacli groups join --code INVITE_CODE`
 - `wacli groups leave --jid GROUP_JID`
 
+Group refresh/info persists WhatsApp Community metadata when whatsmeow reports it. Community rows have `IsParent=true`; subgroups expose `LinkedParentJID` in JSON output.
+
 ## Output formats
 
 Default: human-readable text (tables / aligned columns; TTY-aware wrapping).

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -39,7 +39,7 @@ func (a *App) refreshGroups(ctx context.Context) error {
 			continue
 		}
 		joined[g.JID.String()] = true
-		_ = a.db.UpsertGroup(g.JID.String(), g.GroupName.Name, g.OwnerJID.String(), g.GroupCreated)
+		_ = a.db.UpsertGroupWithHierarchy(g.JID.String(), g.GroupName.Name, g.OwnerJID.String(), g.GroupCreated, g.IsParent, g.LinkedParentJID.String())
 		_ = a.db.UpsertChat(g.JID.String(), "group", g.GroupName.Name, now)
 	}
 	return a.db.MarkGroupsMissingFrom(joined, now)

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -45,6 +45,10 @@ func TestRefreshGroupsStoresGroupsAndChats(t *testing.T) {
 		OwnerJID:     types.JID{User: "999", Server: types.DefaultUserServer},
 		GroupName:    types.GroupName{Name: "MyGroup"},
 		GroupCreated: created,
+		GroupLinkedParent: types.GroupLinkedParent{LinkedParentJID: types.JID{
+			User:   "parent",
+			Server: types.GroupServer,
+		}},
 	}
 
 	if err := a.refreshGroups(context.Background()); err != nil {
@@ -56,6 +60,9 @@ func TestRefreshGroupsStoresGroupsAndChats(t *testing.T) {
 	}
 	if len(gs) != 1 || gs[0].JID != gid.String() {
 		t.Fatalf("expected group to be stored, got %+v", gs)
+	}
+	if gs[0].LinkedParentJID != "parent@g.us" {
+		t.Fatalf("LinkedParentJID = %q, want parent@g.us", gs[0].LinkedParentJID)
 	}
 	c, err := a.db.GetChat(gid.String())
 	if err != nil {

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -334,7 +334,7 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 	// Best-effort: store group metadata (and participants) when available.
 	if pm.Chat.Server == types.GroupServer {
 		if gi, err := a.wa.GetGroupInfo(ctx, pm.Chat); err == nil && gi != nil {
-			_ = a.db.UpsertGroup(gi.JID.String(), gi.GroupName.Name, gi.OwnerJID.String(), gi.GroupCreated)
+			_ = a.db.UpsertGroupWithHierarchy(gi.JID.String(), gi.GroupName.Name, gi.OwnerJID.String(), gi.GroupCreated, gi.IsParent, gi.LinkedParentJID.String())
 			var ps []store.GroupParticipant
 			for _, p := range gi.Participants {
 				role := "member"

--- a/internal/store/groups.go
+++ b/internal/store/groups.go
@@ -20,6 +20,23 @@ func (d *DB) UpsertGroup(jid, name, ownerJID string, created time.Time) error {
 	return err
 }
 
+func (d *DB) UpsertGroupWithHierarchy(jid, name, ownerJID string, created time.Time, isParent bool, linkedParentJID string) error {
+	now := nowUTC().Unix()
+	_, err := d.sql.Exec(`
+		INSERT INTO groups(jid, name, owner_jid, created_ts, is_parent, linked_parent_jid, left_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, NULL, ?)
+		ON CONFLICT(jid) DO UPDATE SET
+			name=COALESCE(NULLIF(excluded.name,''), groups.name),
+			owner_jid=COALESCE(NULLIF(excluded.owner_jid,''), groups.owner_jid),
+			created_ts=COALESCE(NULLIF(excluded.created_ts,0), groups.created_ts),
+			is_parent=excluded.is_parent,
+			linked_parent_jid=excluded.linked_parent_jid,
+			left_at=NULL,
+			updated_at=excluded.updated_at
+	`, jid, name, ownerJID, unix(created), boolToInt(isParent), nullIfEmpty(linkedParentJID), now)
+	return err
+}
+
 func (d *DB) MarkGroupLeft(jid string, leftAt time.Time) error {
 	now := nowUTC().Unix()
 	if leftAt.IsZero() {
@@ -101,7 +118,7 @@ func (d *DB) ListGroups(query string, limit int) ([]Group, error) {
 	if limit <= 0 {
 		limit = 50
 	}
-	q := `SELECT jid, COALESCE(name,''), COALESCE(owner_jid,''), COALESCE(created_ts,0), COALESCE(left_at,0), updated_at FROM groups WHERE left_at IS NULL`
+	q := `SELECT jid, COALESCE(name,''), COALESCE(owner_jid,''), COALESCE(created_ts,0), is_parent, COALESCE(linked_parent_jid,''), COALESCE(left_at,0), updated_at FROM groups WHERE left_at IS NULL`
 	var args []interface{}
 	if strings.TrimSpace(query) != "" {
 		needle := likeContains(query)
@@ -121,10 +138,12 @@ func (d *DB) ListGroups(query string, limit int) ([]Group, error) {
 	for rows.Next() {
 		var g Group
 		var created, left, updated int64
-		if err := rows.Scan(&g.JID, &g.Name, &g.OwnerJID, &created, &left, &updated); err != nil {
+		var isParent int
+		if err := rows.Scan(&g.JID, &g.Name, &g.OwnerJID, &created, &isParent, &g.LinkedParentJID, &left, &updated); err != nil {
 			return nil, err
 		}
 		g.CreatedAt = fromUnix(created)
+		g.IsParent = isParent != 0
 		g.LeftAt = fromUnix(left)
 		g.UpdatedAt = fromUnix(updated)
 		out = append(out, g)

--- a/internal/store/groups_test.go
+++ b/internal/store/groups_test.go
@@ -35,6 +35,61 @@ func TestGroupsUpsertListAndParticipantsReplace(t *testing.T) {
 	}
 }
 
+func TestGroupsStoreCommunityHierarchy(t *testing.T) {
+	db := openTestDB(t)
+
+	parent := "parent@g.us"
+	child := "child@g.us"
+	created := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+	if err := db.UpsertGroupWithHierarchy(parent, "Community", "", created, true, ""); err != nil {
+		t.Fatalf("UpsertGroupWithHierarchy parent: %v", err)
+	}
+	if err := db.UpsertGroupWithHierarchy(child, "Announcements", "", created.Add(time.Hour), false, parent); err != nil {
+		t.Fatalf("UpsertGroupWithHierarchy child: %v", err)
+	}
+
+	gs, err := db.ListGroups("", 10)
+	if err != nil {
+		t.Fatalf("ListGroups: %v", err)
+	}
+	byJID := map[string]Group{}
+	for _, g := range gs {
+		byJID[g.JID] = g
+	}
+	if !byJID[parent].IsParent || byJID[parent].LinkedParentJID != "" {
+		t.Fatalf("parent hierarchy fields = %+v", byJID[parent])
+	}
+	if byJID[child].IsParent || byJID[child].LinkedParentJID != parent {
+		t.Fatalf("child hierarchy fields = %+v", byJID[child])
+	}
+
+	if err := db.UpsertGroup(child, "Announcements renamed", "", time.Time{}); err != nil {
+		t.Fatalf("UpsertGroup child: %v", err)
+	}
+	gs, err = db.ListGroups("", 10)
+	if err != nil {
+		t.Fatalf("ListGroups after plain upsert: %v", err)
+	}
+	for _, g := range gs {
+		if g.JID == child && g.LinkedParentJID != parent {
+			t.Fatalf("plain upsert should preserve linked parent: %+v", g)
+		}
+	}
+
+	if err := db.UpsertGroupWithHierarchy(child, "Announcements", "", created.Add(time.Hour), false, ""); err != nil {
+		t.Fatalf("UpsertGroupWithHierarchy child clear: %v", err)
+	}
+	gs, err = db.ListGroups("", 10)
+	if err != nil {
+		t.Fatalf("ListGroups after clear: %v", err)
+	}
+	for _, g := range gs {
+		if g.JID == child && g.LinkedParentJID != "" {
+			t.Fatalf("linked parent was not cleared: %+v", g)
+		}
+	}
+}
+
 func TestGroupsLeftStateHiddenUntilRefreshed(t *testing.T) {
 	db := openTestDB(t)
 

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -24,6 +24,7 @@ var schemaMigrations = []migration{
 	{version: 8, name: "messages revoked column", up: migrateMessagesRevokedColumn},
 	{version: 9, name: "messages deleted_for_me column", up: migrateMessagesDeletedForMeColumn},
 	{version: 10, name: "chat state columns", up: migrateChatStateColumns},
+	{version: 11, name: "groups community hierarchy columns", up: migrateGroupsCommunityHierarchyColumns},
 }
 
 func (d *DB) ensureSchema() error {
@@ -85,6 +86,33 @@ func migrateGroupsLeftAt(d *DB) error {
 	}
 	if _, err := d.sql.Exec(`ALTER TABLE groups ADD COLUMN left_at INTEGER`); err != nil {
 		return fmt.Errorf("add groups.left_at column: %w", err)
+	}
+	return nil
+}
+
+func migrateGroupsCommunityHierarchyColumns(d *DB) error {
+	hasIsParent, err := d.tableHasColumn("groups", "is_parent")
+	if err != nil {
+		return err
+	}
+	if !hasIsParent {
+		if _, err := d.sql.Exec(`ALTER TABLE groups ADD COLUMN is_parent INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("add groups.is_parent column: %w", err)
+		}
+	}
+
+	hasLinkedParent, err := d.tableHasColumn("groups", "linked_parent_jid")
+	if err != nil {
+		return err
+	}
+	if !hasLinkedParent {
+		if _, err := d.sql.Exec(`ALTER TABLE groups ADD COLUMN linked_parent_jid TEXT`); err != nil {
+			return fmt.Errorf("add groups.linked_parent_jid column: %w", err)
+		}
+	}
+
+	if _, err := d.sql.Exec(`CREATE INDEX IF NOT EXISTS idx_groups_linked_parent_jid ON groups(linked_parent_jid)`); err != nil {
+		return fmt.Errorf("create groups linked parent index: %w", err)
 	}
 	return nil
 }

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -29,9 +29,13 @@ const coreSchemaSQL = `
 		name TEXT,
 		owner_jid TEXT,
 		created_ts INTEGER,
+		is_parent INTEGER NOT NULL DEFAULT 0,
+		linked_parent_jid TEXT,
 		left_at INTEGER,
 		updated_at INTEGER NOT NULL
 	);
+
+	CREATE INDEX IF NOT EXISTS idx_groups_linked_parent_jid ON groups(linked_parent_jid);
 
 	CREATE TABLE IF NOT EXISTS group_participants (
 		group_jid TEXT NOT NULL,

--- a/internal/store/schema_test.go
+++ b/internal/store/schema_test.go
@@ -40,6 +40,16 @@ func TestOpenCreatesExpectedSchema(t *testing.T) {
 		}
 	}
 
+	groupCols, err := tableColumns(db.sql, "groups")
+	if err != nil {
+		t.Fatalf("groups tableColumns: %v", err)
+	}
+	for _, want := range []string{"is_parent", "linked_parent_jid"} {
+		if !groupCols[want] {
+			t.Fatalf("expected groups column %q to exist", want)
+		}
+	}
+
 	starredCols, err := tableColumns(db.sql, "starred")
 	if err != nil {
 		t.Fatalf("starred tableColumns: %v", err)
@@ -47,6 +57,62 @@ func TestOpenCreatesExpectedSchema(t *testing.T) {
 	for _, want := range []string{"chat_jid", "msg_id", "sender_jid", "from_me", "starred_at"} {
 		if !starredCols[want] {
 			t.Fatalf("expected starred column %q to exist", want)
+		}
+	}
+}
+
+func TestOpenMigratesGroupCommunityHierarchyColumns(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wacli.db")
+	raw, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	if _, err := raw.Exec(`
+		CREATE TABLE groups (
+			jid TEXT PRIMARY KEY,
+			name TEXT,
+			owner_jid TEXT,
+			created_ts INTEGER,
+			left_at INTEGER,
+			updated_at INTEGER NOT NULL
+		);
+		CREATE TABLE schema_migrations (
+			version INTEGER PRIMARY KEY,
+			name TEXT NOT NULL,
+			applied_at INTEGER NOT NULL
+		);
+		INSERT INTO schema_migrations(version, name, applied_at) VALUES
+			(1, 'core schema', 1),
+			(2, 'messages display_text column', 1),
+			(3, 'messages fts', 1),
+			(4, 'groups left_at column', 1),
+			(5, 'messages forwarded columns', 1),
+			(6, 'messages reaction columns', 1),
+			(7, 'starred messages', 1),
+			(8, 'messages revoked column', 1),
+			(9, 'messages deleted_for_me column', 1),
+			(10, 'chat state columns', 1);
+	`); err != nil {
+		_ = raw.Close()
+		t.Fatalf("create old schema: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close raw DB: %v", err)
+	}
+
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	cols, err := tableColumns(db.sql, "groups")
+	if err != nil {
+		t.Fatalf("groups tableColumns: %v", err)
+	}
+	for _, want := range []string{"is_parent", "linked_parent_jid"} {
+		if !cols[want] {
+			t.Fatalf("expected migrated groups column %q to exist", want)
 		}
 	}
 }

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -23,12 +23,14 @@ func (c Chat) Muted() bool {
 }
 
 type Group struct {
-	JID       string
-	Name      string
-	OwnerJID  string
-	CreatedAt time.Time
-	LeftAt    time.Time
-	UpdatedAt time.Time
+	JID             string
+	Name            string
+	OwnerJID        string
+	CreatedAt       time.Time
+	IsParent        bool
+	LinkedParentJID string
+	LeftAt          time.Time
+	UpdatedAt       time.Time
 }
 
 type GroupParticipant struct {


### PR DESCRIPTION
## Summary
- Persist WhatsApp Community hierarchy metadata on stored groups via `is_parent` and `linked_parent_jid`, including migration coverage for existing databases.
- Thread `GroupInfo.IsParent` and `GroupInfo.LinkedParentJID` through group refresh, live sync group metadata, and `groups info` persistence.
- Surface Community/subgroup metadata in group human output, JSON store fields, docs, and the changelog.

## Dependency checked
Current pinned `go.mau.fi/whatsmeow v0.0.0-20260427122815-7514259253a7` exposes `types.GroupInfo.IsParent` and `types.GroupInfo.LinkedParentJID`, and its parser fills them from `parent` / `linked_parent` group nodes. This patch persists that contract instead of inferring hierarchy from JID shape or names.

## Credit
Rebuilds #39 by @TheMazzle on current `main` with focused migration/storage regression coverage. The commit includes a `Co-authored-by: Willem-Jan <wjj@productfunction.com>` trailer.

## Tests
- `go test ./internal/store ./internal/app ./cmd/wacli`
- `pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`
