### PR TITLE
feat: preserve interactive message buttons end-to-end

### DIFF
--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -393,6 +393,7 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 		FromMe:          pm.FromMe,
 		Text:            pm.Text,
 		DisplayText:     displayText,
+		Buttons:         waButtonsToStore(pm.Buttons),
 		IsForwarded:     pm.IsForwarded,
 		ForwardingScore: pm.ForwardingScore,
 		ReactionToID:    pm.ReactionToID,
@@ -421,6 +422,24 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 		})
 	}
 	return nil
+}
+
+func waButtonsToStore(buttons []wa.Button) []store.Button {
+	if len(buttons) == 0 {
+		return nil
+	}
+	out := make([]store.Button, len(buttons))
+	for i, b := range buttons {
+		out[i] = store.Button{
+			Type:        b.Type,
+			DisplayText: b.DisplayText,
+			ID:          b.ID,
+			URL:         b.URL,
+			PhoneNumber: b.PhoneNumber,
+			Description: b.Description,
+		}
+	}
+	return out
 }
 
 func (a *App) buildDisplayText(ctx context.Context, pm wa.ParsedMessage) string {

--- a/internal/store/lid_migration.go
+++ b/internal/store/lid_migration.go
@@ -151,7 +151,7 @@ func migrateLIDMessagesToPN(tx *sql.Tx, lidJID, pnJID string) error {
 			is_forwarded, forwarding_score, reaction_to_id, reaction_emoji,
 			media_type, media_caption, filename, mime_type, direct_path,
 			media_key, file_sha256, file_enc_sha256, file_length, local_path, downloaded_at,
-			revoked, deleted_for_me
+			revoked, deleted_for_me, buttons
 		)
 		SELECT
 			?,
@@ -179,7 +179,8 @@ func migrateLIDMessagesToPN(tx *sql.Tx, lidJID, pnJID string) error {
 			local_path,
 			downloaded_at,
 			revoked,
-			deleted_for_me
+			deleted_for_me,
+			buttons
 		FROM messages
 		WHERE chat_jid = ?
 		ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
@@ -206,7 +207,8 @@ func migrateLIDMessagesToPN(tx *sql.Tx, lidJID, pnJID string) error {
 			local_path = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE COALESCE(NULLIF(messages.local_path, ''), excluded.local_path) END,
 			downloaded_at = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN messages.downloaded_at IS NOT NULL AND messages.downloaded_at > 0 THEN messages.downloaded_at ELSE excluded.downloaded_at END,
 			revoked = CASE WHEN messages.revoked != 0 OR excluded.revoked != 0 THEN 1 ELSE 0 END,
-			deleted_for_me = CASE WHEN messages.deleted_for_me != 0 OR excluded.deleted_for_me != 0 THEN 1 ELSE 0 END
+			deleted_for_me = CASE WHEN messages.deleted_for_me != 0 OR excluded.deleted_for_me != 0 THEN 1 ELSE 0 END,
+			buttons = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE COALESCE(messages.buttons, excluded.buttons) END
 	`, pnJID, lidJID, pnJID, lidJID, DeletedForMeMessageDisplayText, DeletedMessageDisplayText); err != nil {
 		return fmt.Errorf("merge lid messages into pn chat: %w", err)
 	}

--- a/internal/store/lid_migration_test.go
+++ b/internal/store/lid_migration_test.go
@@ -164,3 +164,47 @@ func TestMigrateLIDToPNMergesChatsAndMessages(t *testing.T) {
 		t.Fatalf("HistoricalLIDJIDs after migrate = %#v, want none", lids)
 	}
 }
+
+func TestMigrateLIDToPNPreservesButtons(t *testing.T) {
+	db := openTestDB(t)
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	pn := "15551234567@s.whatsapp.net"
+	lid := "999123456789@lid"
+	if err := db.UpsertChat(lid, "dm", "Alice", base); err != nil {
+		t.Fatalf("UpsertChat lid: %v", err)
+	}
+
+	want := []Button{
+		{Type: "url", DisplayText: "Buy flights", URL: "https://example.com/flights"},
+		{Type: "quick_reply", DisplayText: "No thanks", ID: "no"},
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:   lid,
+		MsgID:     "tmpl1",
+		SenderJID: lid,
+		Timestamp: base,
+		Text:      "Check our deals",
+		Buttons:   want,
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	if err := db.MigrateLIDToPN(lid, pn); err != nil {
+		t.Fatalf("MigrateLIDToPN: %v", err)
+	}
+
+	msg, err := db.GetMessage(pn, "tmpl1")
+	if err != nil {
+		t.Fatalf("GetMessage after migration: %v", err)
+	}
+	if len(msg.Buttons) != len(want) {
+		t.Fatalf("expected %d buttons after migration, got %d: %+v", len(want), len(msg.Buttons), msg.Buttons)
+	}
+	for i, b := range want {
+		got := msg.Buttons[i]
+		if got.Type != b.Type || got.DisplayText != b.DisplayText || got.ID != b.ID || got.URL != b.URL {
+			t.Fatalf("button[%d]: got %+v, want %+v", i, got, b)
+		}
+	}
+}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -17,6 +18,7 @@ type UpsertMessageParams struct {
 	FromMe          bool
 	Text            string
 	DisplayText     string
+	Buttons         []Button
 	IsForwarded     bool
 	ForwardingScore uint32
 	ReactionToID    string
@@ -35,7 +37,7 @@ type UpsertMessageParams struct {
 }
 
 func messageSelectColumns(snippet string) string {
-	return fmt.Sprintf(`m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, %s`, snippetSQL(snippet))
+	return fmt.Sprintf(`m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), %s`, snippetSQL(snippet))
 }
 
 func snippetSQL(snippet string) string {
@@ -48,6 +50,7 @@ func snippetSQL(snippet string) string {
 func (d *DB) UpsertMessage(p UpsertMessageParams) error {
 	if p.Revoked || p.DeletedForMe {
 		p.Text = ""
+		p.Buttons = nil
 		if p.DeletedForMe {
 			p.DisplayText = DeletedForMeMessageDisplayText
 		} else {
@@ -63,13 +66,19 @@ func (d *DB) UpsertMessage(p UpsertMessageParams) error {
 		p.FileEncSHA256 = nil
 		p.FileLength = 0
 	}
+	var buttonsJSON interface{}
+	if len(p.Buttons) > 0 {
+		if b, err := json.Marshal(p.Buttons); err == nil {
+			buttonsJSON = string(b)
+		}
+	}
 	_, err := d.sql.Exec(`
 		INSERT INTO messages(
 			chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, display_text,
 			is_forwarded, forwarding_score, reaction_to_id, reaction_emoji,
 			media_type, media_caption, filename, mime_type, direct_path,
-			media_key, file_sha256, file_enc_sha256, file_length, revoked, deleted_for_me
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			media_key, file_sha256, file_enc_sha256, file_length, revoked, deleted_for_me, buttons
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
 			chat_name=COALESCE(NULLIF(excluded.chat_name,''), messages.chat_name),
 			sender_jid=excluded.sender_jid,
@@ -94,11 +103,13 @@ func (d *DB) UpsertMessage(p UpsertMessageParams) error {
 			local_path=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE messages.local_path END,
 			downloaded_at=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE messages.downloaded_at END,
 			revoked=CASE WHEN excluded.revoked != 0 THEN 1 ELSE messages.revoked END,
-			deleted_for_me=CASE WHEN excluded.deleted_for_me != 0 THEN 1 ELSE messages.deleted_for_me END
+			deleted_for_me=CASE WHEN excluded.deleted_for_me != 0 THEN 1 ELSE messages.deleted_for_me END,
+			buttons=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE excluded.buttons END
 	`, p.ChatJID, nullIfEmpty(p.ChatName), p.MsgID, nullIfEmpty(p.SenderJID), nullIfEmpty(p.SenderName), unix(p.Timestamp), boolToInt(p.FromMe), nullIfEmpty(p.Text), nullIfEmpty(p.DisplayText),
 		boolToInt(p.IsForwarded), int64(p.ForwardingScore), nullIfEmpty(p.ReactionToID), nullIfEmpty(p.ReactionEmoji),
 		nullIfEmpty(p.MediaType), nullIfEmpty(p.MediaCaption), nullIfEmpty(p.Filename), nullIfEmpty(p.MimeType), nullIfEmpty(p.DirectPath),
-		p.MediaKey, p.FileSHA256, p.FileEncSHA256, int64(p.FileLength), boolToInt(p.Revoked), boolToInt(p.DeletedForMe), DeletedForMeMessageDisplayText, DeletedMessageDisplayText,
+		p.MediaKey, p.FileSHA256, p.FileEncSHA256, int64(p.FileLength), boolToInt(p.Revoked), boolToInt(p.DeletedForMe), buttonsJSON,
+		DeletedForMeMessageDisplayText, DeletedMessageDisplayText,
 	)
 	return err
 }
@@ -315,7 +326,8 @@ func (d *DB) GetMessage(chatJID, msgID string) (Message, error) {
 	var starredAt int64
 	var revoked int
 	var deletedForMe int
-	if err := row.Scan(&m.rowID, &m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &m.SenderName, &ts, &fromMe, &m.Text, &m.DisplayText, &forwarded, &forwardingScore, &m.ReactionToID, &m.ReactionEmoji, &m.MediaType, &m.MediaCaption, &m.Filename, &m.MimeType, &m.DirectPath, &m.LocalPath, &downloadedAt, &starred, &starredAt, &revoked, &deletedForMe, &m.Snippet); err != nil {
+	var buttonsJSON string
+	if err := row.Scan(&m.rowID, &m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &m.SenderName, &ts, &fromMe, &m.Text, &m.DisplayText, &forwarded, &forwardingScore, &m.ReactionToID, &m.ReactionEmoji, &m.MediaType, &m.MediaCaption, &m.Filename, &m.MimeType, &m.DirectPath, &m.LocalPath, &downloadedAt, &starred, &starredAt, &revoked, &deletedForMe, &buttonsJSON, &m.Snippet); err != nil {
 		return Message{}, err
 	}
 	m.Timestamp = fromUnix(ts)
@@ -327,6 +339,9 @@ func (d *DB) GetMessage(chatJID, msgID string) (Message, error) {
 	m.StarredAt = fromUnix(starredAt)
 	m.Revoked = revoked != 0
 	m.DeletedForMe = deletedForMe != 0
+	if buttonsJSON != "" {
+		_ = json.Unmarshal([]byte(buttonsJSON), &m.Buttons)
+	}
 	return m, nil
 }
 
@@ -454,7 +469,8 @@ func (d *DB) scanMessages(query string, args ...interface{}) ([]Message, error) 
 		var starredAt int64
 		var revoked int
 		var deletedForMe int
-		if err := rows.Scan(&m.rowID, &m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &m.SenderName, &ts, &fromMe, &m.Text, &m.DisplayText, &forwarded, &forwardingScore, &m.ReactionToID, &m.ReactionEmoji, &m.MediaType, &m.MediaCaption, &m.Filename, &m.MimeType, &m.DirectPath, &m.LocalPath, &downloadedAt, &starred, &starredAt, &revoked, &deletedForMe, &m.Snippet); err != nil {
+		var buttonsJSON string
+		if err := rows.Scan(&m.rowID, &m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &m.SenderName, &ts, &fromMe, &m.Text, &m.DisplayText, &forwarded, &forwardingScore, &m.ReactionToID, &m.ReactionEmoji, &m.MediaType, &m.MediaCaption, &m.Filename, &m.MimeType, &m.DirectPath, &m.LocalPath, &downloadedAt, &starred, &starredAt, &revoked, &deletedForMe, &buttonsJSON, &m.Snippet); err != nil {
 			return nil, err
 		}
 		m.Timestamp = fromUnix(ts)
@@ -466,6 +482,9 @@ func (d *DB) scanMessages(query string, args ...interface{}) ([]Message, error) 
 		m.StarredAt = fromUnix(starredAt)
 		m.Revoked = revoked != 0
 		m.DeletedForMe = deletedForMe != 0
+		if buttonsJSON != "" {
+			_ = json.Unmarshal([]byte(buttonsJSON), &m.Buttons)
+		}
 		out = append(out, m)
 	}
 	return out, rows.Err()

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -120,6 +120,7 @@ func (d *DB) MarkMessageRevoked(chatJID, msgID string) error {
 		SET revoked = 1,
 		    text = NULL,
 		    display_text = ?,
+		    buttons = NULL,
 		    media_type = NULL,
 		    media_caption = NULL,
 		    filename = NULL,
@@ -159,6 +160,7 @@ func (d *DB) MarkMessageDeletedForMe(chatJID, msgID, senderJID string, fromMe bo
 		SET deleted_for_me = 1,
 		    text = NULL,
 		    display_text = ?,
+		    buttons = NULL,
 		    media_type = NULL,
 		    media_caption = NULL,
 		    filename = NULL,
@@ -193,6 +195,7 @@ func (d *DB) UpdateMessageText(chatJID, msgID, text string) error {
 		UPDATE messages
 		SET text = ?,
 		    display_text = ?,
+		    buttons = NULL,
 		    media_type = NULL,
 		    media_caption = NULL,
 		    filename = NULL,

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -582,6 +582,195 @@ func TestMessageDeletedForMeTombstoneIsHiddenFromListAndSearch(t *testing.T) {
 	}
 }
 
+func TestMessageButtonsRoundTrip(t *testing.T) {
+	db := openTestDB(t)
+
+	chat := "biz@s.whatsapp.net"
+	now := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	if err := db.UpsertChat(chat, "dm", "Biz", now); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+
+	buttons := []Button{
+		{Type: "url", DisplayText: "Buy flights", URL: "https://example.com/flights"},
+		{Type: "url", DisplayText: "Buy packages", URL: "https://example.com/packages"},
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:   chat,
+		MsgID:     "tmpl1",
+		SenderJID: chat,
+		Timestamp: now,
+		Text:      "Check our deals",
+		Buttons:   buttons,
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	msg, err := db.GetMessage(chat, "tmpl1")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if len(msg.Buttons) != 2 {
+		t.Fatalf("GetMessage: expected 2 buttons, got %d", len(msg.Buttons))
+	}
+	if msg.Buttons[0].Type != "url" || msg.Buttons[0].DisplayText != "Buy flights" || msg.Buttons[0].URL != "https://example.com/flights" {
+		t.Fatalf("GetMessage: unexpected button[0]: %+v", msg.Buttons[0])
+	}
+	if msg.Buttons[1].DisplayText != "Buy packages" {
+		t.Fatalf("GetMessage: unexpected button[1]: %+v", msg.Buttons[1])
+	}
+
+	msgs, err := db.ListMessages(ListMessagesParams{ChatJID: chat, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	if len(msgs) != 1 || len(msgs[0].Buttons) != 2 {
+		t.Fatalf("ListMessages: expected 1 message with 2 buttons, got %+v", msgs)
+	}
+}
+
+func TestMessageButtonsListRowRoundTrip(t *testing.T) {
+	db := openTestDB(t)
+
+	chat := "biz@s.whatsapp.net"
+	now := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	if err := db.UpsertChat(chat, "dm", "Biz", now); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+
+	buttons := []Button{
+		{Type: "list", DisplayText: "Options"},
+		{Type: "list_row", DisplayText: "Alice", ID: "alice", Description: "Send to Alice"},
+		{Type: "list_row", DisplayText: "Bob", ID: "bob"},
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:   chat,
+		MsgID:     "list1",
+		SenderJID: chat,
+		Timestamp: now,
+		Text:      "Who do you want to send money to?",
+		Buttons:   buttons,
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	msg, err := db.GetMessage(chat, "list1")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if len(msg.Buttons) != 3 {
+		t.Fatalf("expected 3 buttons, got %d: %+v", len(msg.Buttons), msg.Buttons)
+	}
+	if msg.Buttons[0].Type != "list" || msg.Buttons[0].DisplayText != "Options" {
+		t.Fatalf("unexpected list button: %+v", msg.Buttons[0])
+	}
+	if msg.Buttons[1].ID != "alice" || msg.Buttons[1].Description != "Send to Alice" {
+		t.Fatalf("unexpected row[0]: %+v", msg.Buttons[1])
+	}
+	if msg.Buttons[2].ID != "bob" || msg.Buttons[2].Description != "" {
+		t.Fatalf("unexpected row[1]: %+v", msg.Buttons[2])
+	}
+}
+
+func TestMessageButtonsClearedOnRevoke(t *testing.T) {
+	db := openTestDB(t)
+
+	chat := "biz@s.whatsapp.net"
+	now := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	if err := db.UpsertChat(chat, "dm", "Biz", now); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:   chat,
+		MsgID:     "m1",
+		SenderJID: chat,
+		Timestamp: now,
+		Text:      "hello",
+		Buttons:   []Button{{Type: "url", DisplayText: "Click", URL: "https://example.com"}},
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	if err := db.MarkMessageRevoked(chat, "m1"); err != nil {
+		t.Fatalf("MarkMessageRevoked: %v", err)
+	}
+
+	msg, err := db.GetMessage(chat, "m1")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if len(msg.Buttons) != 0 {
+		t.Fatalf("expected buttons cleared after revoke, got %+v", msg.Buttons)
+	}
+}
+
+func TestMessageButtonsClearedOnDeletedForMe(t *testing.T) {
+	db := openTestDB(t)
+
+	chat := "biz@s.whatsapp.net"
+	now := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	if err := db.UpsertChat(chat, "dm", "Biz", now); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:   chat,
+		MsgID:     "m1",
+		SenderJID: chat,
+		Timestamp: now,
+		Text:      "hello",
+		Buttons:   []Button{{Type: "quick_reply", DisplayText: "Yes", ID: "yes"}},
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	if err := db.MarkMessageDeletedForMe(chat, "m1", chat, false, now.Add(time.Second)); err != nil {
+		t.Fatalf("MarkMessageDeletedForMe: %v", err)
+	}
+
+	msg, err := db.GetMessage(chat, "m1")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if len(msg.Buttons) != 0 {
+		t.Fatalf("expected buttons cleared after deleted-for-me, got %+v", msg.Buttons)
+	}
+}
+
+func TestMessageButtonsClearedOnUpdateText(t *testing.T) {
+	db := openTestDB(t)
+
+	chat := "biz@s.whatsapp.net"
+	now := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	if err := db.UpsertChat(chat, "dm", "Biz", now); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:   chat,
+		MsgID:     "m1",
+		SenderJID: chat,
+		Timestamp: now,
+		Text:      "original",
+		Buttons:   []Button{{Type: "url", DisplayText: "Click", URL: "https://example.com"}},
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	if err := db.UpdateMessageText(chat, "m1", "edited"); err != nil {
+		t.Fatalf("UpdateMessageText: %v", err)
+	}
+
+	msg, err := db.GetMessage(chat, "m1")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if msg.Text != "edited" {
+		t.Fatalf("expected text=edited, got %q", msg.Text)
+	}
+	if len(msg.Buttons) != 0 {
+		t.Fatalf("expected buttons cleared after text edit, got %+v", msg.Buttons)
+	}
+}
+
 func TestUpdateMessageTextClearsMediaState(t *testing.T) {
 	db := openTestDB(t)
 

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -26,6 +26,7 @@ var schemaMigrations = []migration{
 	{version: 10, name: "chat state columns", up: migrateChatStateColumns},
 	{version: 11, name: "group hierarchy columns", up: migrateGroupHierarchyColumns},
 	{version: 12, name: "contacts system_name column", up: migrateContactsSystemNameColumn},
+	{version: 13, name: "messages buttons column", up: migrateMessagesButtonsColumn},
 }
 
 func (d *DB) ensureSchema() error {
@@ -234,6 +235,27 @@ func migrateGroupHierarchyColumns(d *DB) error {
 	}
 	if _, err := d.sql.Exec(`CREATE INDEX IF NOT EXISTS idx_groups_linked_parent_jid ON groups(linked_parent_jid)`); err != nil {
 		return fmt.Errorf("create groups linked-parent index: %w", err)
+	}
+	return nil
+}
+
+func migrateMessagesButtonsColumn(d *DB) error {
+	hasTable, err := d.tableExists("messages")
+	if err != nil {
+		return err
+	}
+	if !hasTable {
+		return nil
+	}
+	has, err := d.tableHasColumn("messages", "buttons")
+	if err != nil {
+		return err
+	}
+	if has {
+		return nil
+	}
+	if _, err := d.sql.Exec(`ALTER TABLE messages ADD COLUMN buttons TEXT`); err != nil {
+		return fmt.Errorf("add messages.buttons column: %w", err)
 	}
 	return nil
 }

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -86,6 +86,7 @@ const coreSchemaSQL = `
 		downloaded_at INTEGER,
 		revoked INTEGER NOT NULL DEFAULT 0,
 		deleted_for_me INTEGER NOT NULL DEFAULT 0,
+		buttons TEXT,
 		UNIQUE(chat_jid, msg_id),
 		FOREIGN KEY (chat_jid) REFERENCES chats(jid) ON DELETE CASCADE
 	);

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -56,6 +56,15 @@ type MediaDownloadInfo struct {
 	DownloadedAt  time.Time
 }
 
+type Button struct {
+	Type        string `json:"type"`
+	DisplayText string `json:"display_text"`
+	ID          string `json:"id,omitempty"`
+	URL         string `json:"url,omitempty"`
+	PhoneNumber string `json:"phone_number,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
 type Message struct {
 	ChatJID         string
 	ChatName        string
@@ -66,6 +75,7 @@ type Message struct {
 	FromMe          bool
 	Text            string
 	DisplayText     string
+	Buttons         []Button  `json:",omitempty"`
 	IsForwarded     bool
 	ForwardingScore uint32
 	ReactionToID    string

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -75,7 +75,7 @@ type Message struct {
 	FromMe          bool
 	Text            string
 	DisplayText     string
-	Buttons         []Button  `json:",omitempty"`
+	Buttons         []Button `json:",omitempty"`
 	IsForwarded     bool
 	ForwardingScore uint32
 	ReactionToID    string

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -21,6 +21,15 @@ type Media struct {
 	FileLength    uint64
 }
 
+type Button struct {
+	Type        string `json:"type"`
+	DisplayText string `json:"display_text"`
+	ID          string `json:"id,omitempty"`
+	URL         string `json:"url,omitempty"`
+	PhoneNumber string `json:"phone_number,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
 type ParsedMessage struct {
 	Chat            types.JID
 	ID              string
@@ -28,6 +37,7 @@ type ParsedMessage struct {
 	Timestamp       time.Time
 	FromMe          bool
 	Text            string
+	Buttons         []Button
 	Media           *Media
 	PushName        string
 	ReplyToID       string

--- a/internal/wa/messages_business.go
+++ b/internal/wa/messages_business.go
@@ -7,36 +7,75 @@ import (
 )
 
 func extractBusinessText(m *waProto.Message, pm *ParsedMessage) {
-	if tmpl := m.GetTemplateMessage(); tmpl != nil && pm.Text == "" {
+	if tmpl := m.GetTemplateMessage(); tmpl != nil {
 		if hydrated := hydratedTemplate(tmpl); hydrated != nil {
-			var parts []string
-			if t := strings.TrimSpace(hydrated.GetHydratedTitleText()); t != "" {
-				parts = append(parts, t)
+			if pm.Text == "" {
+				var parts []string
+				if t := strings.TrimSpace(hydrated.GetHydratedTitleText()); t != "" {
+					parts = append(parts, t)
+				}
+				if b := strings.TrimSpace(hydrated.GetHydratedContentText()); b != "" {
+					parts = append(parts, b)
+				}
+				if f := strings.TrimSpace(hydrated.GetHydratedFooterText()); f != "" {
+					parts = append(parts, "["+f+"]")
+				}
+				pm.Text = strings.Join(parts, "\n")
 			}
-			if b := strings.TrimSpace(hydrated.GetHydratedContentText()); b != "" {
-				parts = append(parts, b)
+			for _, hb := range hydrated.GetHydratedButtons() {
+				if btn := hb.GetUrlButton(); btn != nil {
+					pm.Buttons = append(pm.Buttons, Button{
+						Type:        "url",
+						DisplayText: strings.TrimSpace(btn.GetDisplayText()),
+						URL:         strings.TrimSpace(btn.GetURL()),
+					})
+				} else if btn := hb.GetQuickReplyButton(); btn != nil {
+					pm.Buttons = append(pm.Buttons, Button{
+						Type:        "quick_reply",
+						DisplayText: strings.TrimSpace(btn.GetDisplayText()),
+						ID:          strings.TrimSpace(btn.GetID()),
+					})
+				} else if btn := hb.GetCallButton(); btn != nil {
+					pm.Buttons = append(pm.Buttons, Button{
+						Type:        "call",
+						DisplayText: strings.TrimSpace(btn.GetDisplayText()),
+						PhoneNumber: strings.TrimSpace(btn.GetPhoneNumber()),
+					})
+				}
 			}
-			if f := strings.TrimSpace(hydrated.GetHydratedFooterText()); f != "" {
-				parts = append(parts, "["+f+"]")
-			}
-			pm.Text = strings.Join(parts, "\n")
 		} else if im := tmpl.GetInteractiveMessageTemplate(); im != nil {
-			pm.Text = interactiveText(im)
+			if pm.Text == "" {
+				pm.Text = interactiveText(im)
+			}
 		}
 	}
 
-	if btn := m.GetButtonsMessage(); btn != nil && pm.Text == "" {
-		var parts []string
-		if t := strings.TrimSpace(btn.GetText()); t != "" {
-			parts = append(parts, t)
+	if btn := m.GetButtonsMessage(); btn != nil {
+		if pm.Text == "" {
+			var parts []string
+			if t := strings.TrimSpace(btn.GetText()); t != "" {
+				parts = append(parts, t)
+			}
+			if b := strings.TrimSpace(btn.GetContentText()); b != "" {
+				parts = append(parts, b)
+			}
+			if f := strings.TrimSpace(btn.GetFooterText()); f != "" {
+				parts = append(parts, "["+f+"]")
+			}
+			pm.Text = strings.Join(parts, "\n")
 		}
-		if b := strings.TrimSpace(btn.GetContentText()); b != "" {
-			parts = append(parts, b)
+		for _, b := range btn.GetButtons() {
+			if bt := b.GetButtonText(); bt != nil {
+				dt := strings.TrimSpace(bt.GetDisplayText())
+				if dt != "" {
+					pm.Buttons = append(pm.Buttons, Button{
+						Type:        "quick_reply",
+						DisplayText: dt,
+						ID:          strings.TrimSpace(b.GetButtonID()),
+					})
+				}
+			}
 		}
-		if f := strings.TrimSpace(btn.GetFooterText()); f != "" {
-			parts = append(parts, "["+f+"]")
-		}
-		pm.Text = strings.Join(parts, "\n")
 	}
 
 	if resp := m.GetButtonsResponseMessage(); resp != nil && pm.Text == "" {
@@ -53,15 +92,34 @@ func extractBusinessText(m *waProto.Message, pm *ParsedMessage) {
 		}
 	}
 
-	if list := m.GetListMessage(); list != nil && pm.Text == "" {
-		var parts []string
-		if t := strings.TrimSpace(list.GetTitle()); t != "" {
-			parts = append(parts, t)
+	if list := m.GetListMessage(); list != nil {
+		if pm.Text == "" {
+			var parts []string
+			if t := strings.TrimSpace(list.GetTitle()); t != "" {
+				parts = append(parts, t)
+			}
+			if d := strings.TrimSpace(list.GetDescription()); d != "" {
+				parts = append(parts, d)
+			}
+			pm.Text = strings.Join(parts, "\n")
 		}
-		if d := strings.TrimSpace(list.GetDescription()); d != "" {
-			parts = append(parts, d)
+		if bt := strings.TrimSpace(list.GetButtonText()); bt != "" {
+			pm.Buttons = append(pm.Buttons, Button{Type: "list", DisplayText: bt})
 		}
-		pm.Text = strings.Join(parts, "\n")
+		for _, sec := range list.GetSections() {
+			for _, row := range sec.GetRows() {
+				dt := strings.TrimSpace(row.GetTitle())
+				if dt == "" {
+					continue
+				}
+				pm.Buttons = append(pm.Buttons, Button{
+					Type:        "list_row",
+					DisplayText: dt,
+					ID:          strings.TrimSpace(row.GetRowID()),
+					Description: strings.TrimSpace(row.GetDescription()),
+				})
+			}
+		}
 	}
 
 	if lr := m.GetListResponseMessage(); lr != nil && pm.Text == "" {

--- a/internal/wa/messages_test.go
+++ b/internal/wa/messages_test.go
@@ -326,6 +326,115 @@ func TestParseTemplateMessage(t *testing.T) {
 	if pm.Text != "Your appointment is confirmed\n[Reply STOP to opt out]" {
 		t.Fatalf("unexpected template text: %q", pm.Text)
 	}
+	if len(pm.Buttons) != 0 {
+		t.Fatalf("expected no buttons, got %d", len(pm.Buttons))
+	}
+}
+
+func TestParseTemplateMessageWithURLButtons(t *testing.T) {
+	chat, _ := types.ParseJID("123@s.whatsapp.net")
+	sender, _ := types.ParseJID("biz@s.whatsapp.net")
+
+	ev := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat: chat, Sender: sender, IsFromMe: false,
+			},
+			ID:        "tmpl2",
+			Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{
+			TemplateMessage: &waProto.TemplateMessage{
+				HydratedTemplate: &waProto.TemplateMessage_HydratedFourRowTemplate{
+					HydratedContentText: proto.String("Check out our deals"),
+					HydratedFooterText:  proto.String("Terms apply"),
+					HydratedButtons: []*waProto.HydratedTemplateButton{
+						{
+							HydratedButton: &waProto.HydratedTemplateButton_UrlButton{
+								UrlButton: &waProto.HydratedTemplateButton_HydratedURLButton{
+									DisplayText: proto.String("Buy flights"),
+									URL:         proto.String("https://example.com/flights"),
+								},
+							},
+						},
+						{
+							HydratedButton: &waProto.HydratedTemplateButton_UrlButton{
+								UrlButton: &waProto.HydratedTemplateButton_HydratedURLButton{
+									DisplayText: proto.String("Buy packages"),
+									URL:         proto.String("https://example.com/packages"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pm := ParseLiveMessage(ev)
+	if pm.Text != "Check out our deals\n[Terms apply]" {
+		t.Fatalf("unexpected template text: %q", pm.Text)
+	}
+	if len(pm.Buttons) != 2 {
+		t.Fatalf("expected 2 buttons, got %d", len(pm.Buttons))
+	}
+	if pm.Buttons[0].Type != "url" || pm.Buttons[0].DisplayText != "Buy flights" || pm.Buttons[0].URL != "https://example.com/flights" {
+		t.Fatalf("unexpected button[0]: %+v", pm.Buttons[0])
+	}
+	if pm.Buttons[1].Type != "url" || pm.Buttons[1].DisplayText != "Buy packages" || pm.Buttons[1].URL != "https://example.com/packages" {
+		t.Fatalf("unexpected button[1]: %+v", pm.Buttons[1])
+	}
+}
+
+func TestParseTemplateMessageWithMixedButtons(t *testing.T) {
+	chat, _ := types.ParseJID("123@s.whatsapp.net")
+	sender, _ := types.ParseJID("biz@s.whatsapp.net")
+
+	ev := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat: chat, Sender: sender, IsFromMe: false,
+			},
+			ID:        "tmpl3",
+			Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{
+			TemplateMessage: &waProto.TemplateMessage{
+				HydratedTemplate: &waProto.TemplateMessage_HydratedFourRowTemplate{
+					HydratedContentText: proto.String("Contact us"),
+					HydratedButtons: []*waProto.HydratedTemplateButton{
+						{
+							HydratedButton: &waProto.HydratedTemplateButton_QuickReplyButton{
+								QuickReplyButton: &waProto.HydratedTemplateButton_HydratedQuickReplyButton{
+									DisplayText: proto.String("Yes"),
+									ID:          proto.String("yes_id"),
+								},
+							},
+						},
+						{
+							HydratedButton: &waProto.HydratedTemplateButton_CallButton{
+								CallButton: &waProto.HydratedTemplateButton_HydratedCallButton{
+									DisplayText: proto.String("Call us"),
+									PhoneNumber: proto.String("+1234567890"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pm := ParseLiveMessage(ev)
+	if len(pm.Buttons) != 2 {
+		t.Fatalf("expected 2 buttons, got %d", len(pm.Buttons))
+	}
+	if pm.Buttons[0].Type != "quick_reply" || pm.Buttons[0].DisplayText != "Yes" || pm.Buttons[0].ID != "yes_id" {
+		t.Fatalf("unexpected quick_reply button: %+v", pm.Buttons[0])
+	}
+	if pm.Buttons[1].Type != "call" || pm.Buttons[1].DisplayText != "Call us" || pm.Buttons[1].PhoneNumber != "+1234567890" {
+		t.Fatalf("unexpected call button: %+v", pm.Buttons[1])
+	}
 }
 
 func TestParseButtonsMessage(t *testing.T) {
@@ -344,6 +453,20 @@ func TestParseButtonsMessage(t *testing.T) {
 			ButtonsMessage: &waProto.ButtonsMessage{
 				ContentText: proto.String("Pick an option"),
 				FooterText:  proto.String("Powered by Biz"),
+				Buttons: []*waProto.ButtonsMessage_Button{
+					{
+						ButtonID: proto.String("btn_a"),
+						ButtonText: &waProto.ButtonsMessage_Button_ButtonText{
+							DisplayText: proto.String("Option A"),
+						},
+					},
+					{
+						ButtonID: proto.String("btn_b"),
+						ButtonText: &waProto.ButtonsMessage_Button_ButtonText{
+							DisplayText: proto.String("Option B"),
+						},
+					},
+				},
 			},
 		},
 	}
@@ -351,6 +474,15 @@ func TestParseButtonsMessage(t *testing.T) {
 	pm := ParseLiveMessage(ev)
 	if pm.Text != "Pick an option\n[Powered by Biz]" {
 		t.Fatalf("unexpected buttons text: %q", pm.Text)
+	}
+	if len(pm.Buttons) != 2 {
+		t.Fatalf("expected 2 buttons, got %d", len(pm.Buttons))
+	}
+	if pm.Buttons[0].Type != "quick_reply" || pm.Buttons[0].DisplayText != "Option A" || pm.Buttons[0].ID != "btn_a" {
+		t.Fatalf("unexpected button[0]: %+v", pm.Buttons[0])
+	}
+	if pm.Buttons[1].Type != "quick_reply" || pm.Buttons[1].DisplayText != "Option B" || pm.Buttons[1].ID != "btn_b" {
+		t.Fatalf("unexpected button[1]: %+v", pm.Buttons[1])
 	}
 }
 
@@ -431,6 +563,16 @@ func TestParseListMessage(t *testing.T) {
 			ListMessage: &waProto.ListMessage{
 				Title:       proto.String("Menu"),
 				Description: proto.String("Choose an item"),
+				ButtonText:  proto.String("Options"),
+				Sections: []*waProto.ListMessage_Section{
+					{
+						Title: proto.String("Section 1"),
+						Rows: []*waProto.ListMessage_Row{
+							{Title: proto.String("Alice"), RowID: proto.String("alice"), Description: proto.String("Send to Alice")},
+							{Title: proto.String("Bob"), RowID: proto.String("bob")},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -438,6 +580,18 @@ func TestParseListMessage(t *testing.T) {
 	pm := ParseLiveMessage(ev)
 	if pm.Text != "Menu\nChoose an item" {
 		t.Fatalf("unexpected list text: %q", pm.Text)
+	}
+	if len(pm.Buttons) != 3 {
+		t.Fatalf("expected 3 buttons (1 list + 2 rows), got %d", len(pm.Buttons))
+	}
+	if pm.Buttons[0].Type != "list" || pm.Buttons[0].DisplayText != "Options" {
+		t.Fatalf("unexpected list button: %+v", pm.Buttons[0])
+	}
+	if pm.Buttons[1].Type != "list_row" || pm.Buttons[1].DisplayText != "Alice" || pm.Buttons[1].ID != "alice" || pm.Buttons[1].Description != "Send to Alice" {
+		t.Fatalf("unexpected row[0]: %+v", pm.Buttons[1])
+	}
+	if pm.Buttons[2].Type != "list_row" || pm.Buttons[2].DisplayText != "Bob" || pm.Buttons[2].ID != "bob" {
+		t.Fatalf("unexpected row[1]: %+v", pm.Buttons[2])
 	}
 }
 


### PR DESCRIPTION
⏺ Closes #223

  ## Summary

  `messages list --json` silently discarded interactive elements from WhatsApp Business message types. Text and display text were captured correctly, but buttons, URL actions, and list rows visible in the WhatsApp UI were dropped at the parser and never stored.

  This PR captures and stores them across the full pipeline: parser → store migration → JSON output. The `Buttons` field is omitted when empty so existing JSON responses are unaffected.

  ## Changes

  **Parser (`internal/wa`)**
  - Add `Button` struct: `type`, `display_text`, `id`, `url`, `phone_number`, `description`
  - Add `Buttons []Button` to `ParsedMessage`
  - `extractBusinessText` now populates buttons independently of the text guard for:
    - `TemplateMessage` (HydratedFourRowTemplate): `url`, `quick_reply`, `call` buttons via `GetHydratedButtons()`
    - `ButtonsMessage`: `quick_reply` buttons with ID via `GetButtons()`
    - `ListMessage`: list opener label via `GetButtonText()` + one `list_row` per row in `GetSections()`

  **Store (`internal/store`)**
  - Add `Button` struct and `Buttons []Button` to `Message`
  - Add `buttons TEXT` column to schema (migration #13, with table-existence guard for partial-schema test databases)
  - Serialize/deserialize buttons as JSON in `UpsertMessage`, `scanMessages`, and `GetMessage`
  - Fix `migrateLIDMessagesToPN`: add `buttons` to its hardcoded column list so interactive data is not dropped during LID→PN chat migration

  **Wire-up (`internal/app`)**
  - `waButtonsToStore` helper converts `[]wa.Button` → `[]store.Button` in `sync.go`

  ## Tests

  - `TestParseTemplateMessageWithURLButtons`: two URL buttons, display text and URL captured
  - `TestParseTemplateMessageWithMixedButtons`: quick-reply + call buttons
  - `TestParseButtonsMessage`: updated to assert button IDs and display text
  - `TestParseListMessage`: updated to assert list opener button + two list rows with ID and description

  ## Local testing

Built locally with `CGO_ENABLED=1 go build -tags sqlite_fts5 -o dist/wacli ./cmd/wacli` and verified against real WhatsApp Business messages