### PR TITLE
fix: truncate table output by rune

### DIFF
--- a/cmd/wacli/helpers.go
+++ b/cmd/wacli/helpers.go
@@ -38,13 +38,17 @@ func sanitize(s string) string {
 
 func truncate(s string, max int) string {
 	s = sanitize(s)
-	if max <= 0 || len(s) <= max {
+	if max <= 0 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
 		return s
 	}
 	if max <= 1 {
-		return s[:max]
+		return string(runes[:max])
 	}
-	return s[:max-1] + "…"
+	return string(runes[:max-1]) + "…"
 }
 
 func fullTableOutput(forceFull bool) bool {

--- a/cmd/wacli/messages_test.go
+++ b/cmd/wacli/messages_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/spf13/cobra"
 	"github.com/steipete/wacli/internal/store"
@@ -32,6 +33,16 @@ func TestTruncate(t *testing.T) {
 		if got := truncate(tc.input, tc.max); got != tc.want {
 			t.Fatalf("truncate(%q, %d) = %q, want %q", tc.input, tc.max, got, tc.want)
 		}
+	}
+}
+
+func TestTruncatePreservesUTF8(t *testing.T) {
+	got := truncate("🙂🙂🙂", 2)
+	if got != "🙂…" {
+		t.Fatalf("truncate emoji = %q, want first rune plus ellipsis", got)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncate produced invalid UTF-8: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes table truncation corrupting non-ASCII output when a byte slice lands inside a multi-byte rune.

The helper now truncates by rune count instead of byte index, preserving valid UTF-8 for contact names, chat names, and message text that include emoji or other non-ASCII characters.

## Testing

- `go test ./cmd/wacli -run 'TestTruncate'`
- `pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`
