### PR TITLE
fix: let max-messages zero override env

### DIFF
--- a/cmd/wacli/storage_limits.go
+++ b/cmd/wacli/storage_limits.go
@@ -13,13 +13,14 @@ const (
 )
 
 type syncStorageLimitFlags struct {
-	maxMessages int64
-	maxDBSize   string
+	maxMessages    int64
+	maxMessagesSet bool
+	maxDBSize      string
 }
 
 func resolveSyncStorageLimits(flags syncStorageLimitFlags) (int64, int64, error) {
 	maxMessages := flags.maxMessages
-	if maxMessages <= 0 {
+	if !flags.maxMessagesSet && maxMessages <= 0 {
 		raw := strings.TrimSpace(os.Getenv(envSyncMaxMessages))
 		if raw != "" {
 			n, err := strconv.ParseInt(raw, 10, 64)

--- a/cmd/wacli/storage_limits_test.go
+++ b/cmd/wacli/storage_limits_test.go
@@ -64,3 +64,18 @@ func TestResolveSyncStorageLimitsFlagsOverrideEnv(t *testing.T) {
 		t.Fatalf("maxDBSize = %d, want 4MiB", maxDBSize)
 	}
 }
+
+func TestResolveSyncStorageLimitsExplicitZeroMaxMessagesOverridesEnv(t *testing.T) {
+	t.Setenv(envSyncMaxMessages, "123")
+
+	maxMessages, _, err := resolveSyncStorageLimits(syncStorageLimitFlags{
+		maxMessages:    0,
+		maxMessagesSet: true,
+	})
+	if err != nil {
+		t.Fatalf("resolveSyncStorageLimits: %v", err)
+	}
+	if maxMessages != 0 {
+		t.Fatalf("maxMessages = %d, want explicit unlimited", maxMessages)
+	}
+}

--- a/cmd/wacli/sync.go
+++ b/cmd/wacli/sync.go
@@ -31,6 +31,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 			if err := flags.requireWritable(); err != nil {
 				return err
 			}
+			storage.maxMessagesSet = cmd.Flags().Changed("max-messages")
 			maxMessages, maxDBSize, err := resolveSyncStorageLimits(storage)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Summary

Fixes `sync --max-messages=0` being unable to disable `WACLI_SYNC_MAX_MESSAGES` for a single command invocation.

The command now records whether `--max-messages` was explicitly provided. When it is omitted, the environment fallback still applies; when it is provided as `0`, the resolved limit stays unlimited as the flag help documents.

## Testing

- `go test ./cmd/wacli -run TestResolveSyncStorageLimits`
- `pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`
