### PR TITLE
fix: apply history coverage filters before limit

### DIFF
--- a/internal/store/history.go
+++ b/internal/store/history.go
@@ -68,6 +68,9 @@ func (d *DB) ListHistoryCoverage(p ListHistoryCoverageParams) ([]HistoryCoverage
 	if len(p.ChatJIDs) > 0 {
 		query, args = appendStringFilter(query, args, "c.jid", "", p.ChatJIDs)
 	}
+	if !p.IncludeBlocked || p.OnlyActionable {
+		query += ` AND COALESCE(ms.message_count, 0) > 0`
+	}
 
 	query += ` ORDER BY COALESCE(c.last_message_ts, 0) DESC, c.jid LIMIT ?`
 	args = append(args, p.Limit)

--- a/internal/store/history_test.go
+++ b/internal/store/history_test.go
@@ -89,6 +89,44 @@ func TestListHistoryCoverage(t *testing.T) {
 	}
 }
 
+func TestListHistoryCoverageAppliesBlockedFilterBeforeLimit(t *testing.T) {
+	db := openTestDB(t)
+	base := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+
+	blocked := "blocked@s.whatsapp.net"
+	ready := "ready@s.whatsapp.net"
+	if err := db.UpsertChat(blocked, "dm", "Blocked", base.Add(2*time.Minute)); err != nil {
+		t.Fatalf("UpsertChat blocked: %v", err)
+	}
+	if err := db.UpsertChat(ready, "dm", "Ready", base.Add(time.Minute)); err != nil {
+		t.Fatalf("UpsertChat ready: %v", err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:   ready,
+		MsgID:     "m1",
+		Timestamp: base.Add(time.Second),
+		Text:      "ready",
+	}); err != nil {
+		t.Fatalf("UpsertMessage ready: %v", err)
+	}
+
+	coverage, err := db.ListHistoryCoverage(ListHistoryCoverageParams{Limit: 1})
+	if err != nil {
+		t.Fatalf("ListHistoryCoverage: %v", err)
+	}
+	if len(coverage) != 1 || coverage[0].ChatJID != ready {
+		t.Fatalf("coverage = %+v, want ready chat despite newer blocked row", coverage)
+	}
+
+	withBlocked, err := db.ListHistoryCoverage(ListHistoryCoverageParams{Limit: 1, IncludeBlocked: true})
+	if err != nil {
+		t.Fatalf("ListHistoryCoverage IncludeBlocked: %v", err)
+	}
+	if len(withBlocked) != 1 || withBlocked[0].ChatJID != blocked {
+		t.Fatalf("withBlocked = %+v, want newer blocked chat when requested", withBlocked)
+	}
+}
+
 func TestListHistoryCoverageEscapesQueryWildcards(t *testing.T) {
 	db := openTestDB(t)
 	when := time.Date(2024, 5, 2, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary

Fixes `history coverage` and `history fill --dry-run` returning too few rows when newer blocked chats consume the SQL limit before Go filters them out.

The ready/actionable predicate now runs in SQL whenever blocked rows are not requested, so `LIMIT` applies to the rows the command can actually show. `--include-blocked` still preserves the previous behavior and can return blocked rows first.

## Testing

- `go test ./internal/store -run TestListHistoryCoverage`
- `pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`
