### PR TITLE
test: make version output captureable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 ### Chore
 
 - CI: compile-test the Windows lock package to catch platform regressions. (#188 — thanks @dinakars777)
+- CLI: route `version` output through Cobra's configured output stream for easier command tests. (#78 — thanks @nikolasdehor)
 - Dependencies: update Go modules including `whatsmeow`, `go-sqlite3`, `x/*`, and related runtime libs.
 - Refactor: split WhatsApp message parsing into focused text, media, business, and context helpers.
 - Refactor: inject clocks in app/store paths for deterministic tests.

--- a/cmd/wacli/version.go
+++ b/cmd/wacli/version.go
@@ -11,7 +11,7 @@ func newVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print version",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(version)
+			fmt.Fprintln(cmd.OutOrStdout(), version)
 		},
 	}
 }

--- a/cmd/wacli/version_test.go
+++ b/cmd/wacli/version_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestVersionCommandUsesConfiguredOutput(t *testing.T) {
+	var out bytes.Buffer
+	cmd := newVersionCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("version command: %v", err)
+	}
+	if got, want := out.String(), version+"\n"; got != want {
+		t.Fatalf("version output = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Route the `version` subcommand through Cobra's configured output stream with `cmd.OutOrStdout()`.
- Add a focused test proving the command output can be captured without replacing process-wide stdout.
- Keep this as a narrow slice of #78 instead of doing the broad repo-wide stream refactor.

## Credit
Extracted from the CLI testability direction in #78 by @nikolasdehor. The commit includes a `Co-authored-by` trailer using @nikolasdehor's GitHub noreply address.

## Tests
- `go test ./cmd/wacli`
- `pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`
