### PR TITLE
docs: add interactive buttons changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Send: add opt-in `send text --ephemeral` wrapping for disappearing-message chats. (#227 - thanks @AndroidPoet)
 
+### Fixed
+
+- Messages: preserve WhatsApp Business buttons and list options in JSON output. (#226 - thanks @ignaciovarela)
+
 ## 0.8.1 - 2026-05-08
 
 ### Changed


### PR DESCRIPTION
## Summary

Adds the missing `Unreleased` changelog entry for #226, which preserved WhatsApp Business buttons and list options in JSON output.

## Notes

This follows the current changelog format and credits @ignaciovarela for the original PR.

## Validation

- `pnpm format:check`
- `git diff --check`
