### PR TITLE
send: support ephemeral wrapping for text messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Send: add opt-in `send text --ephemeral` wrapping for disappearing-message chats. (#227 - thanks @AndroidPoet)
+
 ## 0.8.1 - 2026-05-08
 
 ### Changed

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -41,6 +41,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 	var replyTo string
 	var replyToSender string
 	var noPreview bool
+	var ephemeral bool
 	var messageEscapes bool
 	postSendWait := postSendRetryReceiptWait
 
@@ -76,6 +77,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 					ReplyTo:        replyTo,
 					ReplyToSender:  replyToSender,
 					NoPreview:      noPreview,
+					Ephemeral:      ephemeral,
 					PostSendWaitMS: durationMillis(postSendWait),
 				})
 				if delegated {
@@ -109,7 +111,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 
 			preview := fetchLinkPreview(ctx, message, noPreview)
 			msgID, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (types.MessageID, error) {
-				return sendTextMessage(ctx, a, toJID, message, replyTo, replyToSender, preview, mentionedJIDs)
+				return sendTextMessage(ctx, a, toJID, message, replyTo, replyToSender, preview, mentionedJIDs, ephemeral)
 			})
 			if err != nil {
 				return err
@@ -152,6 +154,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&replyTo, "reply-to", "", "message ID to quote/reply to")
 	cmd.Flags().StringVar(&replyToSender, "reply-to-sender", "", "sender JID of the quoted message (required for unsynced group replies)")
 	cmd.Flags().BoolVar(&noPreview, "no-preview", false, "disable automatic link previews for the first URL in text")
+	cmd.Flags().BoolVar(&ephemeral, "ephemeral", false, "wrap outgoing text in EphemeralMessage for disappearing-message chats")
 	cmd.Flags().BoolVar(&messageEscapes, "message-escapes", false, `interpret backslash escapes in --message (\n, \r, \t, \\, \")`)
 	cmd.Flags().DurationVar(&postSendWait, "post-send-wait", postSendRetryReceiptWait, "keep the connection alive after send so retry receipts can be handled (0 disables)")
 	return cmd
@@ -162,15 +165,29 @@ type sendTextApp interface {
 	DB() *store.DB
 }
 
-func sendTextMessage(ctx context.Context, a sendTextApp, to types.JID, text, replyTo, replyToSender string, preview *linkpreview.Preview, mentionedJIDs []string) (types.MessageID, error) {
+func sendTextMessage(ctx context.Context, a sendTextApp, to types.JID, text, replyTo, replyToSender string, preview *linkpreview.Preview, mentionedJIDs []string, ephemeral bool) (types.MessageID, error) {
 	msg, plainText, err := buildTextMessage(a.DB(), to, text, replyTo, replyToSender, preview, mentionedJIDs)
 	if err != nil {
 		return "", err
 	}
-	if plainText {
+	if plainText && !ephemeral {
 		return a.WA().SendText(ctx, to, text)
 	}
+	if plainText {
+		msg = &waProto.Message{Conversation: proto.String(text)}
+	}
+	if ephemeral {
+		msg = wrapEphemeralMessage(msg)
+	}
 	return a.WA().SendProtoMessage(ctx, to, msg)
+}
+
+func wrapEphemeralMessage(msg *waProto.Message) *waProto.Message {
+	return &waProto.Message{
+		EphemeralMessage: &waProto.FutureProofMessage{
+			Message: msg,
+		},
+	}
 }
 
 func fetchLinkPreview(ctx context.Context, text string, disabled bool) *linkpreview.Preview {

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -35,6 +35,7 @@ type sendDelegateRequest struct {
 	ReplyTo        string   `json:"reply_to,omitempty"`
 	ReplyToSender  string   `json:"reply_to_sender,omitempty"`
 	NoPreview      bool     `json:"no_preview,omitempty"`
+	Ephemeral      bool     `json:"ephemeral,omitempty"`
 	File           string   `json:"file,omitempty"`
 	Filename       string   `json:"filename,omitempty"`
 	Caption        string   `json:"caption,omitempty"`
@@ -210,7 +211,7 @@ func executeDelegatedText(ctx context.Context, a *app.App, req sendDelegateReque
 	}
 	preview := fetchLinkPreview(ctx, req.Message, req.NoPreview)
 	msgID, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (types.MessageID, error) {
-		return sendTextMessage(ctx, a, toJID, req.Message, req.ReplyTo, req.ReplyToSender, preview, mentionedJIDs)
+		return sendTextMessage(ctx, a, toJID, req.Message, req.ReplyTo, req.ReplyToSender, preview, mentionedJIDs, req.Ephemeral)
 	})
 	if err != nil {
 		return sendDelegateResponse{}, err

--- a/cmd/wacli/send_test.go
+++ b/cmd/wacli/send_test.go
@@ -284,6 +284,13 @@ func TestSendTextCommandExposesMessageEscapesFlag(t *testing.T) {
 	}
 }
 
+func TestSendTextCommandExposesEphemeralFlag(t *testing.T) {
+	cmd := newSendTextCmd(&rootFlags{})
+	if cmd.Flags().Lookup("ephemeral") == nil {
+		t.Fatalf("missing --ephemeral flag")
+	}
+}
+
 func TestSendTextCommandExposesMentionFlag(t *testing.T) {
 	cmd := newSendTextCmd(&rootFlags{})
 	if cmd.Flags().Lookup("mention") == nil {
@@ -346,6 +353,35 @@ func TestBuildTextMessageAttachesMentions(t *testing.T) {
 		t.Fatalf("mentioned JIDs = %v, want %v", got, mentions)
 	}
 }
+
+func TestSendTextMessageWrapsPlainTextAsEphemeralWhenRequested(t *testing.T) {
+	protoMsg := &waProto.Message{Conversation: strPtr("hello")}
+	wrapped := wrapEphemeralMessage(protoMsg)
+	if wrapped.GetEphemeralMessage().GetMessage().GetConversation() != "hello" {
+		t.Fatalf("ephemeral plain conversation not preserved")
+	}
+}
+
+func TestSendTextMessageWrapsExtendedTextAsEphemeralWhenRequested(t *testing.T) {
+	db := openSendTestDB(t)
+	chat := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+	preview := &linkpreview.Preview{URL: "https://example.com", Title: "Example"}
+
+	msg, plain, err := buildTextMessage(db, chat, "hello https://example.com", "", "", preview, nil)
+	if err != nil {
+		t.Fatalf("buildTextMessage: %v", err)
+	}
+	if plain || msg == nil || msg.GetExtendedTextMessage() == nil {
+		t.Fatalf("expected extended text path")
+	}
+
+	wrapped := wrapEphemeralMessage(msg)
+	if wrapped.GetEphemeralMessage().GetMessage().GetExtendedTextMessage() == nil {
+		t.Fatalf("extended text not preserved in ephemeral wrapper")
+	}
+}
+
+func strPtr(v string) *string { return &v }
 
 func TestBuildTextMessageCombinesReplyAndMentions(t *testing.T) {
 	db := openSendTestDB(t)

--- a/docs/send.md
+++ b/docs/send.md
@@ -9,7 +9,7 @@ When `sync --follow` is already running for the same store, send commands delega
 ## Commands
 
 ```bash
-wacli send text --to RECIPIENT --message TEXT [--message-escapes] [--pick N] [--mention USER] [--no-preview] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
+wacli send text --to RECIPIENT --message TEXT [--message-escapes] [--pick N] [--mention USER] [--no-preview] [--ephemeral] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send file --to RECIPIENT --file PATH [--pick N] [--caption TEXT] [--filename NAME] [--mime TYPE] [--ptt] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send sticker --to RECIPIENT --file PATH [--pick N] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send voice --to RECIPIENT --file PATH [--pick N] [--mime TYPE] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
@@ -29,6 +29,7 @@ wacli send react --to PHONE_OR_JID --id MSG_ID [--reaction TEXT] [--sender JID] 
 - `send text` fetches Open Graph metadata for the first `http://` or `https://` URL and sends it as a WhatsApp link preview.
 - Preview metadata fetches time out after 10 seconds and fall back to plain text.
 - Pass `--no-preview` to disable link-preview fetching.
+- Pass `--ephemeral` to wrap outgoing text in `EphemeralMessage` for disappearing-message chats.
 - `--message` is literal by default. Pass `--message-escapes` to interpret `\n`, `\r`, `\t`, `\\`, and `\"` before sending.
 - Use repeatable `--mention USER` with a phone number or user JID to add WhatsApp mentions to `send text`.
 - `--reply-to` quotes a stored message ID.
@@ -56,6 +57,7 @@ wacli send react --to PHONE_OR_JID --id MSG_ID [--reaction TEXT] [--sender JID] 
 
 ```bash
 wacli send text --to mom --message "landed"
+wacli send text --to mom --message "auto delete this" --ephemeral
 wacli send text --to mom --message "line1\nline2" --message-escapes
 wacli send text --to "Family" --pick 2 --message "on my way"
 wacli send text --to "Family" --message "hey @15551234567" --mention +15551234567


### PR DESCRIPTION
## Summary
Fixes `openclaw/wacli#224` by adding explicit ephemeral send support for `wacli send text`.

When users send into chats with disappearing messages enabled, WhatsApp expects outgoing payloads to be wrapped in `EphemeralMessage`. Without that wrapper, recipients see:

> "This message won't be deleted. The sender may be using an old version of WhatsApp."

This PR adds an explicit `--ephemeral` path so callers can force correct wrapping when needed.

## Root Cause
`wacli send text` previously sent:
- plain text via `SendText` (conversation payload), or
- rich text via `SendProtoMessage` (extended text payload)

Neither path wrapped outgoing messages in `EphemeralMessage`, so disappearing-mode chats could show the warning.

## What Changed
1. Added `--ephemeral` flag to `wacli send text`.
2. Updated send logic to:
- keep existing fast plain-text behavior when `--ephemeral` is not set,
- switch plain text to protobuf message when `--ephemeral` is set,
- wrap outgoing protobuf message in `EphemeralMessage` via a helper.
3. Extended delegated send IPC so `sync --follow` delegated sends also honor `--ephemeral`.
4. Updated docs and examples for the new flag.

## Files
- `cmd/wacli/send.go`
- `cmd/wacli/send_ipc.go`
- `cmd/wacli/send_test.go`
- `docs/send.md`

## Backward Compatibility
- No behavior change unless `--ephemeral` is explicitly provided.
- Existing `send text` workflows remain unchanged by default.

## Validation
Ran:
- `go test ./cmd/wacli`

Result:
- pass

## Why explicit flag first?
Issue #224 suggested either auto-detection or an opt-in flag. This PR implements the safe opt-in first with minimal risk and immediate user control. Auto-detection can be layered on top in a follow-up once chat timer state retrieval is standardized across DM/group contexts.

Closes #224.
