### PR TITLE
fix: route whatsmeow diagnostics to stderr

### DIFF
--- a/docs/send.md
+++ b/docs/send.md
@@ -2,7 +2,7 @@
 
 Read when: sending text, files, stickers, quoted replies, or reactions.
 
-`wacli send` requires authentication, a live connection, and writable mode. Send attempts are bounded and retry once after reconnect for known stale-session/usync timeout failures. After a successful send, wacli keeps the connection alive briefly so whatsmeow can handle retry receipts from devices that could not decrypt the first copy. Repeated send commands within 5 seconds print a stderr warning so tight loops make WhatsApp rate-limit/account-risk visible.
+`wacli send` requires authentication, a live connection, and writable mode. Send attempts are bounded and retry once after reconnect for known stale-session/usync timeout failures. `Sent to ...` and JSON `sent: true` mean WhatsApp accepted the send request and returned a message ID; they do not confirm recipient delivery. After a successful send, wacli keeps the connection alive briefly so whatsmeow can handle retry receipts from devices that could not decrypt the first copy. Repeated send commands within 5 seconds print a stderr warning so tight loops make WhatsApp rate-limit/account-risk visible.
 
 When `sync --follow` is already running for the same store, send commands delegate the send to that running process instead of opening a second WhatsApp session. This keeps scripts usable while continuous sync owns the store lock.
 

--- a/internal/wa/client_test.go
+++ b/internal/wa/client_test.go
@@ -25,6 +25,9 @@ func TestNewEnablesRetryMessageStore(t *testing.T) {
 	if !c.client.UseRetryMessageStore {
 		t.Fatal("expected retry message store to be enabled")
 	}
+	if _, ok := c.client.Log.(*whatsmeowLogger); !ok {
+		t.Fatalf("client logger = %T, want *whatsmeowLogger", c.client.Log)
+	}
 	if got := c.LinkedJID(); got != "" {
 		t.Fatalf("LinkedJID before auth = %q", got)
 	}

--- a/internal/wa/logger.go
+++ b/internal/wa/logger.go
@@ -1,0 +1,68 @@
+package wa
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	waLog "go.mau.fi/whatsmeow/util/log"
+)
+
+type whatsmeowLogger struct {
+	module string
+	min    int
+	w      io.Writer
+	mu     *sync.Mutex
+}
+
+var _ waLog.Logger = (*whatsmeowLogger)(nil)
+
+var whatsmeowLogLevels = map[string]int{
+	"":      -1,
+	"DEBUG": 0,
+	"INFO":  1,
+	"WARN":  2,
+	"ERROR": 3,
+}
+
+func newWhatsmeowLogger(module, minLevel string, w io.Writer) *whatsmeowLogger {
+	if w == nil {
+		w = io.Discard
+	}
+	min, ok := whatsmeowLogLevels[strings.ToUpper(minLevel)]
+	if !ok {
+		min = whatsmeowLogLevels["ERROR"]
+	}
+	return &whatsmeowLogger{
+		module: module,
+		min:    min,
+		w:      w,
+		mu:     &sync.Mutex{},
+	}
+}
+
+func (l *whatsmeowLogger) Errorf(msg string, args ...interface{}) { l.outputf("ERROR", msg, args...) }
+func (l *whatsmeowLogger) Warnf(msg string, args ...interface{})  { l.outputf("WARN", msg, args...) }
+func (l *whatsmeowLogger) Infof(msg string, args ...interface{})  { l.outputf("INFO", msg, args...) }
+func (l *whatsmeowLogger) Debugf(msg string, args ...interface{}) { l.outputf("DEBUG", msg, args...) }
+
+func (l *whatsmeowLogger) Sub(module string) waLog.Logger {
+	return &whatsmeowLogger{
+		module: fmt.Sprintf("%s/%s", l.module, module),
+		min:    l.min,
+		w:      l.w,
+		mu:     l.mu,
+	}
+}
+
+func (l *whatsmeowLogger) outputf(level, msg string, args ...interface{}) {
+	levelValue, ok := whatsmeowLogLevels[level]
+	if !ok || levelValue < l.min {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fmt.Fprintf(l.w, "%s [%s %s] %s\n", time.Now().Format("15:04:05.000"), l.module, level, fmt.Sprintf(msg, args...))
+}

--- a/internal/wa/logger_test.go
+++ b/internal/wa/logger_test.go
@@ -1,0 +1,34 @@
+package wa
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestWhatsmeowLoggerWritesToConfiguredWriter(t *testing.T) {
+	var stderr bytes.Buffer
+	logger := newWhatsmeowLogger("Client", "ERROR", &stderr)
+
+	logger.Warnf("hidden warning")
+	if stderr.Len() != 0 {
+		t.Fatalf("WARN was written for ERROR logger: %q", stderr.String())
+	}
+
+	logger.Errorf("Failed to issue privacy token for %s: %v", "123@s.whatsapp.net", "bad-request")
+	got := stderr.String()
+	if !strings.Contains(got, "[Client ERROR] Failed to issue privacy token for 123@s.whatsapp.net: bad-request") {
+		t.Fatalf("unexpected log line: %q", got)
+	}
+}
+
+func TestWhatsmeowLoggerSubmoduleSharesWriter(t *testing.T) {
+	var stderr bytes.Buffer
+	logger := newWhatsmeowLogger("Client", "ERROR", &stderr)
+
+	logger.Sub("Socket").Errorf("boom")
+	got := stderr.String()
+	if !strings.Contains(got, "[Client/Socket ERROR] boom") {
+		t.Fatalf("unexpected submodule log line: %q", got)
+	}
+}

--- a/internal/wa/session.go
+++ b/internal/wa/session.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/steipete/wacli/internal/sqliteutil"
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/store/sqlstore"
-	waLog "go.mau.fi/whatsmeow/util/log"
 )
 
 func (c *Client) init() error {
@@ -17,7 +17,7 @@ func (c *Client) init() error {
 	defer c.mu.Unlock()
 
 	ctx := context.Background()
-	dbLog := waLog.Stdout("Database", "ERROR", true)
+	dbLog := newWhatsmeowLogger("Database", "ERROR", os.Stderr)
 	if err := sqliteutil.ChmodFiles(c.opts.StorePath, 0o600); err != nil {
 		return err
 	}
@@ -38,7 +38,7 @@ func (c *Client) init() error {
 		}
 	}
 
-	logger := waLog.Stdout("Client", "ERROR", true)
+	logger := newWhatsmeowLogger("Client", "ERROR", os.Stderr)
 	c.client = whatsmeow.NewClient(deviceStore, logger)
 	c.client.EmitAppStateEventsOnFullSync = true
 	// Persist recently-sent messages so whatsmeow can answer retry-receipts


### PR DESCRIPTION
## Summary
- Route whatsmeow client/database diagnostics through a wacli-owned logger that writes to stderr instead of the upstream stdout logger.
- Add regression coverage for the privacy-token log shape from openclaw/wacli#212 and for `New` wiring the stderr-backed logger.
- Clarify that `Sent to ...` and JSON `sent: true` mean WhatsApp accepted the send request and returned a message ID, not that recipient delivery is confirmed.

Dependency checked: current whatsmeow `v0.0.0-20260505142014-6dd3d24c1ca6` exposes the privacy-token failure through `Logger.Errorf` in `tctoken.go`, while `waLog.Stdout` writes with `fmt.Printf`. `SendMessage` still returns the accepted message ID separately, so this patch keeps dependency diagnostics off primary command output instead of treating the async privacy-token log as a definitive send failure.

Refs openclaw/wacli#212

## Tests
- `go test ./internal/wa -run 'TestWhatsmeowLogger|TestNewEnablesRetryMessageStore'`
- `go test ./cmd/wacli -run 'TestRunSendOperation|TestWaitForPostSendRetryReceipts|TestWarnRapidSend'`
- `pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`
