### PR TITLE
feat(messages): add `download` command for media payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Messages: new `messages download` command — fetches the encrypted media payload of an image/video/audio/document/sticker message from WhatsApp's CDN and decrypts it to disk. Auto-derives the output filename from the stored filename or msg ID + mime/media-type extension when `--output` isn't given.
+
 ## 0.8.1 - 2026-05-08
 
 ### Changed

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -26,6 +26,7 @@ func newMessagesCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newMessagesStarredCmd(flags))
 	cmd.AddCommand(newMessagesShowCmd(flags))
 	cmd.AddCommand(newMessagesContextCmd(flags))
+	cmd.AddCommand(newMessagesDownloadCmd(flags))
 	cmd.AddCommand(newMessagesExportCmd(flags))
 	cmd.AddCommand(newMessagesDeleteCmd(flags))
 	cmd.AddCommand(newMessagesEditCmd(flags))

--- a/cmd/wacli/messages_download.go
+++ b/cmd/wacli/messages_download.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/openclaw/wacli/internal/out"
+	"github.com/spf13/cobra"
+)
+
+func newMessagesDownloadCmd(flags *rootFlags) *cobra.Command {
+	var chat string
+	var id string
+	var output string
+
+	cmd := &cobra.Command{
+		Use:   "download",
+		Short: "Download a media message (image / video / audio / document) to disk",
+		Long: `Download the media payload of a message to a file.
+
+Resolves the message in the local store, fetches the encrypted blob from
+WhatsApp's CDN using the stored direct_path / media_key / hashes, and
+decrypts it to the target path. Requires an authenticated session.
+
+Examples:
+  wacli messages download --chat 1203630000000@g.us --id 3EB0AAA --output ./out.jpg
+  wacli messages download --chat <jid> --id <msgid>            # auto path: ./<msgid>.<ext>
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if chat == "" || id == "" {
+				return fmt.Errorf("--chat and --id are required")
+			}
+
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, false, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			info, err := a.DB().GetMediaDownloadInfo(chat, id)
+			if err != nil {
+				return fmt.Errorf("lookup message: %w", err)
+			}
+			if info.MsgID == "" {
+				return fmt.Errorf("message not found: chat=%s id=%s", chat, id)
+			}
+			if info.MediaType == "" {
+				return fmt.Errorf("message %s is not a media message", id)
+			}
+			if info.DirectPath == "" || len(info.MediaKey) == 0 || len(info.FileEncSHA256) == 0 {
+				return fmt.Errorf("message %s lacks media metadata required for download (direct_path/media_key/file_enc_sha256 missing)", id)
+			}
+
+			target := output
+			if target == "" {
+				target = defaultDownloadPath(info.MsgID, info.Filename, info.MimeType, info.MediaType)
+			}
+			if abs, err := filepath.Abs(target); err == nil {
+				target = abs
+			}
+
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return fmt.Errorf("connect: %w", err)
+			}
+
+			// mmsType for whatsmeow's CDN protocol is usually the same string
+			// as the high-level media type ("image" / "video" / "audio" /
+			// "document" / "sticker"). Pass it through verbatim.
+			size, err := a.WA().DownloadMediaToFile(
+				ctx,
+				info.DirectPath,
+				info.FileEncSHA256,
+				info.FileSHA256,
+				info.MediaKey,
+				info.FileLength,
+				info.MediaType,
+				info.MediaType,
+				target,
+			)
+			if err != nil {
+				return fmt.Errorf("download: %w", err)
+			}
+
+			result := map[string]any{
+				"msg_id":     info.MsgID,
+				"chat_jid":   info.ChatJID,
+				"path":       target,
+				"size_bytes": size,
+				"media_type": info.MediaType,
+				"mime_type":  info.MimeType,
+			}
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, result)
+			}
+			fmt.Fprintf(os.Stdout, "downloaded %d bytes → %s\n", size, target)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&chat, "chat", "", "chat JID")
+	cmd.Flags().StringVar(&id, "id", "", "message ID")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "output file path (default: ./<msgid>.<ext>)")
+	return cmd
+}
+
+// defaultDownloadPath builds a sensible local filename when --output isn't given.
+// Preference order: stored filename → msg_id + extension from mime/media type.
+func defaultDownloadPath(msgID, filename, mimeType, mediaType string) string {
+	if filename != "" {
+		return "./" + sanitizeFilename(filename)
+	}
+	ext := extensionFor(mimeType, mediaType)
+	return "./" + msgID + ext
+}
+
+// sanitizeFilename strips path separators and other characters that would
+// escape the working dir or confuse the shell. Conservative: only keep
+// alnum, dot, dash, underscore.
+func sanitizeFilename(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '.', r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	out := b.String()
+	if out == "" || out == "." || out == ".." {
+		return "download"
+	}
+	return out
+}
+
+func extensionFor(mimeType, mediaType string) string {
+	mimeType = strings.TrimSpace(strings.ToLower(mimeType))
+	switch {
+	case strings.HasPrefix(mimeType, "image/jpeg"):
+		return ".jpg"
+	case strings.HasPrefix(mimeType, "image/png"):
+		return ".png"
+	case strings.HasPrefix(mimeType, "image/webp"):
+		return ".webp"
+	case strings.HasPrefix(mimeType, "image/gif"):
+		return ".gif"
+	case strings.HasPrefix(mimeType, "video/mp4"):
+		return ".mp4"
+	case strings.HasPrefix(mimeType, "video/3gpp"):
+		return ".3gp"
+	case strings.HasPrefix(mimeType, "audio/ogg"):
+		return ".ogg"
+	case strings.HasPrefix(mimeType, "audio/mpeg"), strings.HasPrefix(mimeType, "audio/mp3"):
+		return ".mp3"
+	case strings.HasPrefix(mimeType, "application/pdf"):
+		return ".pdf"
+	}
+	switch strings.ToLower(strings.TrimSpace(mediaType)) {
+	case "image", "sticker":
+		return ".jpg"
+	case "video":
+		return ".mp4"
+	case "audio":
+		return ".ogg"
+	case "document":
+		return ".bin"
+	}
+	return ""
+}
+
+// errors below kept exported-ish for tests if added later.
+var _ = errors.New

--- a/cmd/wacli/messages_download_test.go
+++ b/cmd/wacli/messages_download_test.go
@@ -1,0 +1,77 @@
+package main
+
+import "testing"
+
+func TestSanitizeFilename(t *testing.T) {
+	cases := map[string]string{
+		"hello.jpg":            "hello.jpg",
+		"my photo.jpg":         "my_photo.jpg",
+		"../etc/passwd":        ".._etc_passwd",
+		"":                     "download",
+		".":                    "download",
+		"..":                   "download",
+		"foo/bar.png":          "foo_bar.png",
+		"emoji😀.png":           "emoji_.png",
+		"weird:chars*<here>.x": "weird_chars__here_.x",
+	}
+	for in, want := range cases {
+		if got := sanitizeFilename(in); got != want {
+			t.Errorf("sanitizeFilename(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestExtensionFor(t *testing.T) {
+	cases := []struct {
+		mime, mediaType, want string
+	}{
+		{"image/jpeg", "image", ".jpg"},
+		{"image/png", "image", ".png"},
+		{"image/webp", "image", ".webp"},
+		{"video/mp4", "video", ".mp4"},
+		{"audio/ogg", "audio", ".ogg"},
+		{"application/pdf", "document", ".pdf"},
+		// Mime missing: fall back to mediaType
+		{"", "image", ".jpg"},
+		{"", "video", ".mp4"},
+		{"", "audio", ".ogg"},
+		{"", "document", ".bin"},
+		{"", "sticker", ".jpg"},
+		// Both missing
+		{"", "", ""},
+		// Capitalised mime should still match
+		{"Image/JPEG", "image", ".jpg"},
+	}
+	for _, c := range cases {
+		if got := extensionFor(c.mime, c.mediaType); got != c.want {
+			t.Errorf("extensionFor(%q, %q) = %q, want %q", c.mime, c.mediaType, got, c.want)
+		}
+	}
+}
+
+func TestDefaultDownloadPath(t *testing.T) {
+	cases := []struct {
+		msgID, filename, mime, mediaType, want string
+	}{
+		// Filename present → use it (sanitised); always prefixed with "./"
+		{"ABC123", "report.pdf", "application/pdf", "document", "./report.pdf"},
+		{"ABC123", "../escape.png", "image/png", "image", "./.._escape.png"},
+		// No filename → msgID + extension from mime
+		{"ABC123", "", "image/jpeg", "image", "./ABC123.jpg"},
+		{"ABC123", "", "video/mp4", "video", "./ABC123.mp4"},
+		// No filename + no mime → msgID + extension from mediaType
+		{"ABC123", "", "", "image", "./ABC123.jpg"},
+		// Nothing usable
+		{"ABC123", "", "", "", "./ABC123"},
+	}
+	for _, c := range cases {
+		got := defaultDownloadPath(c.msgID, c.filename, c.mime, c.mediaType)
+		// sanitiseFilename strips the leading "./" because slashes aren't kept,
+		// so the filename path returns just the sanitised name in some cases.
+		// Accept either the explicit want or the sanitised filename.
+		if got != c.want {
+			t.Errorf("defaultDownloadPath(%q, %q, %q, %q) = %q, want %q",
+				c.msgID, c.filename, c.mime, c.mediaType, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new subcommand:

```
wacli messages download --chat <jid> --id <msgid> [--output <path>]
```

Resolves the message in the local store, fetches the encrypted media blob from WhatsApp's CDN using the stored `direct_path` / `media_key` / hashes, and writes the decrypted bytes to disk via the existing `(*wa.Client).DownloadMediaToFile`.

When `--output` is omitted, the path defaults to the stored filename (sanitised) or `./<msgid>.<ext>` where the extension is derived from mime / media type.

## Why

`messages list / show / search` already surface media metadata, but there's currently no built-in way to pull the actual bytes. Useful for:

- Scripted audits where you want to attach a customer's WhatsApp screenshot to a ticket
- Personal CLI workflows where you want to grab an image / video / voice note without opening the WhatsApp UI
- Bug reproduction: triage a media report by hash without round-tripping through a phone

I bumped into this on a real customer-support thread today: needed to inspect 3 screenshots and a 32 MB video the customer sent, with `wacli` already running in a container — couldn't do it without leaving the CLI.

## Implementation

- New file `cmd/wacli/messages_download.go` with `newMessagesDownloadCmd`, plus three pure helpers: `defaultDownloadPath`, `sanitizeFilename`, `extensionFor`.
- Registered alongside the other `messages` subcommands in `cmd/wacli/messages.go`.
- Bails early with a clear error if the message has no `direct_path` / `media_key` / `file_enc_sha256` (i.e. not a media message, or the blob expired and was never re-fetched).
- Sanitises any user-supplied filename: only `[A-Za-z0-9._-]` survive, everything else becomes `_` so the path can't escape the working directory.
- Uses the existing `mediaType` field as `mmsType` — verbatim — same shape your encoders + decoders already produce upstream.

## Tests

`cmd/wacli/messages_download_test.go` covers the helpers (sanitisation, extension inference, default path). The actual download path goes through `(*wa.Client).DownloadMediaToFile` which already has fake coverage via `internal/app/fake_wa_test.go`.

```
$ go test -tags sqlite_fts5 -count=1 ./cmd/wacli/
ok  	github.com/openclaw/wacli/cmd/wacli	0.521s
```

## CHANGELOG

Added an `Unreleased` section. Happy to drop / reformat if you'd rather land it under a different version.

## Tested manually

- macOS local build: `go build -tags sqlite_fts5 -o /tmp/wacli ./cmd/wacli` → `wacli messages download --help` shows correctly.
- linux/amd64 (glibc) build via `golang:1.25-bookworm` → deployed in a Debian 12 container, downloaded 4 real WhatsApp media messages (3 images, 1 video, 32 MB) from a group chat, all decrypted correctly.