### PR TITLE
ci: harden release tap handoff after move

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,8 @@ jobs:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::error::Set HOMEBREW_TAP_TOKEN with workflow access to steipete/homebrew-tap"
-            exit 1
+            echo "::warning::Skipping Homebrew tap update because HOMEBREW_TAP_TOKEN is not configured with workflow access to steipete/homebrew-tap"
+            exit 0
           fi
 
           request_id="wacli-${RELEASE_TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
@@ -76,7 +76,7 @@ jobs:
             --ref main \
             -f formula=wacli \
             -f tag="$RELEASE_TAG" \
-            -f repository=steipete/wacli \
+            -f repository=openclaw/wacli \
             -f macos_artifact=wacli-macos-universal.tar.gz \
             -f request_id="$request_id"
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -30,10 +30,12 @@ early if someone tries to compile it with `CGO_ENABLED=0`.
 
 ## Homebrew Tap
 
-The release workflow dispatches the `Update Formula` workflow in `steipete/homebrew-tap` after the macOS artifact is published. The tap workflow owns the formula-editing logic and updates both the macOS artifact SHA256 and the Linux source archive SHA256 in `Formula/wacli.rb`.
+The release workflow dispatches the `Update Formula` workflow in `steipete/homebrew-tap` after the macOS artifact is published when the tap token is configured. The tap workflow owns the formula-editing logic and updates both the macOS artifact SHA256 and the Linux source archive SHA256 in `Formula/wacli.rb`.
 
-Required repository secret:
+Optional repository secret:
 
 - `HOMEBREW_TAP_TOKEN`: token with permission to run workflows in `steipete/homebrew-tap`
+
+If `HOMEBREW_TAP_TOKEN` is missing, release artifacts are still published and the tap update is skipped with a workflow warning.
 
 To backfill an existing release, rerun the `release` workflow manually with `tag: vX.Y.Z`.


### PR DESCRIPTION
## Summary
- Pass `openclaw/wacli` to the Homebrew tap updater so generated formula updates source the moved repository.
- Treat a missing `HOMEBREW_TAP_TOKEN` as a warning and skip only the tap handoff, rather than failing the whole release after artifacts publish.
- Update release docs to match the optional tap-token behavior.

This addresses one migration gap from the steipete-to-OpenClaw move: release artifacts should not be marked failed solely because the org secret has not been restored yet.

## Tests
- `pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`
