### PR TITLE
feat: implement WhatsApp polls (send/vote/decrypt/query)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Docker: add a local image with `/data` persistence, bundled `ffmpeg`, and Docker CI smoke coverage.
+- Polls: add sending, voting, local result inspection, and sync persistence for WhatsApp polls. (#230 - thanks @Ortes)
 - Send: add opt-in `send text --ephemeral` wrapping for disappearing-message chats. (#227 - thanks @AndroidPoet)
 
 ### Security

--- a/cmd/wacli/poll_cmd.go
+++ b/cmd/wacli/poll_cmd.go
@@ -262,6 +262,7 @@ func buildPollVoteInfo(a *app.App, chat types.JID, pollMsgID, senderOverride str
 			Chat:     chat,
 			Sender:   senderJID,
 			IsFromMe: fromMe,
+			IsGroup:  chat.Server == types.GroupServer,
 		},
 		ID:        pollMsgID,
 		Timestamp: ts,

--- a/cmd/wacli/poll_cmd.go
+++ b/cmd/wacli/poll_cmd.go
@@ -101,7 +101,7 @@ func newPollVoteCmd(flags *rootFlags) *cobra.Command {
 			}
 			toJID = warmupRecipient(ctx, a.WA(), toJID, os.Stderr)
 
-			info, knownOptions, selectableCount, err := buildPollVoteInfo(a, toJID, msgID, senderOverride)
+			info, knownOptions, selectableCount, err := buildPollVoteInfo(ctx, a, toJID, msgID, senderOverride)
 			if err != nil {
 				return err
 			}
@@ -194,8 +194,8 @@ func requirePollSelectableCount(selectable uint32, requested []string) error {
 // buildPollVoteInfo resolves the MessageInfo whatsmeow needs to encrypt the
 // vote. Looks up the poll in the local store first; falls back to manually
 // supplied --sender for unknown polls.
-func buildPollVoteInfo(a *app.App, chat types.JID, pollMsgID, senderOverride string) (*types.MessageInfo, []string, uint32, error) {
-	chatJID := chat.String()
+func buildPollVoteInfo(ctx context.Context, a *app.App, chat types.JID, pollMsgID, senderOverride string) (*types.MessageInfo, []string, uint32, error) {
+	chatJID := pollStoreLookupJID(ctx, a, chat).String()
 
 	var (
 		senderJID       types.JID
@@ -259,7 +259,7 @@ func buildPollVoteInfo(a *app.App, chat types.JID, pollMsgID, senderOverride str
 
 	if senderJID.IsEmpty() {
 		// 1:1 DMs: the chat itself is the sender unless we sent the poll.
-		if chat.Server == types.DefaultUserServer {
+		if chat.Server == types.DefaultUserServer || chat.Server == types.HiddenUserServer {
 			senderJID = chat
 		} else if chat.Server == types.GroupServer {
 			return nil, knownOptions, selectableCount, fmt.Errorf("poll %s is not in the local store; pass --sender <JID> to vote", pollMsgID)
@@ -280,6 +280,16 @@ func buildPollVoteInfo(a *app.App, chat types.JID, pollMsgID, senderOverride str
 		Timestamp: ts,
 	}
 	return info, knownOptions, selectableCount, nil
+}
+
+func pollStoreLookupJID(ctx context.Context, a *app.App, jid types.JID) types.JID {
+	if a != nil && a.WA() != nil {
+		jid = a.WA().ResolveLIDToPN(ctx, jid)
+	}
+	if jid.Server == types.DefaultUserServer {
+		return jid.ToNonAD()
+	}
+	return jid
 }
 
 func persistOutboundVote(ctx context.Context, a *app.App, chat types.JID, pollMsgID, voteMsgID string, options []string, now time.Time) {
@@ -321,7 +331,7 @@ func executeDelegatedPollVote(ctx context.Context, a *app.App, req sendDelegateR
 		return sendDelegateResponse{}, err
 	}
 	toJID = warmupDelegatedRecipient(ctx, a, toJID)
-	info, knownOptions, selectableCount, err := buildPollVoteInfo(a, toJID, req.ID, req.Sender)
+	info, knownOptions, selectableCount, err := buildPollVoteInfo(ctx, a, toJID, req.ID, req.Sender)
 	if err != nil {
 		return sendDelegateResponse{}, err
 	}

--- a/cmd/wacli/poll_cmd.go
+++ b/cmd/wacli/poll_cmd.go
@@ -102,7 +102,7 @@ func newPollVoteCmd(flags *rootFlags) *cobra.Command {
 			}
 			toJID = warmupRecipient(ctx, a.WA(), toJID, os.Stderr)
 
-			info, knownOptions, selectableCount, err := buildPollVoteInfo(ctx, a, toJID, msgID, senderOverride)
+			info, knownOptions, selectableCount, pollChatJID, err := buildPollVoteInfo(ctx, a, toJID, msgID, senderOverride)
 			if err != nil {
 				return err
 			}
@@ -126,7 +126,7 @@ func newPollVoteCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			now := time.Now().UTC()
-			persistOutboundVote(ctx, a, toJID, msgID, string(sentID), cleaned, now)
+			persistOutboundVote(ctx, a, toJID, pollChatJID, msgID, string(sentID), cleaned, now)
 			waitForPostSendRetryReceipts(ctx, postSendWait)
 
 			if flags.asJSON {
@@ -195,8 +195,18 @@ func requirePollSelectableCount(selectable uint32, requested []string) error {
 // buildPollVoteInfo resolves the MessageInfo whatsmeow needs to encrypt the
 // vote. Looks up the poll in the local store first; falls back to manually
 // supplied --sender for unknown polls.
-func buildPollVoteInfo(ctx context.Context, a *app.App, chat types.JID, pollMsgID, senderOverride string) (*types.MessageInfo, []string, uint32, error) {
-	chatJID := pollStoreLookupJID(ctx, a, chat).String()
+func buildPollVoteInfo(ctx context.Context, a *app.App, chat types.JID, pollMsgID, senderOverride string) (*types.MessageInfo, []string, uint32, string, error) {
+	return buildPollVoteInfoForChats(ctx, a, chat, pollChatJIDCandidates(ctx, a, chat), pollMsgID, senderOverride)
+}
+
+func buildPollVoteInfoForChats(ctx context.Context, a *app.App, chat types.JID, chatJIDs []string, pollMsgID, senderOverride string) (*types.MessageInfo, []string, uint32, string, error) {
+	chatJID := ""
+	if len(chatJIDs) > 0 {
+		chatJID = chatJIDs[0]
+	}
+	if chatJID == "" {
+		chatJID = canonicalMessageFilterJID(chat).String()
+	}
 
 	var (
 		senderJID       types.JID
@@ -208,15 +218,31 @@ func buildPollVoteInfo(ctx context.Context, a *app.App, chat types.JID, pollMsgI
 	if pollSenderRaw != "" {
 		jid, err := wa.ParseUserOrJID(pollSenderRaw)
 		if err != nil {
-			return nil, nil, 0, fmt.Errorf("invalid --sender: %w", err)
+			return nil, nil, 0, "", fmt.Errorf("invalid --sender: %w", err)
 		}
 		senderJID = jid
 	}
 
 	fromMe := false
-	poll, err := a.DB().GetPoll(chatJID, pollMsgID)
-	switch {
-	case err == nil:
+	var poll store.Poll
+	pollFound := false
+	for _, candidate := range chatJIDs {
+		p, err := a.DB().GetPoll(candidate, pollMsgID)
+		switch {
+		case err == nil:
+			poll = p
+			pollFound = true
+			chatJID = poll.ChatJID
+		case errors.Is(err, sql.ErrNoRows):
+			continue
+		default:
+			return nil, nil, 0, "", fmt.Errorf("lookup poll: %w", err)
+		}
+		if pollFound {
+			break
+		}
+	}
+	if pollFound {
 		knownOptions = append([]string(nil), poll.Options...)
 		selectableCount = poll.SelectableCount
 		if senderJID.IsEmpty() && strings.TrimSpace(poll.SenderJID) != "" {
@@ -225,10 +251,6 @@ func buildPollVoteInfo(ctx context.Context, a *app.App, chat types.JID, pollMsgI
 			}
 		}
 		ts = poll.CreatedAt
-	case errors.Is(err, sql.ErrNoRows):
-		// Fine if the user supplied --sender (and this is a DM, or a group with override).
-	default:
-		return nil, nil, 0, fmt.Errorf("lookup poll: %w", err)
 	}
 
 	// Look up the original poll message to recover IsFromMe (and fall back
@@ -244,7 +266,7 @@ func buildPollVoteInfo(ctx context.Context, a *app.App, chat types.JID, pollMsgI
 			ts = msg.Timestamp
 		}
 	} else if !errors.Is(merr, sql.ErrNoRows) {
-		return nil, nil, 0, fmt.Errorf("lookup poll message: %w", merr)
+		return nil, nil, 0, "", fmt.Errorf("lookup poll message: %w", merr)
 	}
 
 	// If we sent the poll, the encrypted secret was stored against our own
@@ -263,7 +285,7 @@ func buildPollVoteInfo(ctx context.Context, a *app.App, chat types.JID, pollMsgI
 		if chat.Server == types.DefaultUserServer || chat.Server == types.HiddenUserServer {
 			senderJID = chat
 		} else if chat.Server == types.GroupServer {
-			return nil, knownOptions, selectableCount, fmt.Errorf("poll %s is not in the local store; pass --sender <JID> to vote", pollMsgID)
+			return nil, knownOptions, selectableCount, "", fmt.Errorf("poll %s is not in the local store; pass --sender <JID> to vote", pollMsgID)
 		}
 	}
 
@@ -280,17 +302,7 @@ func buildPollVoteInfo(ctx context.Context, a *app.App, chat types.JID, pollMsgI
 		ID:        pollMsgID,
 		Timestamp: ts,
 	}
-	return info, knownOptions, selectableCount, nil
-}
-
-func pollStoreLookupJID(ctx context.Context, a *app.App, jid types.JID) types.JID {
-	if a != nil && a.WA() != nil {
-		jid = a.WA().ResolveLIDToPN(ctx, jid)
-	}
-	if jid.Server == types.DefaultUserServer {
-		return jid.ToNonAD()
-	}
-	return jid
+	return info, knownOptions, selectableCount, chatJID, nil
 }
 
 func primaryPollChatJID(ctx context.Context, a *app.App, jid types.JID) string {
@@ -321,8 +333,10 @@ func pollChatJIDCandidates(ctx context.Context, a *app.App, jid types.JID) []str
 	return jidStrings(jids)
 }
 
-func persistOutboundVote(ctx context.Context, a *app.App, chat types.JID, pollMsgID, voteMsgID string, options []string, now time.Time) {
-	chatJID := primaryPollChatJID(ctx, a, chat)
+func persistOutboundVote(ctx context.Context, a *app.App, chat types.JID, chatJID, pollMsgID, voteMsgID string, options []string, now time.Time) {
+	if strings.TrimSpace(chatJID) == "" {
+		chatJID = primaryPollChatJID(ctx, a, chat)
+	}
 	chatName := a.WA().ResolveChatName(ctx, chat, "")
 	_ = a.DB().UpsertChat(chatJID, chatKindFromJID(chat), chatName, now)
 	_ = a.DB().UpsertMessage(store.UpsertMessageParams{
@@ -361,7 +375,7 @@ func executeDelegatedPollVote(ctx context.Context, a *app.App, req sendDelegateR
 		return sendDelegateResponse{}, err
 	}
 	toJID = warmupDelegatedRecipient(ctx, a, toJID)
-	info, knownOptions, selectableCount, err := buildPollVoteInfo(ctx, a, toJID, req.ID, req.Sender)
+	info, knownOptions, selectableCount, pollChatJID, err := buildPollVoteInfo(ctx, a, toJID, req.ID, req.Sender)
 	if err != nil {
 		return sendDelegateResponse{}, err
 	}
@@ -383,7 +397,7 @@ func executeDelegatedPollVote(ctx context.Context, a *app.App, req sendDelegateR
 		return sendDelegateResponse{}, err
 	}
 	now := time.Now().UTC()
-	persistOutboundVote(ctx, a, toJID, req.ID, string(sentID), cleaned, now)
+	persistOutboundVote(ctx, a, toJID, pollChatJID, req.ID, string(sentID), cleaned, now)
 	waitForPostSendRetryReceipts(ctx, millisDuration(req.PostSendWaitMS, 0))
 	return sendDelegateResponse{
 		OK:       true,
@@ -592,7 +606,7 @@ func newPollsListCmd(flags *rootFlags) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				filter.ChatJID = primaryPollChatJID(ctx, a, toJID)
+				filter.ChatJIDs = pollChatJIDCandidates(ctx, a, toJID)
 			}
 			polls, err := a.DB().ListPolls(filter)
 			if err != nil {

--- a/cmd/wacli/poll_cmd.go
+++ b/cmd/wacli/poll_cmd.go
@@ -99,6 +99,7 @@ func newPollVoteCmd(flags *rootFlags) *cobra.Command {
 			if err := a.Connect(ctx, false, nil); err != nil {
 				return err
 			}
+			toJID = warmupRecipient(ctx, a.WA(), toJID, os.Stderr)
 
 			info, knownOptions, err := buildPollVoteInfo(a, toJID, msgID, senderOverride)
 			if err != nil {
@@ -306,6 +307,7 @@ func executeDelegatedPollVote(ctx context.Context, a *app.App, req sendDelegateR
 	if err != nil {
 		return sendDelegateResponse{}, err
 	}
+	toJID = warmupDelegatedRecipient(ctx, a, toJID)
 	info, knownOptions, err := buildPollVoteInfo(a, toJID, req.ID, req.Sender)
 	if err != nil {
 		return sendDelegateResponse{}, err

--- a/cmd/wacli/poll_cmd.go
+++ b/cmd/wacli/poll_cmd.go
@@ -101,12 +101,15 @@ func newPollVoteCmd(flags *rootFlags) *cobra.Command {
 			}
 			toJID = warmupRecipient(ctx, a.WA(), toJID, os.Stderr)
 
-			info, knownOptions, err := buildPollVoteInfo(a, toJID, msgID, senderOverride)
+			info, knownOptions, selectableCount, err := buildPollVoteInfo(a, toJID, msgID, senderOverride)
 			if err != nil {
 				return err
 			}
 			if knownOptions != nil {
 				if err := requirePollOptionsExist(knownOptions, cleaned); err != nil {
+					return err
+				}
+				if err := requirePollSelectableCount(selectableCount, cleaned); err != nil {
 					return err
 				}
 			}
@@ -181,22 +184,30 @@ func requirePollOptionsExist(known, requested []string) error {
 	return nil
 }
 
+func requirePollSelectableCount(selectable uint32, requested []string) error {
+	if selectable == 0 || len(requested) <= int(selectable) {
+		return nil
+	}
+	return fmt.Errorf("poll allows at most %d option(s); got %d", selectable, len(requested))
+}
+
 // buildPollVoteInfo resolves the MessageInfo whatsmeow needs to encrypt the
 // vote. Looks up the poll in the local store first; falls back to manually
 // supplied --sender for unknown polls.
-func buildPollVoteInfo(a *app.App, chat types.JID, pollMsgID, senderOverride string) (*types.MessageInfo, []string, error) {
+func buildPollVoteInfo(a *app.App, chat types.JID, pollMsgID, senderOverride string) (*types.MessageInfo, []string, uint32, error) {
 	chatJID := chat.String()
 
 	var (
-		senderJID    types.JID
-		knownOptions []string
-		ts           time.Time
+		senderJID       types.JID
+		knownOptions    []string
+		selectableCount uint32
+		ts              time.Time
 	)
 	pollSenderRaw := strings.TrimSpace(senderOverride)
 	if pollSenderRaw != "" {
 		jid, err := wa.ParseUserOrJID(pollSenderRaw)
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid --sender: %w", err)
+			return nil, nil, 0, fmt.Errorf("invalid --sender: %w", err)
 		}
 		senderJID = jid
 	}
@@ -206,6 +217,7 @@ func buildPollVoteInfo(a *app.App, chat types.JID, pollMsgID, senderOverride str
 	switch {
 	case err == nil:
 		knownOptions = append([]string(nil), poll.Options...)
+		selectableCount = poll.SelectableCount
 		if senderJID.IsEmpty() && strings.TrimSpace(poll.SenderJID) != "" {
 			if jid, perr := types.ParseJID(poll.SenderJID); perr == nil {
 				senderJID = jid
@@ -215,7 +227,7 @@ func buildPollVoteInfo(a *app.App, chat types.JID, pollMsgID, senderOverride str
 	case errors.Is(err, sql.ErrNoRows):
 		// Fine if the user supplied --sender (and this is a DM, or a group with override).
 	default:
-		return nil, nil, fmt.Errorf("lookup poll: %w", err)
+		return nil, nil, 0, fmt.Errorf("lookup poll: %w", err)
 	}
 
 	// Look up the original poll message to recover IsFromMe (and fall back
@@ -231,7 +243,7 @@ func buildPollVoteInfo(a *app.App, chat types.JID, pollMsgID, senderOverride str
 			ts = msg.Timestamp
 		}
 	} else if !errors.Is(merr, sql.ErrNoRows) {
-		return nil, nil, fmt.Errorf("lookup poll message: %w", merr)
+		return nil, nil, 0, fmt.Errorf("lookup poll message: %w", merr)
 	}
 
 	// If we sent the poll, the encrypted secret was stored against our own
@@ -250,7 +262,7 @@ func buildPollVoteInfo(a *app.App, chat types.JID, pollMsgID, senderOverride str
 		if chat.Server == types.DefaultUserServer {
 			senderJID = chat
 		} else if chat.Server == types.GroupServer {
-			return nil, knownOptions, fmt.Errorf("poll %s is not in the local store; pass --sender <JID> to vote", pollMsgID)
+			return nil, knownOptions, selectableCount, fmt.Errorf("poll %s is not in the local store; pass --sender <JID> to vote", pollMsgID)
 		}
 	}
 
@@ -267,7 +279,7 @@ func buildPollVoteInfo(a *app.App, chat types.JID, pollMsgID, senderOverride str
 		ID:        pollMsgID,
 		Timestamp: ts,
 	}
-	return info, knownOptions, nil
+	return info, knownOptions, selectableCount, nil
 }
 
 func persistOutboundVote(ctx context.Context, a *app.App, chat types.JID, pollMsgID, voteMsgID string, options []string, now time.Time) {
@@ -309,12 +321,15 @@ func executeDelegatedPollVote(ctx context.Context, a *app.App, req sendDelegateR
 		return sendDelegateResponse{}, err
 	}
 	toJID = warmupDelegatedRecipient(ctx, a, toJID)
-	info, knownOptions, err := buildPollVoteInfo(a, toJID, req.ID, req.Sender)
+	info, knownOptions, selectableCount, err := buildPollVoteInfo(a, toJID, req.ID, req.Sender)
 	if err != nil {
 		return sendDelegateResponse{}, err
 	}
 	if knownOptions != nil {
 		if err := requirePollOptionsExist(knownOptions, cleaned); err != nil {
+			return sendDelegateResponse{}, err
+		}
+		if err := requirePollSelectableCount(selectableCount, cleaned); err != nil {
 			return sendDelegateResponse{}, err
 		}
 	}

--- a/cmd/wacli/poll_cmd.go
+++ b/cmd/wacli/poll_cmd.go
@@ -1,0 +1,583 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/openclaw/wacli/internal/app"
+	"github.com/openclaw/wacli/internal/out"
+	"github.com/openclaw/wacli/internal/store"
+	"github.com/openclaw/wacli/internal/wa"
+	"github.com/spf13/cobra"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func newPollCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "poll",
+		Short: "Vote on or inspect a poll",
+	}
+	cmd.AddCommand(newPollVoteCmd(flags))
+	cmd.AddCommand(newPollShowCmd(flags))
+	return cmd
+}
+
+func newPollsCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "polls",
+		Short: "List polls",
+	}
+	cmd.AddCommand(newPollsListCmd(flags))
+	return cmd
+}
+
+// ---- vote -----------------------------------------------------------------
+
+type pollVoteSender interface {
+	SendPollVote(ctx context.Context, pollInfo *types.MessageInfo, options []string) (types.MessageID, error)
+}
+
+func newPollVoteCmd(flags *rootFlags) *cobra.Command {
+	var to string
+	var pick int
+	var msgID string
+	var voteOptions []string
+	var senderOverride string
+	postSendWait := postSendRetryReceiptWait
+
+	cmd := &cobra.Command{
+		Use:   "vote",
+		Short: "Vote on a poll",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(to) == "" || strings.TrimSpace(msgID) == "" {
+				return fmt.Errorf("--to and --id are required")
+			}
+			cleaned, err := cleanVoteOptions(voteOptions)
+			if err != nil {
+				return err
+			}
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				resp, delegated, delegateErr := tryDelegateSend(ctx, flags, err, sendDelegateRequest{
+					Kind:           "poll_vote",
+					To:             to,
+					Pick:           pick,
+					ID:             msgID,
+					Sender:         senderOverride,
+					Options:        cleaned,
+					PostSendWaitMS: durationMillis(postSendWait),
+				})
+				if delegated {
+					if delegateErr != nil {
+						return delegateErr
+					}
+					return writeDelegatedSendOutput(flags, "poll_vote", resp)
+				}
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			toJID, err := resolveRecipient(a, to, recipientOptions{pick: pick, asJSON: flags.asJSON})
+			if err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+
+			info, knownOptions, err := buildPollVoteInfo(a, toJID, msgID, senderOverride)
+			if err != nil {
+				return err
+			}
+			if knownOptions != nil {
+				if err := requirePollOptionsExist(knownOptions, cleaned); err != nil {
+					return err
+				}
+			}
+			if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
+				return err
+			}
+
+			sentID, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (types.MessageID, error) {
+				return a.WA().SendPollVote(ctx, info, cleaned)
+			})
+			if err != nil {
+				return err
+			}
+
+			now := time.Now().UTC()
+			persistOutboundVote(ctx, a, toJID, msgID, string(sentID), cleaned, now)
+			waitForPostSendRetryReceipts(ctx, postSendWait)
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"sent":     true,
+					"to":       toJID.String(),
+					"id":       string(sentID),
+					"target":   msgID,
+					"selected": cleaned,
+				})
+			}
+			fmt.Fprintf(os.Stdout, "Voted on %s in %s (id %s)\n", msgID, toJID.String(), sentID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&to, "to", "", "chat JID, phone number, or contact/group/chat name where the poll lives")
+	cmd.Flags().IntVar(&pick, "pick", 0, "when --to is ambiguous, pick the Nth match (1-indexed)")
+	cmd.Flags().StringVar(&msgID, "id", "", "poll message ID (the original PollCreationMessage)")
+	cmd.Flags().StringArrayVar(&voteOptions, "option", nil, "option to vote for (repeat for multi-select)")
+	cmd.Flags().StringVar(&senderOverride, "sender", "", "JID of the poll author (required for groups when the poll is not in the local store)")
+	cmd.Flags().DurationVar(&postSendWait, "post-send-wait", postSendRetryReceiptWait, "keep the connection alive after send so retry receipts can be handled (0 disables)")
+	return cmd
+}
+
+func cleanVoteOptions(opts []string) ([]string, error) {
+	cleaned := make([]string, 0, len(opts))
+	seen := make(map[string]struct{}, len(opts))
+	for _, opt := range opts {
+		opt = strings.TrimSpace(opt)
+		if opt == "" {
+			continue
+		}
+		if _, dup := seen[opt]; dup {
+			continue
+		}
+		seen[opt] = struct{}{}
+		cleaned = append(cleaned, opt)
+	}
+	if len(cleaned) == 0 {
+		return nil, fmt.Errorf("at least one --option is required (use --option \"\" to retract a vote is not supported)")
+	}
+	return cleaned, nil
+}
+
+func requirePollOptionsExist(known, requested []string) error {
+	set := make(map[string]struct{}, len(known))
+	for _, k := range known {
+		set[k] = struct{}{}
+	}
+	for _, opt := range requested {
+		if _, ok := set[opt]; !ok {
+			return fmt.Errorf("option %q is not part of the poll (known: %s)", opt, strings.Join(known, ", "))
+		}
+	}
+	return nil
+}
+
+// buildPollVoteInfo resolves the MessageInfo whatsmeow needs to encrypt the
+// vote. Looks up the poll in the local store first; falls back to manually
+// supplied --sender for unknown polls.
+func buildPollVoteInfo(a *app.App, chat types.JID, pollMsgID, senderOverride string) (*types.MessageInfo, []string, error) {
+	chatJID := chat.String()
+
+	var (
+		senderJID    types.JID
+		knownOptions []string
+		ts           time.Time
+	)
+	pollSenderRaw := strings.TrimSpace(senderOverride)
+	if pollSenderRaw != "" {
+		jid, err := wa.ParseUserOrJID(pollSenderRaw)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid --sender: %w", err)
+		}
+		senderJID = jid
+	}
+
+	fromMe := false
+	poll, err := a.DB().GetPoll(chatJID, pollMsgID)
+	switch {
+	case err == nil:
+		knownOptions = append([]string(nil), poll.Options...)
+		if senderJID.IsEmpty() && strings.TrimSpace(poll.SenderJID) != "" {
+			if jid, perr := types.ParseJID(poll.SenderJID); perr == nil {
+				senderJID = jid
+			}
+		}
+		ts = poll.CreatedAt
+	case errors.Is(err, sql.ErrNoRows):
+		// Fine if the user supplied --sender (and this is a DM, or a group with override).
+	default:
+		return nil, nil, fmt.Errorf("lookup poll: %w", err)
+	}
+
+	// Look up the original poll message to recover IsFromMe (and fall back
+	// for sender / timestamp if the poll row didn't carry them).
+	if msg, merr := a.DB().GetMessage(chatJID, pollMsgID); merr == nil {
+		fromMe = msg.FromMe
+		if senderJID.IsEmpty() && strings.TrimSpace(msg.SenderJID) != "" {
+			if jid, perr := types.ParseJID(msg.SenderJID); perr == nil {
+				senderJID = jid
+			}
+		}
+		if ts.IsZero() {
+			ts = msg.Timestamp
+		}
+	} else if !errors.Is(merr, sql.ErrNoRows) {
+		return nil, nil, fmt.Errorf("lookup poll message: %w", merr)
+	}
+
+	// If we sent the poll, the encrypted secret was stored against our own
+	// JID rather than against the recipient. Use the linked JID as sender
+	// so BuildPollVote can find the message secret and set the right key.
+	if fromMe && senderJID.IsEmpty() {
+		if linked := strings.TrimSpace(a.WA().LinkedJID()); linked != "" {
+			if jid, perr := types.ParseJID(linked); perr == nil {
+				senderJID = jid
+			}
+		}
+	}
+
+	if senderJID.IsEmpty() {
+		// 1:1 DMs: the chat itself is the sender unless we sent the poll.
+		if chat.Server == types.DefaultUserServer {
+			senderJID = chat
+		} else if chat.Server == types.GroupServer {
+			return nil, knownOptions, fmt.Errorf("poll %s is not in the local store; pass --sender <JID> to vote", pollMsgID)
+		}
+	}
+
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
+	info := &types.MessageInfo{
+		MessageSource: types.MessageSource{
+			Chat:     chat,
+			Sender:   senderJID,
+			IsFromMe: fromMe,
+		},
+		ID:        pollMsgID,
+		Timestamp: ts,
+	}
+	return info, knownOptions, nil
+}
+
+func persistOutboundVote(ctx context.Context, a *app.App, chat types.JID, pollMsgID, voteMsgID string, options []string, now time.Time) {
+	chatName := a.WA().ResolveChatName(ctx, chat, "")
+	_ = a.DB().UpsertChat(chat.String(), chatKindFromJID(chat), chatName, now)
+	_ = a.DB().UpsertMessage(store.UpsertMessageParams{
+		ChatJID:    chat.String(),
+		ChatName:   chatName,
+		MsgID:      voteMsgID,
+		SenderName: "me",
+		Timestamp:  now,
+		FromMe:     true,
+		Text:       "Voted: " + strings.Join(options, ", "),
+	})
+	voter := a.WA().LinkedJID()
+	if voter == "" {
+		return
+	}
+	_ = a.DB().UpsertPollVote(store.PollVote{
+		ChatJID:   chat.String(),
+		PollMsgID: pollMsgID,
+		VoterJID:  voter,
+		VoteMsgID: voteMsgID,
+		Selected:  options,
+		VotedAt:   now,
+	})
+}
+
+func executeDelegatedPollVote(ctx context.Context, a *app.App, req sendDelegateRequest) (sendDelegateResponse, error) {
+	if strings.TrimSpace(req.To) == "" || strings.TrimSpace(req.ID) == "" {
+		return sendDelegateResponse{}, fmt.Errorf("poll vote requires --to and --id")
+	}
+	cleaned, err := cleanVoteOptions(req.Options)
+	if err != nil {
+		return sendDelegateResponse{}, err
+	}
+	toJID, err := resolveRecipient(a, req.To, recipientOptions{pick: req.Pick, asJSON: true})
+	if err != nil {
+		return sendDelegateResponse{}, err
+	}
+	info, knownOptions, err := buildPollVoteInfo(a, toJID, req.ID, req.Sender)
+	if err != nil {
+		return sendDelegateResponse{}, err
+	}
+	if knownOptions != nil {
+		if err := requirePollOptionsExist(knownOptions, cleaned); err != nil {
+			return sendDelegateResponse{}, err
+		}
+	}
+	if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
+		return sendDelegateResponse{}, err
+	}
+	sentID, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (types.MessageID, error) {
+		return a.WA().SendPollVote(ctx, info, cleaned)
+	})
+	if err != nil {
+		return sendDelegateResponse{}, err
+	}
+	now := time.Now().UTC()
+	persistOutboundVote(ctx, a, toJID, req.ID, string(sentID), cleaned, now)
+	waitForPostSendRetryReceipts(ctx, millisDuration(req.PostSendWaitMS, 0))
+	return sendDelegateResponse{
+		OK:       true,
+		Sent:     true,
+		To:       toJID.String(),
+		ID:       string(sentID),
+		Target:   req.ID,
+		Selected: cleaned,
+	}, nil
+}
+
+// ---- show -----------------------------------------------------------------
+
+func newPollShowCmd(flags *rootFlags) *cobra.Command {
+	var to string
+	var pick int
+	var msgID string
+
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Show a poll's question, options, and votes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(to) == "" || strings.TrimSpace(msgID) == "" {
+				return fmt.Errorf("--to and --id are required")
+			}
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, false, true)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			toJID, err := resolveRecipient(a, to, recipientOptions{pick: pick, asJSON: flags.asJSON})
+			if err != nil {
+				return err
+			}
+			poll, err := a.DB().GetPoll(toJID.String(), msgID)
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return fmt.Errorf("poll %s not found in local store for chat %s; run `wacli sync` first", msgID, toJID.String())
+				}
+				return err
+			}
+			votes, err := a.DB().ListPollVotes(toJID.String(), msgID)
+			if err != nil {
+				return err
+			}
+
+			aggregates := aggregatePollVotes(poll.Options, votes)
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, pollShowPayload(a, ctx, poll, votes, aggregates))
+			}
+			renderPollShow(os.Stdout, a, ctx, poll, votes, aggregates)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&to, "to", "", "chat JID, phone number, or contact/group/chat name")
+	cmd.Flags().IntVar(&pick, "pick", 0, "when --to is ambiguous, pick the Nth match (1-indexed)")
+	cmd.Flags().StringVar(&msgID, "id", "", "poll message ID")
+	return cmd
+}
+
+func aggregatePollVotes(options []string, votes []store.PollVote) map[string]int {
+	out := make(map[string]int, len(options))
+	for _, o := range options {
+		out[o] = 0
+	}
+	for _, v := range votes {
+		for _, sel := range v.Selected {
+			out[sel]++
+		}
+	}
+	return out
+}
+
+type pollVoterPayload struct {
+	JID      string   `json:"jid"`
+	Name     string   `json:"name,omitempty"`
+	Selected []string `json:"selected"`
+	VotedAt  string   `json:"voted_at"`
+}
+
+type pollShowJSON struct {
+	Question        string             `json:"question"`
+	Options         []string           `json:"options"`
+	SelectableCount uint32             `json:"selectable_count"`
+	ChatJID         string             `json:"chat_jid"`
+	MsgID           string             `json:"msg_id"`
+	SenderJID       string             `json:"sender_jid,omitempty"`
+	CreatedAt       string             `json:"created_at"`
+	Aggregates      map[string]int     `json:"aggregates"`
+	Voters          []pollVoterPayload `json:"voters"`
+}
+
+func pollShowPayload(a *app.App, ctx context.Context, poll store.Poll, votes []store.PollVote, aggregates map[string]int) pollShowJSON {
+	out := pollShowJSON{
+		Question:        poll.Question,
+		Options:         poll.Options,
+		SelectableCount: poll.SelectableCount,
+		ChatJID:         poll.ChatJID,
+		MsgID:           poll.MsgID,
+		SenderJID:       poll.SenderJID,
+		CreatedAt:       poll.CreatedAt.Format(time.RFC3339),
+		Aggregates:      aggregates,
+		Voters:          make([]pollVoterPayload, 0, len(votes)),
+	}
+	for _, v := range votes {
+		name := resolveVoterName(a, ctx, v.VoterJID)
+		out.Voters = append(out.Voters, pollVoterPayload{
+			JID:      v.VoterJID,
+			Name:     name,
+			Selected: v.Selected,
+			VotedAt:  v.VotedAt.Format(time.RFC3339),
+		})
+	}
+	return out
+}
+
+func resolveVoterName(a *app.App, ctx context.Context, jid string) string {
+	jid = strings.TrimSpace(jid)
+	if jid == "" {
+		return ""
+	}
+	if a != nil && a.DB() != nil {
+		if c, err := a.DB().GetContact(jid); err == nil {
+			if name := strings.TrimSpace(c.Name); name != "" {
+				return name
+			}
+		}
+	}
+	parsed, err := types.ParseJID(jid)
+	if err != nil {
+		return ""
+	}
+	if a == nil || a.WA() == nil {
+		return ""
+	}
+	return a.WA().ResolveChatName(ctx, parsed, "")
+}
+
+func renderPollShow(w *os.File, a *app.App, ctx context.Context, poll store.Poll, votes []store.PollVote, aggregates map[string]int) {
+	fmt.Fprintf(w, "Poll: %s\n", poll.Question)
+	fmt.Fprintf(w, "Chat: %s   Msg: %s   Selectable: %d\n", poll.ChatJID, poll.MsgID, poll.SelectableCount)
+	fmt.Fprintf(w, "\nResults (%d voter(s)):\n", len(votes))
+	for _, opt := range poll.Options {
+		fmt.Fprintf(w, "  %3d  %s\n", aggregates[opt], opt)
+	}
+	if len(votes) == 0 {
+		fmt.Fprintln(w, "\nNo votes yet.")
+		return
+	}
+	fmt.Fprintln(w, "\nVoters:")
+	for _, v := range votes {
+		name := resolveVoterName(a, ctx, v.VoterJID)
+		who := v.VoterJID
+		if name != "" && name != v.VoterJID {
+			who = fmt.Sprintf("%s (%s)", name, v.VoterJID)
+		}
+		fmt.Fprintf(w, "  %s — %s [%s]\n", who, strings.Join(v.Selected, ", "), v.VotedAt.Format(time.RFC3339))
+	}
+}
+
+// ---- list -----------------------------------------------------------------
+
+func newPollsListCmd(flags *rootFlags) *cobra.Command {
+	var chat string
+	var pick int
+	var limit int
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List polls stored locally",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, false, true)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			filter := store.PollListFilter{Limit: limit}
+			if strings.TrimSpace(chat) != "" {
+				toJID, err := resolveRecipient(a, chat, recipientOptions{pick: pick, asJSON: flags.asJSON})
+				if err != nil {
+					return err
+				}
+				filter.ChatJID = toJID.String()
+			}
+			polls, err := a.DB().ListPolls(filter)
+			if err != nil {
+				return err
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{"polls": pollsToJSON(polls)})
+			}
+			renderPollsList(os.Stdout, polls)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&chat, "chat", "", "filter to a single chat")
+	cmd.Flags().IntVar(&pick, "pick", 0, "when --chat is ambiguous, pick the Nth match (1-indexed)")
+	cmd.Flags().IntVar(&limit, "limit", 50, "max polls to return (0 = unlimited)")
+	return cmd
+}
+
+type pollListItemJSON struct {
+	ChatJID         string   `json:"chat_jid"`
+	MsgID           string   `json:"msg_id"`
+	Question        string   `json:"question"`
+	Options         []string `json:"options"`
+	SelectableCount uint32   `json:"selectable_count"`
+	SenderJID       string   `json:"sender_jid,omitempty"`
+	CreatedAt       string   `json:"created_at"`
+}
+
+func pollsToJSON(polls []store.Poll) []pollListItemJSON {
+	out := make([]pollListItemJSON, 0, len(polls))
+	for _, p := range polls {
+		out = append(out, pollListItemJSON{
+			ChatJID:         p.ChatJID,
+			MsgID:           p.MsgID,
+			Question:        p.Question,
+			Options:         p.Options,
+			SelectableCount: p.SelectableCount,
+			SenderJID:       p.SenderJID,
+			CreatedAt:       p.CreatedAt.Format(time.RFC3339),
+		})
+	}
+	return out
+}
+
+func renderPollsList(w *os.File, polls []store.Poll) {
+	if len(polls) == 0 {
+		fmt.Fprintln(w, "No polls.")
+		return
+	}
+	for _, p := range polls {
+		fmt.Fprintf(w, "%s  %s\n  chat=%s  options=%d  selectable=%d  id=%s\n",
+			p.CreatedAt.Format(time.RFC3339),
+			p.Question,
+			p.ChatJID,
+			len(p.Options),
+			p.SelectableCount,
+			p.MsgID,
+		)
+	}
+}

--- a/cmd/wacli/poll_cmd.go
+++ b/cmd/wacli/poll_cmd.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -292,11 +293,40 @@ func pollStoreLookupJID(ctx context.Context, a *app.App, jid types.JID) types.JI
 	return jid
 }
 
+func primaryPollChatJID(ctx context.Context, a *app.App, jid types.JID) string {
+	candidates := pollChatJIDCandidates(ctx, a, jid)
+	if len(candidates) == 0 {
+		return ""
+	}
+	return candidates[0]
+}
+
+func pollChatJIDCandidates(ctx context.Context, a *app.App, jid types.JID) []string {
+	jids := make([]types.JID, 0, 3)
+	if a != nil {
+		if a.WA() == nil {
+			if _, err := os.Stat(filepath.Join(a.StoreDir(), "session.db")); err == nil {
+				_ = a.OpenWA()
+			}
+		}
+		if client := a.WA(); client != nil {
+			resolved := client.ResolveLIDToPN(ctx, jid)
+			jids = append(jids, canonicalMessageFilterJID(resolved))
+			if resolved.Server == types.DefaultUserServer {
+				jids = append(jids, canonicalMessageFilterJID(client.ResolvePNToLID(ctx, resolved)))
+			}
+		}
+	}
+	jids = append(jids, canonicalMessageFilterJID(jid))
+	return jidStrings(jids)
+}
+
 func persistOutboundVote(ctx context.Context, a *app.App, chat types.JID, pollMsgID, voteMsgID string, options []string, now time.Time) {
+	chatJID := primaryPollChatJID(ctx, a, chat)
 	chatName := a.WA().ResolveChatName(ctx, chat, "")
-	_ = a.DB().UpsertChat(chat.String(), chatKindFromJID(chat), chatName, now)
+	_ = a.DB().UpsertChat(chatJID, chatKindFromJID(chat), chatName, now)
 	_ = a.DB().UpsertMessage(store.UpsertMessageParams{
-		ChatJID:    chat.String(),
+		ChatJID:    chatJID,
 		ChatName:   chatName,
 		MsgID:      voteMsgID,
 		SenderName: "me",
@@ -309,7 +339,7 @@ func persistOutboundVote(ctx context.Context, a *app.App, chat types.JID, pollMs
 		return
 	}
 	_ = a.DB().UpsertPollVote(store.PollVote{
-		ChatJID:   chat.String(),
+		ChatJID:   chatJID,
 		PollMsgID: pollMsgID,
 		VoterJID:  voter,
 		VoteMsgID: voteMsgID,
@@ -392,15 +422,11 @@ func newPollShowCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			poll, err := a.DB().GetPoll(toJID.String(), msgID)
+			poll, votes, err := getPollForShow(ctx, a, toJID, msgID)
 			if err != nil {
 				if errors.Is(err, sql.ErrNoRows) {
 					return fmt.Errorf("poll %s not found in local store for chat %s; run `wacli sync` first", msgID, toJID.String())
 				}
-				return err
-			}
-			votes, err := a.DB().ListPollVotes(toJID.String(), msgID)
-			if err != nil {
 				return err
 			}
 
@@ -418,6 +444,26 @@ func newPollShowCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().IntVar(&pick, "pick", 0, "when --to is ambiguous, pick the Nth match (1-indexed)")
 	cmd.Flags().StringVar(&msgID, "id", "", "poll message ID")
 	return cmd
+}
+
+func getPollForShow(ctx context.Context, a *app.App, chat types.JID, msgID string) (store.Poll, []store.PollVote, error) {
+	var lastErr error = sql.ErrNoRows
+	for _, chatJID := range pollChatJIDCandidates(ctx, a, chat) {
+		poll, err := a.DB().GetPoll(chatJID, msgID)
+		if err != nil {
+			lastErr = err
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return store.Poll{}, nil, err
+		}
+		votes, err := a.DB().ListPollVotes(poll.ChatJID, msgID)
+		if err != nil {
+			return store.Poll{}, nil, err
+		}
+		return poll, votes, nil
+	}
+	return store.Poll{}, nil, lastErr
 }
 
 func aggregatePollVotes(options []string, votes []store.PollVote) map[string]int {
@@ -546,7 +592,7 @@ func newPollsListCmd(flags *rootFlags) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				filter.ChatJID = toJID.String()
+				filter.ChatJID = primaryPollChatJID(ctx, a, toJID)
 			}
 			polls, err := a.DB().ListPolls(filter)
 			if err != nil {

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -60,6 +60,8 @@ func execute(args []string) error {
 	rootCmd.AddCommand(newSyncCmd(&flags))
 	rootCmd.AddCommand(newMessagesCmd(&flags))
 	rootCmd.AddCommand(newSendCmd(&flags))
+	rootCmd.AddCommand(newPollCmd(&flags))
+	rootCmd.AddCommand(newPollsCmd(&flags))
 	rootCmd.AddCommand(newMediaCmd(&flags))
 	rootCmd.AddCommand(newContactsCmd(&flags))
 	rootCmd.AddCommand(newChatsCmd(&flags))

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -30,6 +30,7 @@ func newSendCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newSendStickerCmd(flags))
 	cmd.AddCommand(newSendVoiceCmd(flags))
 	cmd.AddCommand(newSendReactCmd(flags))
+	cmd.AddCommand(newSendPollCmd(flags))
 	return cmd
 }
 

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -44,6 +44,9 @@ type sendDelegateRequest struct {
 	ID             string   `json:"id,omitempty"`
 	Reaction       string   `json:"reaction,omitempty"`
 	Sender         string   `json:"sender,omitempty"`
+	Question       string   `json:"question,omitempty"`
+	Options        []string `json:"options,omitempty"`
+	Selectable     int      `json:"selectable,omitempty"`
 	PostSendWaitMS int64    `json:"post_send_wait_ms,omitempty"`
 	TimeoutMS      int64    `json:"timeout_ms,omitempty"`
 }
@@ -56,6 +59,9 @@ type sendDelegateResponse struct {
 	ID       string            `json:"id,omitempty"`
 	Target   string            `json:"target,omitempty"`
 	Reaction string            `json:"reaction,omitempty"`
+	Question string            `json:"question,omitempty"`
+	Options  []string          `json:"options,omitempty"`
+	Selected []string          `json:"selected,omitempty"`
 	File     map[string]string `json:"file,omitempty"`
 }
 
@@ -192,6 +198,10 @@ func executeDelegatedSend(parent context.Context, a *app.App, req sendDelegateRe
 		return executeDelegatedSticker(ctx, a, req)
 	case "react":
 		return executeDelegatedReact(ctx, a, req)
+	case "poll":
+		return executeDelegatedPoll(ctx, a, req)
+	case "poll_vote":
+		return executeDelegatedPollVote(ctx, a, req)
 	default:
 		return sendDelegateResponse{}, fmt.Errorf("unsupported send kind %q", req.Kind)
 	}
@@ -317,6 +327,14 @@ func writeDelegatedSendOutput(flags *rootFlags, kind string, resp sendDelegateRe
 			body["target"] = resp.Target
 			body["reaction"] = resp.Reaction
 		}
+		if kind == "poll" {
+			body["question"] = resp.Question
+			body["options"] = resp.Options
+		}
+		if kind == "poll_vote" {
+			body["target"] = resp.Target
+			body["selected"] = resp.Selected
+		}
 		return out.WriteJSON(os.Stdout, body)
 	}
 	switch kind {
@@ -332,6 +350,10 @@ func writeDelegatedSendOutput(flags *rootFlags, kind string, resp sendDelegateRe
 		} else {
 			fmt.Fprintf(os.Stdout, "Reacted %s to %s (id %s)\n", resp.Reaction, resp.Target, resp.ID)
 		}
+	case "poll":
+		fmt.Fprintf(os.Stdout, "Sent poll to %s (id %s)\n", resp.To, resp.ID)
+	case "poll_vote":
+		fmt.Fprintf(os.Stdout, "Voted on %s in %s (id %s)\n", resp.Target, resp.To, resp.ID)
 	default:
 		fmt.Fprintf(os.Stdout, "Sent to %s (id %s)\n", resp.To, resp.ID)
 	}

--- a/cmd/wacli/send_poll_cmd.go
+++ b/cmd/wacli/send_poll_cmd.go
@@ -82,6 +82,7 @@ func newSendPollCmd(flags *rootFlags) *cobra.Command {
 			if err := a.Connect(ctx, false, nil); err != nil {
 				return err
 			}
+			toJID = warmupRecipient(ctx, a.WA(), toJID, os.Stderr)
 			if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
 				return err
 			}
@@ -191,6 +192,7 @@ func executeDelegatedPoll(ctx context.Context, a *app.App, req sendDelegateReque
 	if err != nil {
 		return sendDelegateResponse{}, err
 	}
+	toJID = warmupDelegatedRecipient(ctx, a, toJID)
 	if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
 		return sendDelegateResponse{}, err
 	}

--- a/cmd/wacli/send_poll_cmd.go
+++ b/cmd/wacli/send_poll_cmd.go
@@ -23,6 +23,12 @@ type pollSender interface {
 	SendPoll(ctx context.Context, to types.JID, name string, options []string, selectable int, ephemeral bool) (types.MessageID, error)
 }
 
+type outboundPollIdentityResolver interface {
+	LinkedJID() string
+	ResolvePNToLID(ctx context.Context, jid types.JID) types.JID
+	GetGroupInfo(ctx context.Context, jid types.JID) (*types.GroupInfo, error)
+}
+
 func newSendPollCmd(flags *rootFlags) *cobra.Command {
 	var to string
 	var pick int
@@ -176,12 +182,35 @@ func persistOutboundPoll(ctx context.Context, a *app.App, chat types.JID, msgID,
 	_ = a.DB().UpsertPoll(store.Poll{
 		ChatJID:         chatJID,
 		MsgID:           msgID,
-		SenderJID:       a.WA().LinkedJID(),
+		SenderJID:       outboundPollSenderJID(ctx, a.WA(), chat),
 		Question:        question,
 		Options:         options,
 		SelectableCount: selectable,
 		CreatedAt:       now,
 	})
+}
+
+func outboundPollSenderJID(ctx context.Context, wa outboundPollIdentityResolver, chat types.JID) string {
+	if wa == nil {
+		return ""
+	}
+	linked := strings.TrimSpace(wa.LinkedJID())
+	if chat.Server != types.GroupServer {
+		return linked
+	}
+	info, _ := wa.GetGroupInfo(ctx, chat)
+	if info == nil || info.AddressingMode != types.AddressingModeLID {
+		return linked
+	}
+	linkedJID, err := types.ParseJID(linked)
+	if err != nil {
+		return ""
+	}
+	lid := wa.ResolvePNToLID(ctx, linkedJID)
+	if lid.IsEmpty() || lid.Server != types.HiddenUserServer {
+		return ""
+	}
+	return lid.String()
 }
 
 func executeDelegatedPoll(ctx context.Context, a *app.App, req sendDelegateRequest) (sendDelegateResponse, error) {

--- a/cmd/wacli/send_poll_cmd.go
+++ b/cmd/wacli/send_poll_cmd.go
@@ -161,10 +161,11 @@ func sendPollMessage(ctx context.Context, sender pollSender, to types.JID, quest
 }
 
 func persistOutboundPoll(ctx context.Context, a *app.App, chat types.JID, msgID, question string, options []string, selectable uint32, now time.Time) {
+	chatJID := primaryPollChatJID(ctx, a, chat)
 	chatName := a.WA().ResolveChatName(ctx, chat, "")
-	_ = a.DB().UpsertChat(chat.String(), chatKindFromJID(chat), chatName, now)
+	_ = a.DB().UpsertChat(chatJID, chatKindFromJID(chat), chatName, now)
 	_ = a.DB().UpsertMessage(store.UpsertMessageParams{
-		ChatJID:    chat.String(),
+		ChatJID:    chatJID,
 		ChatName:   chatName,
 		MsgID:      msgID,
 		SenderName: "me",
@@ -173,7 +174,7 @@ func persistOutboundPoll(ctx context.Context, a *app.App, chat types.JID, msgID,
 		Text:       "Poll: " + question,
 	})
 	_ = a.DB().UpsertPoll(store.Poll{
-		ChatJID:         chat.String(),
+		ChatJID:         chatJID,
 		MsgID:           msgID,
 		SenderJID:       a.WA().LinkedJID(),
 		Question:        question,

--- a/cmd/wacli/send_poll_cmd.go
+++ b/cmd/wacli/send_poll_cmd.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/openclaw/wacli/internal/app"
+	"github.com/openclaw/wacli/internal/out"
+	"github.com/openclaw/wacli/internal/store"
+	"github.com/spf13/cobra"
+	"go.mau.fi/whatsmeow/types"
+)
+
+const (
+	pollMinOptions = 2
+	pollMaxOptions = 12
+)
+
+type pollSender interface {
+	SendPoll(ctx context.Context, to types.JID, name string, options []string, selectable int, ephemeral bool) (types.MessageID, error)
+}
+
+func newSendPollCmd(flags *rootFlags) *cobra.Command {
+	var to string
+	var pick int
+	var question string
+	var options []string
+	var multi int
+	var ephemeral bool
+	postSendWait := postSendRetryReceiptWait
+
+	cmd := &cobra.Command{
+		Use:   "poll",
+		Short: "Send a poll",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if to == "" {
+				return fmt.Errorf("--to is required")
+			}
+			cleaned, err := validatePollOptions(question, options, multi)
+			if err != nil {
+				return err
+			}
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				resp, delegated, delegateErr := tryDelegateSend(ctx, flags, err, sendDelegateRequest{
+					Kind:           "poll",
+					To:             to,
+					Pick:           pick,
+					Question:       question,
+					Options:        cleaned,
+					Selectable:     multi,
+					Ephemeral:      ephemeral,
+					PostSendWaitMS: durationMillis(postSendWait),
+				})
+				if delegated {
+					if delegateErr != nil {
+						return delegateErr
+					}
+					return writeDelegatedSendOutput(flags, "poll", resp)
+				}
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			toJID, err := resolveRecipient(a, to, recipientOptions{pick: pick, asJSON: flags.asJSON})
+			if err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+			if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
+				return err
+			}
+
+			msgID, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (types.MessageID, error) {
+				return sendPollMessage(ctx, a.WA(), toJID, question, cleaned, multi, ephemeral)
+			})
+			if err != nil {
+				return err
+			}
+
+			persistOutboundPoll(ctx, a, toJID, string(msgID), question, cleaned, uint32(multi), time.Now().UTC())
+			waitForPostSendRetryReceipts(ctx, postSendWait)
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"sent":     true,
+					"to":       toJID.String(),
+					"id":       msgID,
+					"question": question,
+					"options":  cleaned,
+				})
+			}
+			fmt.Fprintf(os.Stdout, "Sent poll to %s (id %s)\n", toJID.String(), msgID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&to, "to", "", "recipient JID, phone number, or contact/group/chat name")
+	cmd.Flags().IntVar(&pick, "pick", 0, "when --to is ambiguous, pick the Nth match (1-indexed)")
+	cmd.Flags().StringVar(&question, "question", "", "poll question")
+	cmd.Flags().StringArrayVar(&options, "option", nil, "poll option (repeat for each option, 2-12 total)")
+	cmd.Flags().IntVar(&multi, "multi", 1, "maximum number of options a voter may pick (1 = single-select)")
+	cmd.Flags().BoolVar(&ephemeral, "ephemeral", false, "wrap the poll in EphemeralMessage for disappearing-message chats")
+	cmd.Flags().DurationVar(&postSendWait, "post-send-wait", postSendRetryReceiptWait, "keep the connection alive after send so retry receipts can be handled (0 disables)")
+	return cmd
+}
+
+// validatePollOptions trims, deduplicates, and bounds-checks user-supplied
+// poll options. Returns the cleaned, ordered option list.
+func validatePollOptions(question string, options []string, multi int) ([]string, error) {
+	q := strings.TrimSpace(question)
+	if q == "" {
+		return nil, fmt.Errorf("--question is required")
+	}
+	cleaned := make([]string, 0, len(options))
+	seen := make(map[string]struct{}, len(options))
+	for _, opt := range options {
+		opt = strings.TrimSpace(opt)
+		if opt == "" {
+			continue
+		}
+		if _, dup := seen[opt]; dup {
+			return nil, fmt.Errorf("duplicate option %q", opt)
+		}
+		seen[opt] = struct{}{}
+		cleaned = append(cleaned, opt)
+	}
+	if len(cleaned) < pollMinOptions {
+		return nil, fmt.Errorf("at least %d options are required (got %d)", pollMinOptions, len(cleaned))
+	}
+	if len(cleaned) > pollMaxOptions {
+		return nil, fmt.Errorf("at most %d options are allowed (got %d)", pollMaxOptions, len(cleaned))
+	}
+	if multi < 1 {
+		return nil, fmt.Errorf("--multi must be at least 1")
+	}
+	if multi > len(cleaned) {
+		return nil, fmt.Errorf("--multi (%d) cannot exceed the number of options (%d)", multi, len(cleaned))
+	}
+	return cleaned, nil
+}
+
+func sendPollMessage(ctx context.Context, sender pollSender, to types.JID, question string, options []string, multi int, ephemeral bool) (types.MessageID, error) {
+	return sender.SendPoll(ctx, to, question, options, multi, ephemeral)
+}
+
+func persistOutboundPoll(ctx context.Context, a *app.App, chat types.JID, msgID, question string, options []string, selectable uint32, now time.Time) {
+	chatName := a.WA().ResolveChatName(ctx, chat, "")
+	_ = a.DB().UpsertChat(chat.String(), chatKindFromJID(chat), chatName, now)
+	_ = a.DB().UpsertMessage(store.UpsertMessageParams{
+		ChatJID:    chat.String(),
+		ChatName:   chatName,
+		MsgID:      msgID,
+		SenderName: "me",
+		Timestamp:  now,
+		FromMe:     true,
+		Text:       "Poll: " + question,
+	})
+	_ = a.DB().UpsertPoll(store.Poll{
+		ChatJID:         chat.String(),
+		MsgID:           msgID,
+		SenderJID:       a.WA().LinkedJID(),
+		Question:        question,
+		Options:         options,
+		SelectableCount: selectable,
+		CreatedAt:       now,
+	})
+}
+
+func executeDelegatedPoll(ctx context.Context, a *app.App, req sendDelegateRequest) (sendDelegateResponse, error) {
+	cleaned, err := validatePollOptions(req.Question, req.Options, req.Selectable)
+	if err != nil {
+		return sendDelegateResponse{}, err
+	}
+	toJID, err := resolveRecipient(a, req.To, recipientOptions{pick: req.Pick, asJSON: true})
+	if err != nil {
+		return sendDelegateResponse{}, err
+	}
+	if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
+		return sendDelegateResponse{}, err
+	}
+	msgID, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (types.MessageID, error) {
+		return sendPollMessage(ctx, a.WA(), toJID, req.Question, cleaned, req.Selectable, req.Ephemeral)
+	})
+	if err != nil {
+		return sendDelegateResponse{}, err
+	}
+	persistOutboundPoll(ctx, a, toJID, string(msgID), req.Question, cleaned, uint32(req.Selectable), time.Now().UTC())
+	waitForPostSendRetryReceipts(ctx, millisDuration(req.PostSendWaitMS, 0))
+	return sendDelegateResponse{
+		OK:       true,
+		Sent:     true,
+		To:       toJID.String(),
+		ID:       string(msgID),
+		Question: req.Question,
+		Options:  cleaned,
+	}, nil
+}

--- a/cmd/wacli/send_poll_test.go
+++ b/cmd/wacli/send_poll_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/openclaw/wacli/internal/app"
 	"go.mau.fi/whatsmeow/types"
 )
 
@@ -127,5 +128,29 @@ func TestCleanVoteOptionsDedupAndTrim(t *testing.T) {
 	}
 	if _, err := cleanVoteOptions(nil); err == nil {
 		t.Fatal("expected error for empty options")
+	}
+}
+
+func TestBuildPollVoteInfoMarksGroupMessages(t *testing.T) {
+	a, err := app.New(app.Options{StoreDir: t.TempDir(), AllowUnauthed: true})
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	defer a.Close()
+
+	group := types.NewJID("120363001234567890", types.GroupServer)
+	sender := "15551234567@s.whatsapp.net"
+	info, _, err := buildPollVoteInfo(a, group, "poll-id", sender)
+	if err != nil {
+		t.Fatalf("buildPollVoteInfo: %v", err)
+	}
+	if !info.IsGroup {
+		t.Fatalf("IsGroup = false, want true")
+	}
+	if info.Chat != group {
+		t.Fatalf("Chat = %s, want %s", info.Chat, group)
+	}
+	if info.Sender.String() != sender {
+		t.Fatalf("Sender = %s, want %s", info.Sender, sender)
 	}
 }

--- a/cmd/wacli/send_poll_test.go
+++ b/cmd/wacli/send_poll_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+type recordingPollSender struct {
+	calls []recordingPollCall
+}
+
+type recordingPollCall struct {
+	to         types.JID
+	name       string
+	options    []string
+	selectable int
+	ephemeral  bool
+}
+
+func (r *recordingPollSender) SendPoll(_ context.Context, to types.JID, name string, options []string, selectable int, ephemeral bool) (types.MessageID, error) {
+	r.calls = append(r.calls, recordingPollCall{
+		to:         to,
+		name:       name,
+		options:    append([]string(nil), options...),
+		selectable: selectable,
+		ephemeral:  ephemeral,
+	})
+	return "pollid", nil
+}
+
+func TestValidatePollOptionsRequiresQuestion(t *testing.T) {
+	if _, err := validatePollOptions("", []string{"a", "b"}, 1); err == nil {
+		t.Fatal("expected error for empty question")
+	}
+}
+
+func TestValidatePollOptionsTrimsAndRejectsDuplicates(t *testing.T) {
+	if _, err := validatePollOptions("Q?", []string{"Yes", "  Yes  "}, 1); err == nil {
+		t.Fatal("expected duplicate option error")
+	}
+	cleaned, err := validatePollOptions("Q?", []string{" Yes ", "No", ""}, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(cleaned, []string{"Yes", "No"}) {
+		t.Fatalf("cleaned = %v", cleaned)
+	}
+}
+
+func TestValidatePollOptionsBoundsCheck(t *testing.T) {
+	if _, err := validatePollOptions("Q?", []string{"a"}, 1); err == nil {
+		t.Fatal("expected error for <2 options")
+	}
+	tooMany := []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13"}
+	if _, err := validatePollOptions("Q?", tooMany, 1); err == nil {
+		t.Fatal("expected error for >12 options")
+	}
+}
+
+func TestValidatePollOptionsMultiBounds(t *testing.T) {
+	if _, err := validatePollOptions("Q?", []string{"a", "b"}, 0); err == nil {
+		t.Fatal("expected error for multi=0")
+	}
+	if _, err := validatePollOptions("Q?", []string{"a", "b"}, 3); err == nil {
+		t.Fatal("expected error for multi > options")
+	}
+	if _, err := validatePollOptions("Q?", []string{"a", "b", "c"}, 2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSendPollMessageDispatchesSendPoll(t *testing.T) {
+	rec := &recordingPollSender{}
+	to := types.NewJID("15551234567", types.DefaultUserServer)
+	id, err := sendPollMessage(context.Background(), rec, to, "Pizza?", []string{"Yes", "No"}, 1, false)
+	if err != nil {
+		t.Fatalf("sendPollMessage: %v", err)
+	}
+	if id != "pollid" {
+		t.Fatalf("id = %q", id)
+	}
+	if len(rec.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(rec.calls))
+	}
+	got := rec.calls[0]
+	if got.name != "Pizza?" || !reflect.DeepEqual(got.options, []string{"Yes", "No"}) || got.selectable != 1 || got.ephemeral {
+		t.Fatalf("unexpected call: %+v", got)
+	}
+	if got.to.String() != to.String() {
+		t.Fatalf("to = %s", got.to)
+	}
+}
+
+func TestSendPollMessageEphemeral(t *testing.T) {
+	rec := &recordingPollSender{}
+	to := types.NewJID("15551234567", types.DefaultUserServer)
+	if _, err := sendPollMessage(context.Background(), rec, to, "Q?", []string{"a", "b"}, 2, true); err != nil {
+		t.Fatalf("sendPollMessage: %v", err)
+	}
+	if !rec.calls[0].ephemeral {
+		t.Fatal("expected ephemeral=true to flow through")
+	}
+	if rec.calls[0].selectable != 2 {
+		t.Fatalf("selectable = %d", rec.calls[0].selectable)
+	}
+}
+
+func TestRequirePollOptionsExist(t *testing.T) {
+	if err := requirePollOptionsExist([]string{"Yes", "No"}, []string{"Yes"}); err != nil {
+		t.Fatalf("expected ok: %v", err)
+	}
+	if err := requirePollOptionsExist([]string{"Yes", "No"}, []string{"Maybe"}); err == nil {
+		t.Fatal("expected error for unknown option")
+	}
+}
+
+func TestCleanVoteOptionsDedupAndTrim(t *testing.T) {
+	cleaned, err := cleanVoteOptions([]string{"  A ", "B", "A", ""})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(cleaned, []string{"A", "B"}) {
+		t.Fatalf("cleaned = %v", cleaned)
+	}
+	if _, err := cleanVoteOptions(nil); err == nil {
+		t.Fatal("expected error for empty options")
+	}
+}

--- a/cmd/wacli/send_poll_test.go
+++ b/cmd/wacli/send_poll_test.go
@@ -118,6 +118,18 @@ func TestRequirePollOptionsExist(t *testing.T) {
 	}
 }
 
+func TestRequirePollSelectableCount(t *testing.T) {
+	if err := requirePollSelectableCount(1, []string{"Yes"}); err != nil {
+		t.Fatalf("expected ok: %v", err)
+	}
+	if err := requirePollSelectableCount(0, []string{"Yes", "No"}); err != nil {
+		t.Fatalf("expected zero count to be unbounded: %v", err)
+	}
+	if err := requirePollSelectableCount(1, []string{"Yes", "No"}); err == nil {
+		t.Fatal("expected error for over-selecting")
+	}
+}
+
 func TestCleanVoteOptionsDedupAndTrim(t *testing.T) {
 	cleaned, err := cleanVoteOptions([]string{"  A ", "B", "A", ""})
 	if err != nil {
@@ -140,7 +152,7 @@ func TestBuildPollVoteInfoMarksGroupMessages(t *testing.T) {
 
 	group := types.NewJID("120363001234567890", types.GroupServer)
 	sender := "15551234567@s.whatsapp.net"
-	info, _, err := buildPollVoteInfo(a, group, "poll-id", sender)
+	info, _, _, err := buildPollVoteInfo(a, group, "poll-id", sender)
 	if err != nil {
 		t.Fatalf("buildPollVoteInfo: %v", err)
 	}

--- a/cmd/wacli/send_poll_test.go
+++ b/cmd/wacli/send_poll_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/openclaw/wacli/internal/app"
+	"github.com/openclaw/wacli/internal/store"
 	"go.mau.fi/whatsmeow/types"
 )
 
@@ -164,5 +166,48 @@ func TestBuildPollVoteInfoMarksGroupMessages(t *testing.T) {
 	}
 	if info.Sender.String() != sender {
 		t.Fatalf("Sender = %s, want %s", info.Sender, sender)
+	}
+}
+
+func TestGetPollForShowFindsNonADChat(t *testing.T) {
+	a, err := app.New(app.Options{StoreDir: t.TempDir(), AllowUnauthed: true})
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	defer a.Close()
+
+	chat := types.NewJID("15551234567", types.DefaultUserServer)
+	deviceChat := chat
+	deviceChat.Device = 2
+	if err := a.DB().UpsertPoll(store.Poll{
+		ChatJID:         chat.String(),
+		MsgID:           "poll-id",
+		Question:        "Dinner?",
+		Options:         []string{"Yes", "No"},
+		SelectableCount: 1,
+		CreatedAt:       time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("UpsertPoll: %v", err)
+	}
+	if err := a.DB().UpsertPollVote(store.PollVote{
+		ChatJID:   chat.String(),
+		PollMsgID: "poll-id",
+		VoterJID:  "15557654321@s.whatsapp.net",
+		VoteMsgID: "vote-id",
+		Selected:  []string{"Yes"},
+		VotedAt:   time.Date(2026, 5, 9, 12, 1, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("UpsertPollVote: %v", err)
+	}
+
+	poll, votes, err := getPollForShow(context.Background(), a, deviceChat, "poll-id")
+	if err != nil {
+		t.Fatalf("getPollForShow: %v", err)
+	}
+	if poll.ChatJID != chat.String() {
+		t.Fatalf("ChatJID = %q, want %q", poll.ChatJID, chat.String())
+	}
+	if len(votes) != 1 || votes[0].VoteMsgID != "vote-id" {
+		t.Fatalf("votes = %+v", votes)
 	}
 }

--- a/cmd/wacli/send_poll_test.go
+++ b/cmd/wacli/send_poll_test.go
@@ -152,7 +152,7 @@ func TestBuildPollVoteInfoMarksGroupMessages(t *testing.T) {
 
 	group := types.NewJID("120363001234567890", types.GroupServer)
 	sender := "15551234567@s.whatsapp.net"
-	info, _, _, err := buildPollVoteInfo(a, group, "poll-id", sender)
+	info, _, _, err := buildPollVoteInfo(context.Background(), a, group, "poll-id", sender)
 	if err != nil {
 		t.Fatalf("buildPollVoteInfo: %v", err)
 	}

--- a/cmd/wacli/send_poll_test.go
+++ b/cmd/wacli/send_poll_test.go
@@ -154,7 +154,7 @@ func TestBuildPollVoteInfoMarksGroupMessages(t *testing.T) {
 
 	group := types.NewJID("120363001234567890", types.GroupServer)
 	sender := "15551234567@s.whatsapp.net"
-	info, _, _, err := buildPollVoteInfo(context.Background(), a, group, "poll-id", sender)
+	info, _, _, _, err := buildPollVoteInfo(context.Background(), a, group, "poll-id", sender)
 	if err != nil {
 		t.Fatalf("buildPollVoteInfo: %v", err)
 	}
@@ -163,6 +163,53 @@ func TestBuildPollVoteInfoMarksGroupMessages(t *testing.T) {
 	}
 	if info.Chat != group {
 		t.Fatalf("Chat = %s, want %s", info.Chat, group)
+	}
+	if info.Sender.String() != sender {
+		t.Fatalf("Sender = %s, want %s", info.Sender, sender)
+	}
+}
+
+func TestBuildPollVoteInfoFindsAlternateChatKey(t *testing.T) {
+	a, err := app.New(app.Options{StoreDir: t.TempDir(), AllowUnauthed: true})
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	defer a.Close()
+
+	pnChat := types.NewJID("15551234567", types.DefaultUserServer)
+	lidChat := types.NewJID("123456789", types.HiddenUserServer)
+	sender := "15557654321@s.whatsapp.net"
+	if err := a.DB().UpsertPoll(store.Poll{
+		ChatJID:         lidChat.String(),
+		MsgID:           "poll-id",
+		SenderJID:       sender,
+		Question:        "Dinner?",
+		Options:         []string{"Yes", "No"},
+		SelectableCount: 1,
+		CreatedAt:       time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("UpsertPoll: %v", err)
+	}
+
+	info, options, selectable, matchedChatJID, err := buildPollVoteInfoForChats(
+		context.Background(),
+		a,
+		pnChat,
+		[]string{pnChat.String(), lidChat.String()},
+		"poll-id",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("buildPollVoteInfoForChats: %v", err)
+	}
+	if matchedChatJID != lidChat.String() {
+		t.Fatalf("matchedChatJID = %q, want %q", matchedChatJID, lidChat.String())
+	}
+	if !reflect.DeepEqual(options, []string{"Yes", "No"}) {
+		t.Fatalf("options = %v", options)
+	}
+	if selectable != 1 {
+		t.Fatalf("selectable = %d, want 1", selectable)
 	}
 	if info.Sender.String() != sender {
 		t.Fatalf("Sender = %s, want %s", info.Sender, sender)

--- a/cmd/wacli/send_poll_test.go
+++ b/cmd/wacli/send_poll_test.go
@@ -15,6 +15,12 @@ type recordingPollSender struct {
 	calls []recordingPollCall
 }
 
+type fakeOutboundPollIdentity struct {
+	linked string
+	group  *types.GroupInfo
+	lid    types.JID
+}
+
 type recordingPollCall struct {
 	to         types.JID
 	name       string
@@ -32,6 +38,18 @@ func (r *recordingPollSender) SendPoll(_ context.Context, to types.JID, name str
 		ephemeral:  ephemeral,
 	})
 	return "pollid", nil
+}
+
+func (f fakeOutboundPollIdentity) LinkedJID() string {
+	return f.linked
+}
+
+func (f fakeOutboundPollIdentity) ResolvePNToLID(_ context.Context, _ types.JID) types.JID {
+	return f.lid
+}
+
+func (f fakeOutboundPollIdentity) GetGroupInfo(_ context.Context, _ types.JID) (*types.GroupInfo, error) {
+	return f.group, nil
 }
 
 func TestValidatePollOptionsRequiresQuestion(t *testing.T) {
@@ -108,6 +126,38 @@ func TestSendPollMessageEphemeral(t *testing.T) {
 	}
 	if rec.calls[0].selectable != 2 {
 		t.Fatalf("selectable = %d", rec.calls[0].selectable)
+	}
+}
+
+func TestOutboundPollSenderJIDUsesGroupLIDAddressing(t *testing.T) {
+	group := types.NewJID("120363001234567890", types.GroupServer)
+	pn := types.NewJID("15551234567", types.DefaultUserServer)
+	lid := types.NewJID("999123456789", types.HiddenUserServer)
+	wa := fakeOutboundPollIdentity{
+		linked: pn.String(),
+		group:  &types.GroupInfo{AddressingMode: types.AddressingModeLID},
+		lid:    lid,
+	}
+
+	got := outboundPollSenderJID(context.Background(), wa, group)
+	if got != lid.String() {
+		t.Fatalf("sender = %q, want %q", got, lid.String())
+	}
+}
+
+func TestOutboundPollSenderJIDKeepsPNForPNAddressedGroup(t *testing.T) {
+	group := types.NewJID("120363001234567890", types.GroupServer)
+	pn := types.NewJID("15551234567", types.DefaultUserServer)
+	lid := types.NewJID("999123456789", types.HiddenUserServer)
+	wa := fakeOutboundPollIdentity{
+		linked: pn.String(),
+		group:  &types.GroupInfo{AddressingMode: types.AddressingModePN},
+		lid:    lid,
+	}
+
+	got := outboundPollSenderJID(context.Background(), wa, group)
+	if got != pn.String() {
+		t.Fatalf("sender = %q, want %q", got, pn.String())
 	}
 }
 

--- a/docs/send.md
+++ b/docs/send.md
@@ -1,6 +1,6 @@
 # send
 
-Read when: sending text, files, stickers, quoted replies, or reactions.
+Read when: sending text, files, stickers, polls, quoted replies, or reactions.
 
 `wacli send` requires authentication, a live connection, and writable mode. Send attempts are bounded and retry once after reconnect for known stale-session/usync timeout failures. `Sent to ...` and JSON `sent: true` mean WhatsApp accepted the send request and returned a message ID; they do not confirm recipient delivery. After a successful send, wacli keeps the connection alive briefly so whatsmeow can handle retry receipts from devices that could not decrypt the first copy. Repeated send commands within 5 seconds print a stderr warning so tight loops make WhatsApp rate-limit/account-risk visible.
 
@@ -14,6 +14,10 @@ wacli send file --to RECIPIENT --file PATH [--pick N] [--caption TEXT] [--filena
 wacli send sticker --to RECIPIENT --file PATH [--pick N] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send voice --to RECIPIENT --file PATH [--pick N] [--mime TYPE] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send react --to PHONE_OR_JID --id MSG_ID [--reaction TEXT] [--sender JID] [--post-send-wait 2s]
+wacli send poll --to RECIPIENT --question TEXT --option TEXT --option TEXT [--multi N] [--ephemeral] [--post-send-wait 2s]
+wacli poll vote --to RECIPIENT --id MSG_ID --option TEXT [--option TEXT] [--sender JID] [--post-send-wait 2s]
+wacli poll show --to RECIPIENT --id MSG_ID [--json]
+wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 ```
 
 ## Recipients
@@ -39,6 +43,16 @@ wacli send react --to PHONE_OR_JID --id MSG_ID [--reaction TEXT] [--sender JID] 
 - Sent reactions are stored locally immediately, including reaction target and display text.
 - For group reactions, pass `--sender` for the original message sender.
 - Use `--post-send-wait 0` to disable the retry-receipt grace window for latency-sensitive scripts.
+
+## Polls
+
+- `send poll` accepts 2-12 repeatable `--option` values.
+- `--multi N` sets how many options a voter may select. The default is `1`.
+- Incoming polls and poll votes are stored during sync in the local poll tables.
+- `poll vote` validates selected options when the original poll is present in the local store.
+- For unsynced group polls, pass `--sender` with the poll author's JID.
+- `poll show` prints current aggregates and per-voter selections from the local store.
+- `polls list` shows recently synced or sent polls, optionally filtered with `--chat`.
 
 ## Files
 
@@ -69,4 +83,8 @@ wacli send file --to 1234567890 --file /tmp/report --filename report.pdf
 wacli send sticker --to 1234567890 --file ./sticker-512.webp
 wacli send voice --to 1234567890 --file ./voice.ogg
 wacli send react --to 1234567890 --id ABC123 --reaction "❤️"
+wacli send poll --to "Family" --question "Dinner?" --option "Pizza" --option "Sushi" --multi 1
+wacli poll vote --to "Family" --id ABC123 --option "Pizza"
+wacli poll show --to "Family" --id ABC123 --json
+wacli polls list --chat "Family" --limit 10
 ```

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -55,6 +55,9 @@ type WAClient interface {
 	SendProtoMessage(ctx context.Context, to types.JID, msg *waProto.Message) (types.MessageID, error)
 	SendProtoMessageWithExtra(ctx context.Context, to types.JID, msg *waProto.Message, mediaHandle string) (types.MessageID, error)
 	SendReaction(ctx context.Context, chat, sender types.JID, targetID types.MessageID, reaction string) (types.MessageID, error)
+	SendPoll(ctx context.Context, to types.JID, name string, options []string, selectable int, ephemeral bool) (types.MessageID, error)
+	SendPollVote(ctx context.Context, pollInfo *types.MessageInfo, options []string) (types.MessageID, error)
+	DecryptPollVote(ctx context.Context, evt *events.Message) (*waE2E.PollVoteMessage, error)
 	RevokeMessage(ctx context.Context, chat types.JID, targetID types.MessageID) (types.MessageID, error)
 	DeleteMessageForMe(ctx context.Context, info types.MessageInfo, deleteMedia bool) error
 	EditMessage(ctx context.Context, chat types.JID, targetID types.MessageID, text string) (types.MessageID, error)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -60,6 +60,7 @@ type WAClient interface {
 	SendPoll(ctx context.Context, to types.JID, name string, options []string, selectable int, ephemeral bool) (types.MessageID, error)
 	SendPollVote(ctx context.Context, pollInfo *types.MessageInfo, options []string) (types.MessageID, error)
 	DecryptPollVote(ctx context.Context, evt *events.Message) (*waE2E.PollVoteMessage, error)
+	DecryptSecretEncryptedMessage(ctx context.Context, evt *events.Message) (*waE2E.Message, error)
 	RevokeMessage(ctx context.Context, chat types.JID, targetID types.MessageID) (types.MessageID, error)
 	DeleteMessageForMe(ctx context.Context, info types.MessageInfo, deleteMedia bool) error
 	EditMessage(ctx context.Context, chat types.JID, targetID types.MessageID, text string) (types.MessageID, error)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -77,6 +77,7 @@ type WAClient interface {
 	DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error)
 	SetManualHistorySyncDownload(enabled bool)
 	DownloadHistorySync(ctx context.Context, notif *waE2E.HistorySyncNotification) (*waHistorySync.HistorySync, error)
+	DeleteHistorySyncMedia(ctx context.Context, notif *waE2E.HistorySyncNotification) error
 	RequestHistorySyncOnDemand(ctx context.Context, lastKnown types.MessageInfo, count int) (types.MessageID, error)
 	FetchAppState(ctx context.Context, name string, fullSync, onlyIfNotSynced bool) error
 	RequestAppStateRecovery(ctx context.Context, name string) (types.MessageID, error)

--- a/internal/app/backfill_test.go
+++ b/internal/app/backfill_test.go
@@ -80,8 +80,8 @@ func TestBackfillHistoryAddsOlderMessages(t *testing.T) {
 	if oldest.MsgID != "m1" {
 		t.Fatalf("expected oldest m1, got %q", oldest.MsgID)
 	}
-	if len(f.manualHistorySyncCalls) != 2 || !f.manualHistorySyncCalls[0] || f.manualHistorySyncCalls[1] {
-		t.Fatalf("manual history sync calls = %v, want [true false]", f.manualHistorySyncCalls)
+	if got := f.manualHistorySyncCalls; len(got) != 4 || !got[0] || !got[1] || got[2] || got[3] {
+		t.Fatalf("manual history sync calls = %v, want [true true false false]", got)
 	}
 }
 

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -46,6 +46,7 @@ type fakeWA struct {
 	sendPollCalls       []fakeSendPollCall
 	sendPollVoteCalls   []fakeSendPollVoteCall
 	decryptPollVoteFunc func(evt *events.Message) (*waE2E.PollVoteMessage, error)
+	decryptSecretFunc   func(evt *events.Message) (*waE2E.Message, error)
 	onDemandHistory     func(lastKnown types.MessageInfo, count int) *events.HistorySync
 	onDemandEvent       func(lastKnown types.MessageInfo, count int) interface{}
 	downloadHistory     func(notif *waE2E.HistorySyncNotification) (*waHistorySync.HistorySync, error)
@@ -415,6 +416,16 @@ func (f *fakeWA) SendPollVote(ctx context.Context, pollInfo *types.MessageInfo, 
 func (f *fakeWA) DecryptPollVote(ctx context.Context, evt *events.Message) (*waE2E.PollVoteMessage, error) {
 	f.mu.Lock()
 	cb := f.decryptPollVoteFunc
+	f.mu.Unlock()
+	if cb != nil {
+		return cb(evt)
+	}
+	return nil, fmt.Errorf("not supported")
+}
+
+func (f *fakeWA) DecryptSecretEncryptedMessage(ctx context.Context, evt *events.Message) (*waE2E.Message, error) {
+	f.mu.Lock()
+	cb := f.decryptSecretFunc
 	f.mu.Unlock()
 	if cb != nil {
 		return cb(evt)

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -42,6 +42,9 @@ type fakeWA struct {
 
 	decryptedReaction   *waProto.ReactionMessage
 	decryptReactionErr  error
+	sendPollCalls       []fakeSendPollCall
+	sendPollVoteCalls   []fakeSendPollVoteCall
+	decryptPollVoteFunc func(evt *events.Message) (*waE2E.PollVoteMessage, error)
 	onDemandHistory     func(lastKnown types.MessageInfo, count int) *events.HistorySync
 	onDemandEvent       func(lastKnown types.MessageInfo, count int) interface{}
 	downloadHistory     func(notif *waE2E.HistorySyncNotification) (*waHistorySync.HistorySync, error)
@@ -81,6 +84,19 @@ type fakeMarkReadCall struct {
 	read       bool
 	lastMsgTS  time.Time
 	lastMsgKey *waCommon.MessageKey
+}
+
+type fakeSendPollCall struct {
+	to         types.JID
+	name       string
+	options    []string
+	selectable int
+	ephemeral  bool
+}
+
+type fakeSendPollVoteCall struct {
+	pollInfo types.MessageInfo
+	options  []string
 }
 
 type fakeAppStateFetch struct {
@@ -359,6 +375,42 @@ func (f *fakeWA) SendProtoMessageWithExtra(ctx context.Context, to types.JID, ms
 
 func (f *fakeWA) SendReaction(ctx context.Context, chat, sender types.JID, targetID types.MessageID, reaction string) (types.MessageID, error) {
 	return types.MessageID("reactionid"), nil
+}
+
+func (f *fakeWA) SendPoll(ctx context.Context, to types.JID, name string, options []string, selectable int, ephemeral bool) (types.MessageID, error) {
+	f.mu.Lock()
+	f.sendPollCalls = append(f.sendPollCalls, fakeSendPollCall{
+		to:         to,
+		name:       name,
+		options:    append([]string(nil), options...),
+		selectable: selectable,
+		ephemeral:  ephemeral,
+	})
+	f.mu.Unlock()
+	return types.MessageID("pollid"), nil
+}
+
+func (f *fakeWA) SendPollVote(ctx context.Context, pollInfo *types.MessageInfo, options []string) (types.MessageID, error) {
+	if pollInfo == nil {
+		return "", fmt.Errorf("poll info required")
+	}
+	f.mu.Lock()
+	f.sendPollVoteCalls = append(f.sendPollVoteCalls, fakeSendPollVoteCall{
+		pollInfo: *pollInfo,
+		options:  append([]string(nil), options...),
+	})
+	f.mu.Unlock()
+	return types.MessageID("pollvoteid"), nil
+}
+
+func (f *fakeWA) DecryptPollVote(ctx context.Context, evt *events.Message) (*waE2E.PollVoteMessage, error) {
+	f.mu.Lock()
+	cb := f.decryptPollVoteFunc
+	f.mu.Unlock()
+	if cb != nil {
+		return cb(evt)
+	}
+	return nil, fmt.Errorf("not supported")
 }
 
 func (f *fakeWA) RevokeMessage(ctx context.Context, chat types.JID, targetID types.MessageID) (types.MessageID, error) {

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -50,6 +50,7 @@ type fakeWA struct {
 	onDemandHistory     func(lastKnown types.MessageInfo, count int) *events.HistorySync
 	onDemandEvent       func(lastKnown types.MessageInfo, count int) interface{}
 	downloadHistory     func(notif *waE2E.HistorySyncNotification) (*waHistorySync.HistorySync, error)
+	deleteHistoryCalls  []*waE2E.HistorySyncNotification
 	appStateRecoveryErr error
 	appStateFetchErr    error
 	appStateFetchEvent  func(name string, fullSync, onlyIfNotSynced bool) interface{}
@@ -477,6 +478,13 @@ func (f *fakeWA) DownloadHistorySync(ctx context.Context, notif *waE2E.HistorySy
 		return nil, fmt.Errorf("not supported")
 	}
 	return cb(notif)
+}
+
+func (f *fakeWA) DeleteHistorySyncMedia(ctx context.Context, notif *waE2E.HistorySyncNotification) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleteHistoryCalls = append(f.deleteHistoryCalls, notif)
+	return nil
 }
 
 func (f *fakeWA) ParseWebMessage(chatJID types.JID, webMsg *waWeb.WebMessageInfo) (*events.Message, error) {

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -415,6 +415,9 @@ func (f *fakeWA) SendPollVote(ctx context.Context, pollInfo *types.MessageInfo, 
 }
 
 func (f *fakeWA) DecryptPollVote(ctx context.Context, evt *events.Message) (*waE2E.PollVoteMessage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	f.mu.Lock()
 	cb := f.decryptPollVoteFunc
 	f.mu.Unlock()

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -477,14 +477,18 @@ func (f *fakeWA) ParseWebMessage(chatJID types.JID, webMsg *waWeb.WebMessageInfo
 		chatJID = parsed
 	}
 	sender := chatJID
-	if participant := webMsg.GetParticipant(); participant != "" {
+	if webMsg.GetKey().GetFromMe() {
+		if linked, err := types.ParseJID(f.LinkedJID()); err == nil {
+			sender = linked
+		}
+	} else if participant := webMsg.GetParticipant(); participant != "" {
 		parsed, err := types.ParseJID(participant)
 		if err != nil {
 			return nil, err
 		}
 		sender = parsed
 	}
-	return &events.Message{
+	evt := &events.Message{
 		Info: types.MessageInfo{
 			MessageSource: types.MessageSource{
 				Chat:     chatJID,
@@ -495,8 +499,10 @@ func (f *fakeWA) ParseWebMessage(chatJID types.JID, webMsg *waWeb.WebMessageInfo
 			ID:        webMsg.GetKey().GetID(),
 			Timestamp: time.Unix(int64(webMsg.GetMessageTimestamp()), 0).UTC(),
 		},
-		Message: webMsg.GetMessage(),
-	}, nil
+		RawMessage: webMsg.GetMessage(),
+	}
+	evt.UnwrapRaw()
+	return evt, nil
 }
 
 func (f *fakeWA) DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error) {

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -79,6 +79,8 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 	if err := a.OpenWA(); err != nil {
 		return SyncResult{}, err
 	}
+	a.wa.SetManualHistorySyncDownload(true)
+	defer a.wa.SetManualHistorySyncDownload(false)
 
 	var messagesStored atomic.Int64
 	lastEvent := atomic.Int64{}

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -218,6 +218,13 @@ func (a *App) downloadAndHandleHistorySync(ctx context.Context, opts SyncOptions
 		return
 	}
 	a.handleHistorySync(ctx, opts, &events.HistorySync{Data: data}, messagesStored, lastEvent, enqueueMedia, limits...)
+	if err := a.wa.DeleteHistorySyncMedia(ctx, notif); err != nil {
+		a.emitWarning(
+			"history_delete_failed",
+			fmt.Sprintf("warning: failed to delete history sync media: %v", err),
+			map[string]any{"error": err.Error()},
+		)
+	}
 }
 
 func historySyncNotificationFromMessage(v *events.Message) *waE2E.HistorySyncNotification {

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -268,6 +268,7 @@ func (a *App) handleHistorySync(ctx context.Context, opts SyncOptions, v *events
 					pendingPolls = append(pendingPolls, historyPollSideEffect{pm: pm, evt: pollEvt, hist: m.Message})
 				}
 			} else if ctx.Err() != nil {
+				a.handleHistoryPollSideEffectsBatch(context.WithoutCancel(ctx), pendingPolls)
 				return
 			}
 			if opts.DownloadMedia && pm.Media != nil && pm.ID != "" {

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -215,6 +215,7 @@ func (a *App) handleHistorySync(ctx context.Context, opts SyncOptions, v *events
 		if chatID == "" {
 			continue
 		}
+		var pendingPolls []historyPollSideEffect
 		for _, m := range conv.Messages {
 			lastEvent.Store(nowUTC().UnixNano())
 			if m.Message == nil {
@@ -243,7 +244,9 @@ func (a *App) handleHistorySync(ctx context.Context, opts SyncOptions, v *events
 			}
 			if err := a.storeParsedMessageForSync(ctx, pm, limits...); err == nil {
 				a.emitSyncProgress(messagesStored.Add(1))
-				a.handleHistoryPollSideEffects(ctx, pm, pollEvt, m.Message)
+				if pm.Poll != nil || pm.PollVote != nil {
+					pendingPolls = append(pendingPolls, historyPollSideEffect{pm: pm, evt: pollEvt, hist: m.Message})
+				}
 			} else if ctx.Err() != nil {
 				return
 			}
@@ -251,6 +254,7 @@ func (a *App) handleHistorySync(ctx context.Context, opts SyncOptions, v *events
 				enqueueMedia(pm.Chat.String(), pm.ID)
 			}
 		}
+		a.handleHistoryPollSideEffectsBatch(ctx, pendingPolls)
 	}
 	if !a.eventsEnabled() {
 		a.emitOrPrint("progress", map[string]any{"messages_synced": messagesStored.Load()}, "\rSynced %d messages...", messagesStored.Load())

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -56,6 +56,13 @@ func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, message
 		switch v := evt.(type) {
 		case *events.Message:
 			lastEvent.Store(nowUTC().UnixNano())
+			if notif := historySyncNotificationFromMessage(v); notif != nil {
+				if notif.GetSyncType() == waE2E.HistorySyncType_ON_DEMAND {
+					return
+				}
+				a.downloadAndHandleHistorySync(ctx, opts, notif, messagesStored, lastEvent, enqueueMedia, limits)
+				return
+			}
 			a.handleLiveSyncMessage(ctx, opts, v, messagesStored, enqueueMedia, enqueueWebhook, limits)
 		case *events.HistorySync:
 			lastEvent.Store(nowUTC().UnixNano())
@@ -198,6 +205,19 @@ func (a *App) handleLiveSyncMessage(ctx context.Context, opts SyncOptions, v *ev
 	if opts.DownloadMedia && pm.Media != nil && pm.ID != "" {
 		enqueueMedia(pm.Chat.String(), pm.ID)
 	}
+}
+
+func (a *App) downloadAndHandleHistorySync(ctx context.Context, opts SyncOptions, notif *waE2E.HistorySyncNotification, messagesStored, lastEvent *atomic.Int64, enqueueMedia func(string, string), limits ...*syncStorageLimits) {
+	data, err := a.wa.DownloadHistorySync(ctx, notif)
+	if err != nil {
+		a.emitWarning(
+			"history_download_failed",
+			fmt.Sprintf("warning: failed to download history sync: %v", err),
+			map[string]any{"error": err.Error()},
+		)
+		return
+	}
+	a.handleHistorySync(ctx, opts, &events.HistorySync{Data: data}, messagesStored, lastEvent, enqueueMedia, limits...)
 }
 
 func historySyncNotificationFromMessage(v *events.Message) *waE2E.HistorySyncNotification {

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -224,6 +224,11 @@ func (a *App) handleHistorySync(ctx context.Context, opts SyncOptions, v *events
 			if pm.ID == "" || pm.Chat.IsEmpty() {
 				continue
 			}
+			var pollEvt *events.Message
+			if normalized, evt, ok := a.normalizeHistoryPollMessage(pm, m.Message); ok {
+				pm = normalized
+				pollEvt = evt
+			}
 			if pm.ReactionToID != "" && pm.ReactionEmoji == "" && m.Message.GetMessage().GetEncReactionMessage() != nil {
 				evt, err := a.wa.ParseWebMessage(pm.Chat, m.Message)
 				if err != nil {
@@ -238,7 +243,7 @@ func (a *App) handleHistorySync(ctx context.Context, opts SyncOptions, v *events
 			}
 			if err := a.storeParsedMessageForSync(ctx, pm, limits...); err == nil {
 				a.emitSyncProgress(messagesStored.Add(1))
-				a.handleHistoryPollSideEffects(ctx, pm, m.Message)
+				a.handleHistoryPollSideEffects(ctx, pm, pollEvt, m.Message)
 			} else if ctx.Err() != nil {
 				return
 			}

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -244,7 +244,7 @@ func (a *App) handleHistorySync(ctx context.Context, opts SyncOptions, v *events
 			}
 			if err := a.storeParsedMessageForSync(ctx, pm, limits...); err == nil {
 				a.emitSyncProgress(messagesStored.Add(1))
-				if pm.Poll != nil || pm.PollVote != nil {
+				if pm.Poll != nil || pm.PollAdd != nil || pm.PollVote != nil {
 					pendingPolls = append(pendingPolls, historyPollSideEffect{pm: pm, evt: pollEvt, hist: m.Message})
 				}
 			} else if ctx.Err() != nil {

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -282,7 +282,11 @@ func (a *App) handleHistorySync(ctx context.Context, opts SyncOptions, v *events
 				enqueueMedia(pm.Chat.String(), pm.ID)
 			}
 		}
-		a.handleHistoryPollSideEffectsBatch(ctx, pendingPolls)
+		flushCtx := ctx
+		if ctx.Err() != nil {
+			flushCtx = context.WithoutCancel(ctx)
+		}
+		a.handleHistoryPollSideEffectsBatch(flushCtx, pendingPolls)
 	}
 	if !a.eventsEnabled() {
 		a.emitOrPrint("progress", map[string]any{"messages_synced": messagesStored.Load()}, "\rSynced %d messages...", messagesStored.Load())

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -193,6 +193,7 @@ func (a *App) handleLiveSyncMessage(ctx context.Context, opts SyncOptions, v *ev
 		if enqueueWebhook != nil {
 			enqueueWebhook(pm)
 		}
+		a.handlePollSideEffects(ctx, pm, v)
 	}
 	if opts.DownloadMedia && pm.Media != nil && pm.ID != "" {
 		enqueueMedia(pm.Chat.String(), pm.ID)
@@ -237,6 +238,7 @@ func (a *App) handleHistorySync(ctx context.Context, opts SyncOptions, v *events
 			}
 			if err := a.storeParsedMessageForSync(ctx, pm, limits...); err == nil {
 				a.emitSyncProgress(messagesStored.Add(1))
+				a.handleHistoryPollSideEffects(ctx, pm, m.Message)
 			} else if ctx.Err() != nil {
 				return
 			}

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -200,7 +200,11 @@ func (a *App) handleLiveSyncMessage(ctx context.Context, opts SyncOptions, v *ev
 		if enqueueWebhook != nil {
 			enqueueWebhook(pm)
 		}
-		a.handlePollSideEffects(ctx, pm, v)
+		sideEffectCtx := ctx
+		if ctx.Err() != nil {
+			sideEffectCtx = context.WithoutCancel(ctx)
+		}
+		a.handlePollSideEffects(sideEffectCtx, pm, v)
 	}
 	if opts.DownloadMedia && pm.Media != nil && pm.ID != "" {
 		enqueueMedia(pm.Chat.String(), pm.ID)

--- a/internal/app/sync_limits_test.go
+++ b/internal/app/sync_limits_test.go
@@ -40,6 +40,35 @@ func TestSyncStopsAtMaxMessages(t *testing.T) {
 	}
 }
 
+func TestSyncFlushesHistoryPollsAtMaxMessages(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "123", Server: types.DefaultUserServer}
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	f.connectEvents = []interface{}{historySyncWithPollAndText(chat, base, "poll-limit", "after-limit")}
+
+	res, err := a.Sync(context.Background(), SyncOptions{
+		Mode:        SyncModeFollow,
+		AllowQR:     false,
+		MaxMessages: 1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "sync storage limit reached: message is 1, limit is 1") {
+		t.Fatalf("Sync error = %v", err)
+	}
+	if res.MessagesStored != 1 {
+		t.Fatalf("MessagesStored = %d, want 1", res.MessagesStored)
+	}
+	poll, err := a.db.GetPoll(chat.String(), "poll-limit")
+	if err != nil {
+		t.Fatalf("GetPoll after limit cancellation: %v", err)
+	}
+	if poll.Question != "Limit poll?" {
+		t.Fatalf("poll question = %q", poll.Question)
+	}
+}
+
 func TestSyncRejectsExistingDBOverSizeLimit(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()
@@ -76,6 +105,49 @@ func TestSyncWarnsWhenStorageUncapped(t *testing.T) {
 	})
 	if !strings.Contains(out, "warning: sync storage is uncapped") {
 		t.Fatalf("stderr = %q", out)
+	}
+}
+
+func historySyncWithPollAndText(chat types.JID, start time.Time, pollID, textID string) *events.HistorySync {
+	return &events.HistorySync{
+		Data: &waHistorySync.HistorySync{
+			SyncType: waHistorySync.HistorySync_FULL.Enum(),
+			Conversations: []*waHistorySync.Conversation{{
+				ID: proto.String(chat.String()),
+				Messages: []*waHistorySync.HistorySyncMsg{
+					{
+						Message: &waWeb.WebMessageInfo{
+							Key: &waCommon.MessageKey{
+								RemoteJID: proto.String(chat.String()),
+								FromMe:    proto.Bool(false),
+								ID:        proto.String(pollID),
+							},
+							MessageTimestamp: proto.Uint64(uint64(start.Unix())),
+							Message: &waProto.Message{
+								PollCreationMessageV3: &waProto.PollCreationMessage{
+									Name: proto.String("Limit poll?"),
+									Options: []*waProto.PollCreationMessage_Option{
+										{OptionName: proto.String("Yes")},
+										{OptionName: proto.String("No")},
+									},
+								},
+							},
+						},
+					},
+					{
+						Message: &waWeb.WebMessageInfo{
+							Key: &waCommon.MessageKey{
+								RemoteJID: proto.String(chat.String()),
+								FromMe:    proto.Bool(false),
+								ID:        proto.String(textID),
+							},
+							MessageTimestamp: proto.Uint64(uint64(start.Add(time.Second).Unix())),
+							Message:          &waProto.Message{Conversation: proto.String("text " + textID)},
+						},
+					},
+				},
+			}},
+		},
 	}
 }
 

--- a/internal/app/sync_limits_test.go
+++ b/internal/app/sync_limits_test.go
@@ -6,8 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openclaw/wacli/internal/store"
+	"go.mau.fi/whatsmeow"
 	waProto "go.mau.fi/whatsmeow/binary/proto"
 	"go.mau.fi/whatsmeow/proto/waCommon"
+	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/proto/waHistorySync"
 	"go.mau.fi/whatsmeow/proto/waWeb"
 	"go.mau.fi/whatsmeow/types"
@@ -66,6 +69,51 @@ func TestSyncFlushesHistoryPollsAtMaxMessages(t *testing.T) {
 	}
 	if poll.Question != "Limit poll?" {
 		t.Fatalf("poll question = %q", poll.Question)
+	}
+}
+
+func TestSyncFlushesFinalHistoryPollVoteAtMaxMessages(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "123", Server: types.DefaultUserServer}
+	voter := types.JID{User: "777", Server: types.DefaultUserServer}
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	pollMsgID := "poll-final-limit"
+	if err := a.db.UpsertPoll(store.Poll{
+		ChatJID:         chat.String(),
+		MsgID:           pollMsgID,
+		SenderJID:       chat.String(),
+		Question:        "Final limit?",
+		Options:         []string{"Yes", "No"},
+		SelectableCount: 1,
+		CreatedAt:       base,
+	}); err != nil {
+		t.Fatalf("UpsertPoll: %v", err)
+	}
+	f.decryptPollVoteFunc = func(_ *events.Message) (*waE2E.PollVoteMessage, error) {
+		return &waE2E.PollVoteMessage{SelectedOptions: whatsmeow.HashPollOptions([]string{"Yes"})}, nil
+	}
+	f.connectEvents = []interface{}{historySyncWithPollVote(chat, voter, base, pollMsgID, "vote-final-limit")}
+
+	res, err := a.Sync(context.Background(), SyncOptions{
+		Mode:        SyncModeFollow,
+		AllowQR:     false,
+		MaxMessages: 1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "sync storage limit reached: message is 1, limit is 1") {
+		t.Fatalf("Sync error = %v", err)
+	}
+	if res.MessagesStored != 1 {
+		t.Fatalf("MessagesStored = %d, want 1", res.MessagesStored)
+	}
+	votes, err := a.db.ListPollVotes(chat.String(), pollMsgID)
+	if err != nil {
+		t.Fatalf("ListPollVotes: %v", err)
+	}
+	if len(votes) != 1 || votes[0].VoterJID != voter.String() || votes[0].VoteMsgID != "vote-final-limit" {
+		t.Fatalf("votes = %+v", votes)
 	}
 }
 
@@ -146,6 +194,36 @@ func historySyncWithPollAndText(chat types.JID, start time.Time, pollID, textID 
 						},
 					},
 				},
+			}},
+		},
+	}
+}
+
+func historySyncWithPollVote(chat, voter types.JID, ts time.Time, pollID, voteID string) *events.HistorySync {
+	return &events.HistorySync{
+		Data: &waHistorySync.HistorySync{
+			SyncType: waHistorySync.HistorySync_FULL.Enum(),
+			Conversations: []*waHistorySync.Conversation{{
+				ID: proto.String(chat.String()),
+				Messages: []*waHistorySync.HistorySyncMsg{{
+					Message: &waWeb.WebMessageInfo{
+						Key: &waCommon.MessageKey{
+							RemoteJID: proto.String(chat.String()),
+							FromMe:    proto.Bool(false),
+							ID:        proto.String(voteID),
+						},
+						Participant:      proto.String(voter.String()),
+						MessageTimestamp: proto.Uint64(uint64(ts.Unix())),
+						Message: &waProto.Message{
+							PollUpdateMessage: &waProto.PollUpdateMessage{
+								PollCreationMessageKey: &waCommon.MessageKey{
+									ID:        proto.String(pollID),
+									RemoteJID: proto.String(chat.String()),
+								},
+							},
+						},
+					},
+				}},
 			}},
 		},
 	}

--- a/internal/app/sync_limits_test.go
+++ b/internal/app/sync_limits_test.go
@@ -117,6 +117,51 @@ func TestSyncFlushesFinalHistoryPollVoteAtMaxMessages(t *testing.T) {
 	}
 }
 
+func TestSyncFlushesFinalLivePollVoteAtMaxMessages(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "123", Server: types.DefaultUserServer}
+	voter := types.JID{User: "777", Server: types.DefaultUserServer}
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	pollMsgID := "poll-live-limit"
+	if err := a.db.UpsertPoll(store.Poll{
+		ChatJID:         chat.String(),
+		MsgID:           pollMsgID,
+		SenderJID:       chat.String(),
+		Question:        "Live limit?",
+		Options:         []string{"Yes", "No"},
+		SelectableCount: 1,
+		CreatedAt:       base,
+	}); err != nil {
+		t.Fatalf("UpsertPoll: %v", err)
+	}
+	f.decryptPollVoteFunc = func(_ *events.Message) (*waE2E.PollVoteMessage, error) {
+		return &waE2E.PollVoteMessage{SelectedOptions: whatsmeow.HashPollOptions([]string{"Yes"})}, nil
+	}
+	f.connectEvents = []interface{}{livePollVote(chat, voter, base, pollMsgID, "vote-live-limit")}
+
+	res, err := a.Sync(context.Background(), SyncOptions{
+		Mode:        SyncModeFollow,
+		AllowQR:     false,
+		MaxMessages: 1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "sync storage limit reached: message is 1, limit is 1") {
+		t.Fatalf("Sync error = %v", err)
+	}
+	if res.MessagesStored != 1 {
+		t.Fatalf("MessagesStored = %d, want 1", res.MessagesStored)
+	}
+	votes, err := a.db.ListPollVotes(chat.String(), pollMsgID)
+	if err != nil {
+		t.Fatalf("ListPollVotes: %v", err)
+	}
+	if len(votes) != 1 || votes[0].VoterJID != voter.String() || votes[0].VoteMsgID != "vote-live-limit" {
+		t.Fatalf("votes = %+v", votes)
+	}
+}
+
 func TestSyncRejectsExistingDBOverSizeLimit(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()
@@ -195,6 +240,27 @@ func historySyncWithPollAndText(chat types.JID, start time.Time, pollID, textID 
 					},
 				},
 			}},
+		},
+	}
+}
+
+func livePollVote(chat, voter types.JID, ts time.Time, pollID, voteID string) *events.Message {
+	return &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:   chat,
+				Sender: voter,
+			},
+			ID:        voteID,
+			Timestamp: ts,
+		},
+		Message: &waProto.Message{
+			PollUpdateMessage: &waProto.PollUpdateMessage{
+				PollCreationMessageKey: &waCommon.MessageKey{
+					ID:        proto.String(pollID),
+					RemoteJID: proto.String(chat.String()),
+				},
+			},
 		},
 	}
 }

--- a/internal/app/sync_polls.go
+++ b/internal/app/sync_polls.go
@@ -20,6 +20,9 @@ func (a *App) handlePollSideEffects(ctx context.Context, pm wa.ParsedMessage, ev
 	if pm.Poll != nil {
 		a.upsertPollFromParsed(ctx, pm)
 	}
+	if pm.PollAdd != nil && evt != nil {
+		a.handlePollAddOption(ctx, pm, evt)
+	}
 	if pm.PollVote != nil && evt != nil {
 		a.handlePollVote(ctx, pm, evt)
 	}
@@ -38,6 +41,23 @@ func (a *App) handleHistoryPollSideEffects(ctx context.Context, pm wa.ParsedMess
 	}
 	if pm.Poll != nil {
 		a.upsertPollFromParsed(ctx, pm)
+	}
+	if pm.PollAdd != nil {
+		if evt == nil && hist != nil {
+			parsed, err := a.wa.ParseWebMessage(pm.Chat, hist)
+			if err != nil {
+				a.emitWarning(
+					"poll_add_parse_failed",
+					fmt.Sprintf("warning: failed to parse history poll option %s: %v", pm.ID, err),
+					map[string]any{"message_id": pm.ID, "error": err.Error()},
+				)
+				return
+			}
+			evt = parsed
+		}
+		if evt != nil {
+			a.handlePollAddOption(ctx, pm, evt)
+		}
 	}
 	if pm.PollVote != nil {
 		if evt == nil && hist != nil {
@@ -77,7 +97,12 @@ func (a *App) handleHistoryPollSideEffectsBatch(ctx context.Context, pending []h
 		}
 	}
 	for _, item := range pending {
-		if item.pm.Poll == nil && item.pm.PollVote != nil {
+		if item.pm.Poll == nil && item.pm.PollAdd != nil {
+			a.handleHistoryPollSideEffects(ctx, item.pm, item.evt, item.hist)
+		}
+	}
+	for _, item := range pending {
+		if item.pm.Poll == nil && item.pm.PollAdd == nil && item.pm.PollVote != nil {
 			a.handleHistoryPollSideEffects(ctx, item.pm, item.evt, item.hist)
 		}
 	}
@@ -97,7 +122,7 @@ func (a *App) normalizeHistoryPollMessage(pm wa.ParsedMessage, hist *waProto.Web
 		return pm, nil, false
 	}
 	normalized := wa.ParseLiveMessage(parsed)
-	if normalized.Poll == nil && normalized.PollVote == nil {
+	if normalized.Poll == nil && normalized.PollAdd == nil && normalized.PollVote == nil {
 		return pm, parsed, false
 	}
 	if pm.StarredKnown {
@@ -108,7 +133,7 @@ func (a *App) normalizeHistoryPollMessage(pm wa.ParsedMessage, hist *waProto.Web
 }
 
 func historyPollNeedsEventParse(pm wa.ParsedMessage, hist *waProto.WebMessageInfo) bool {
-	if pm.Poll != nil || pm.PollVote != nil {
+	if pm.Poll != nil || pm.PollAdd != nil || pm.PollVote != nil {
 		return true
 	}
 	if hist == nil {
@@ -123,6 +148,67 @@ func historyPollNeedsEventParse(pm wa.ParsedMessage, hist *waProto.WebMessageInf
 		msg.GetViewOnceMessage().GetMessage() != nil ||
 		msg.GetViewOnceMessageV2().GetMessage() != nil ||
 		msg.GetViewOnceMessageV2Extension().GetMessage() != nil
+}
+
+func (a *App) handlePollAddOption(ctx context.Context, pm wa.ParsedMessage, evt *events.Message) {
+	if a.db == nil || pm.PollAdd == nil {
+		return
+	}
+	add := pm.PollAdd
+	if strings.TrimSpace(add.Option) == "" && evt != nil && evt.Message.GetSecretEncryptedMessage() != nil {
+		decrypted, err := a.wa.DecryptSecretEncryptedMessage(ctx, evt)
+		if err != nil {
+			a.emitWarning(
+				"poll_add_decrypt_failed",
+				fmt.Sprintf("warning: failed to decrypt poll option %s: %v", pm.ID, err),
+				map[string]any{"message_id": pm.ID, "error": err.Error()},
+			)
+			return
+		}
+		parsed := wa.ParseLiveMessage(&events.Message{Info: evt.Info, Message: decrypted})
+		if parsed.PollAdd != nil {
+			add = parsed.PollAdd
+		}
+	}
+	option := strings.TrimSpace(add.Option)
+	if option == "" {
+		return
+	}
+	chatJID, pollMsgID, err := resolvePollAddKey(pm, add)
+	if err != nil {
+		a.emitWarning(
+			"poll_add_unknown_key",
+			fmt.Sprintf("warning: poll option %s has invalid key: %v", pm.ID, err),
+			map[string]any{"message_id": pm.ID, "error": err.Error()},
+		)
+		return
+	}
+	poll, err := a.db.GetPoll(chatJID, pollMsgID)
+	if err != nil {
+		if alt, altErr := a.db.FindPollByMsgID(pollMsgID); altErr == nil {
+			poll = alt
+		} else {
+			a.emitWarning(
+				"poll_add_unknown_poll",
+				fmt.Sprintf("warning: poll option %s references unknown poll %s/%s: %v", pm.ID, chatJID, pollMsgID, err),
+				map[string]any{"message_id": pm.ID, "poll_chat_jid": chatJID, "poll_msg_id": pollMsgID, "error": err.Error()},
+			)
+			return
+		}
+	}
+	for _, existing := range poll.Options {
+		if existing == option {
+			return
+		}
+	}
+	poll.Options = append(poll.Options, option)
+	if err := a.db.UpsertPoll(poll); err != nil {
+		a.emitWarning(
+			"poll_add_store_failed",
+			fmt.Sprintf("warning: failed to store poll option %s: %v", pm.ID, err),
+			map[string]any{"message_id": pm.ID, "error": err.Error()},
+		)
+	}
 }
 
 func (a *App) upsertPollFromParsed(ctx context.Context, pm wa.ParsedMessage) {
@@ -254,6 +340,27 @@ func resolvePollKey(pm wa.ParsedMessage) (string, string, error) {
 		chatJID = canonicalJIDString(pm.Chat)
 	}
 	pollMsgID := strings.TrimSpace(pm.PollVote.PollMessageID)
+	if chatJID == "" || pollMsgID == "" {
+		return "", "", fmt.Errorf("missing poll chat or id")
+	}
+	return chatJID, pollMsgID, nil
+}
+
+func resolvePollAddKey(pm wa.ParsedMessage, add *wa.PollAddOptionRef) (string, string, error) {
+	if add == nil {
+		return "", "", fmt.Errorf("not a poll option add")
+	}
+	rawChat := strings.TrimSpace(add.PollChatJID)
+	chatJID := ""
+	if rawChat != "" {
+		if jid, err := types.ParseJID(rawChat); err == nil {
+			chatJID = canonicalJIDString(jid)
+		}
+	}
+	if chatJID == "" {
+		chatJID = canonicalJIDString(pm.Chat)
+	}
+	pollMsgID := strings.TrimSpace(add.PollMessageID)
 	if chatJID == "" || pollMsgID == "" {
 		return "", "", fmt.Errorf("missing poll chat or id")
 	}

--- a/internal/app/sync_polls.go
+++ b/internal/app/sync_polls.go
@@ -295,7 +295,8 @@ func (a *App) handlePollVote(ctx context.Context, pm wa.ParsedMessage, evt *even
 		return
 	}
 
-	selected := matchPollOptions(poll.Options, decrypted.GetSelectedOptions())
+	selectedHashes := decrypted.GetSelectedOptions()
+	selected := matchPollOptions(poll.Options, selectedHashes)
 
 	voterJID := strings.TrimSpace(pm.SenderJID)
 	if voterJID == "" && pm.FromMe {
@@ -313,13 +314,25 @@ func (a *App) handlePollVote(ctx context.Context, pm wa.ParsedMessage, evt *even
 		return
 	}
 
+	votedAt := pollVoteTimestamp(pm)
+	if len(selectedHashes) == 0 {
+		if err := a.db.DeletePollVote(chatJID, pollMsgID, voterJID, votedAt); err != nil {
+			a.emitWarning(
+				"poll_vote_delete_failed",
+				fmt.Sprintf("warning: failed to delete poll vote %s: %v", pm.ID, err),
+				map[string]any{"message_id": pm.ID, "error": err.Error()},
+			)
+		}
+		return
+	}
+
 	if err := a.db.UpsertPollVote(store.PollVote{
 		ChatJID:   chatJID,
 		PollMsgID: pollMsgID,
 		VoterJID:  voterJID,
 		VoteMsgID: pm.ID,
 		Selected:  selected,
-		VotedAt:   pollVoteTimestamp(pm),
+		VotedAt:   votedAt,
 	}); err != nil {
 		a.emitWarning(
 			"poll_vote_store_failed",

--- a/internal/app/sync_polls.go
+++ b/internal/app/sync_polls.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/openclaw/wacli/internal/store"
 	"github.com/openclaw/wacli/internal/wa"
@@ -312,7 +313,7 @@ func (a *App) handlePollVote(ctx context.Context, pm wa.ParsedMessage, evt *even
 		VoterJID:  voterJID,
 		VoteMsgID: pm.ID,
 		Selected:  selected,
-		VotedAt:   pm.Timestamp,
+		VotedAt:   pollVoteTimestamp(pm),
 	}); err != nil {
 		a.emitWarning(
 			"poll_vote_store_failed",
@@ -320,6 +321,13 @@ func (a *App) handlePollVote(ctx context.Context, pm wa.ParsedMessage, evt *even
 			map[string]any{"message_id": pm.ID, "error": err.Error()},
 		)
 	}
+}
+
+func pollVoteTimestamp(pm wa.ParsedMessage) time.Time {
+	if pm.PollVote != nil && pm.PollVote.SenderTsMS > 0 {
+		return time.UnixMilli(pm.PollVote.SenderTsMS).UTC()
+	}
+	return pm.Timestamp
 }
 
 // resolvePollKey returns the (chat, msg_id) for the poll referenced by a

--- a/internal/app/sync_polls.go
+++ b/internal/app/sync_polls.go
@@ -64,6 +64,25 @@ func (a *App) handleHistoryPollSideEffects(ctx context.Context, pm wa.ParsedMess
 	}
 }
 
+type historyPollSideEffect struct {
+	pm   wa.ParsedMessage
+	evt  *events.Message
+	hist *waProto.WebMessageInfo
+}
+
+func (a *App) handleHistoryPollSideEffectsBatch(ctx context.Context, pending []historyPollSideEffect) {
+	for _, item := range pending {
+		if item.pm.Poll != nil {
+			a.handleHistoryPollSideEffects(ctx, item.pm, item.evt, item.hist)
+		}
+	}
+	for _, item := range pending {
+		if item.pm.Poll == nil && item.pm.PollVote != nil {
+			a.handleHistoryPollSideEffects(ctx, item.pm, item.evt, item.hist)
+		}
+	}
+}
+
 func (a *App) normalizeHistoryPollMessage(pm wa.ParsedMessage, hist *waProto.WebMessageInfo) (wa.ParsedMessage, *events.Message, bool) {
 	if hist == nil || !historyPollNeedsEventParse(pm, hist) {
 		return pm, nil, false

--- a/internal/app/sync_polls.go
+++ b/internal/app/sync_polls.go
@@ -134,7 +134,7 @@ func (a *App) upsertPollFromParsed(ctx context.Context, pm wa.ParsedMessage) {
 		return
 	}
 	senderJID := strings.TrimSpace(pm.SenderJID)
-	if jid, err := types.ParseJID(senderJID); err == nil {
+	if jid, err := types.ParseJID(senderJID); err == nil && pm.Chat.Server != types.GroupServer {
 		senderJID = canonicalJIDString(a.canonicalStoreJID(ctx, jid))
 	}
 	if err := a.db.UpsertPoll(store.Poll{

--- a/internal/app/sync_polls.go
+++ b/internal/app/sync_polls.go
@@ -30,21 +30,64 @@ func (a *App) handlePollSideEffects(ctx context.Context, pm wa.ParsedMessage, ev
 // than an events.Message. Vote decryption requires an events.Message-shaped
 // input, which we reconstruct via ParseWebMessage.
 func (a *App) handleHistoryPollSideEffects(ctx context.Context, pm wa.ParsedMessage, hist *waProto.WebMessageInfo) {
+	var evt *events.Message
+	if hist != nil && historyPollNeedsEventParse(pm, hist) {
+		parsed, err := a.wa.ParseWebMessage(pm.Chat, hist)
+		if err != nil {
+			a.emitWarning(
+				"poll_history_parse_failed",
+				fmt.Sprintf("warning: failed to parse history poll message %s: %v", pm.ID, err),
+				map[string]any{"message_id": pm.ID, "error": err.Error()},
+			)
+			return
+		}
+		evt = parsed
+		pm = wa.ParseLiveMessage(parsed)
+	}
 	if pm.Poll != nil {
 		a.upsertPollFromParsed(ctx, pm)
 	}
-	if pm.PollVote != nil && hist != nil {
-		evt, err := a.wa.ParseWebMessage(pm.Chat, hist)
-		if err != nil {
+	if pm.PollVote != nil {
+		if evt == nil && hist != nil {
+			parsed, err := a.wa.ParseWebMessage(pm.Chat, hist)
+			if err != nil {
+				a.emitWarning(
+					"poll_vote_parse_failed",
+					fmt.Sprintf("warning: failed to parse history poll vote %s: %v", pm.ID, err),
+					map[string]any{"message_id": pm.ID, "error": err.Error()},
+				)
+				return
+			}
+			evt = parsed
+		}
+		if evt == nil {
 			a.emitWarning(
 				"poll_vote_parse_failed",
-				fmt.Sprintf("warning: failed to parse history poll vote %s: %v", pm.ID, err),
-				map[string]any{"message_id": pm.ID, "error": err.Error()},
+				fmt.Sprintf("warning: failed to parse history poll vote %s: missing history message", pm.ID),
+				map[string]any{"message_id": pm.ID, "error": "missing history message"},
 			)
 			return
 		}
 		a.handlePollVote(ctx, pm, evt)
 	}
+}
+
+func historyPollNeedsEventParse(pm wa.ParsedMessage, hist *waProto.WebMessageInfo) bool {
+	if pm.Poll != nil || pm.PollVote != nil {
+		return true
+	}
+	if hist == nil {
+		return false
+	}
+	msg := hist.GetMessage()
+	if msg == nil {
+		return false
+	}
+	return msg.GetDeviceSentMessage().GetMessage() != nil ||
+		msg.GetEphemeralMessage().GetMessage() != nil ||
+		msg.GetViewOnceMessage().GetMessage() != nil ||
+		msg.GetViewOnceMessageV2().GetMessage() != nil ||
+		msg.GetViewOnceMessageV2Extension().GetMessage() != nil
 }
 
 func (a *App) upsertPollFromParsed(ctx context.Context, pm wa.ParsedMessage) {

--- a/internal/app/sync_polls.go
+++ b/internal/app/sync_polls.go
@@ -9,9 +9,9 @@ import (
 	"github.com/openclaw/wacli/internal/store"
 	"github.com/openclaw/wacli/internal/wa"
 	"go.mau.fi/whatsmeow"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
-	waProto "go.mau.fi/whatsmeow/binary/proto"
 )
 
 // handlePollSideEffects writes Poll / PollVote rows after the underlying

--- a/internal/app/sync_polls.go
+++ b/internal/app/sync_polls.go
@@ -168,7 +168,7 @@ func (a *App) handlePollAddOption(ctx context.Context, pm wa.ParsedMessage, evt 
 		}
 		parsed := wa.ParseLiveMessage(&events.Message{Info: evt.Info, Message: decrypted})
 		if parsed.PollAdd != nil {
-			add = parsed.PollAdd
+			add = mergePollAddOption(add, parsed.PollAdd)
 		}
 	}
 	option := strings.TrimSpace(add.Option)
@@ -358,6 +358,29 @@ func resolvePollKey(pm wa.ParsedMessage) (string, string, error) {
 		return "", "", fmt.Errorf("missing poll chat or id")
 	}
 	return chatJID, pollMsgID, nil
+}
+
+func mergePollAddOption(wrapper, decrypted *wa.PollAddOptionRef) *wa.PollAddOptionRef {
+	if wrapper == nil {
+		return decrypted
+	}
+	if decrypted == nil {
+		return wrapper
+	}
+	merged := *wrapper
+	if strings.TrimSpace(decrypted.Option) != "" {
+		merged.Option = decrypted.Option
+	}
+	if strings.TrimSpace(merged.PollMessageID) == "" {
+		merged.PollMessageID = decrypted.PollMessageID
+	}
+	if strings.TrimSpace(merged.PollChatJID) == "" {
+		merged.PollChatJID = decrypted.PollChatJID
+	}
+	if strings.TrimSpace(merged.PollSenderJID) == "" {
+		merged.PollSenderJID = decrypted.PollSenderJID
+	}
+	return &merged
 }
 
 func resolvePollAddKey(pm wa.ParsedMessage, add *wa.PollAddOptionRef) (string, string, error) {

--- a/internal/app/sync_polls.go
+++ b/internal/app/sync_polls.go
@@ -223,6 +223,12 @@ func (a *App) upsertPollFromParsed(ctx context.Context, pm wa.ParsedMessage) {
 	senderJID := strings.TrimSpace(pm.SenderJID)
 	if jid, err := types.ParseJID(senderJID); err == nil && pm.Chat.Server != types.GroupServer {
 		senderJID = canonicalJIDString(a.canonicalStoreJID(ctx, jid))
+	} else if err == nil && pm.FromMe && jid.Server == types.DefaultUserServer {
+		if info, infoErr := a.wa.GetGroupInfo(ctx, pm.Chat); infoErr == nil && info != nil && info.AddressingMode == types.AddressingModeLID {
+			if lid := a.wa.ResolvePNToLID(ctx, jid); !lid.IsEmpty() && lid.Server == types.HiddenUserServer {
+				senderJID = canonicalJIDString(lid)
+			}
+		}
 	}
 	if err := a.db.UpsertPoll(store.Poll{
 		ChatJID:         chatJID,

--- a/internal/app/sync_polls.go
+++ b/internal/app/sync_polls.go
@@ -18,7 +18,7 @@ import (
 // message has been persisted to the messages table.
 func (a *App) handlePollSideEffects(ctx context.Context, pm wa.ParsedMessage, evt *events.Message) {
 	if pm.Poll != nil {
-		a.upsertPollFromParsed(pm)
+		a.upsertPollFromParsed(ctx, pm)
 	}
 	if pm.PollVote != nil && evt != nil {
 		a.handlePollVote(ctx, pm, evt)
@@ -31,7 +31,7 @@ func (a *App) handlePollSideEffects(ctx context.Context, pm wa.ParsedMessage, ev
 // input, which we reconstruct via ParseWebMessage.
 func (a *App) handleHistoryPollSideEffects(ctx context.Context, pm wa.ParsedMessage, hist *waProto.WebMessageInfo) {
 	if pm.Poll != nil {
-		a.upsertPollFromParsed(pm)
+		a.upsertPollFromParsed(ctx, pm)
 	}
 	if pm.PollVote != nil && hist != nil {
 		evt, err := a.wa.ParseWebMessage(pm.Chat, hist)
@@ -47,18 +47,22 @@ func (a *App) handleHistoryPollSideEffects(ctx context.Context, pm wa.ParsedMess
 	}
 }
 
-func (a *App) upsertPollFromParsed(pm wa.ParsedMessage) {
+func (a *App) upsertPollFromParsed(ctx context.Context, pm wa.ParsedMessage) {
 	if a.db == nil || pm.Poll == nil {
 		return
 	}
-	chatJID := canonicalJIDString(pm.Chat)
+	chatJID := canonicalJIDString(a.canonicalStoreJID(ctx, pm.Chat))
 	if chatJID == "" {
 		return
+	}
+	senderJID := strings.TrimSpace(pm.SenderJID)
+	if jid, err := types.ParseJID(senderJID); err == nil {
+		senderJID = canonicalJIDString(a.canonicalStoreJID(ctx, jid))
 	}
 	if err := a.db.UpsertPoll(store.Poll{
 		ChatJID:         chatJID,
 		MsgID:           pm.ID,
-		SenderJID:       pm.SenderJID,
+		SenderJID:       senderJID,
 		Question:        pm.Poll.Question,
 		Options:         pm.Poll.Options,
 		SelectableCount: pm.Poll.SelectableCount,

--- a/internal/app/sync_polls.go
+++ b/internal/app/sync_polls.go
@@ -29,20 +29,12 @@ func (a *App) handlePollSideEffects(ctx context.Context, pm wa.ParsedMessage, ev
 // arriving via HistorySync, where we have a *waProto.WebMessageInfo rather
 // than an events.Message. Vote decryption requires an events.Message-shaped
 // input, which we reconstruct via ParseWebMessage.
-func (a *App) handleHistoryPollSideEffects(ctx context.Context, pm wa.ParsedMessage, hist *waProto.WebMessageInfo) {
-	var evt *events.Message
-	if hist != nil && historyPollNeedsEventParse(pm, hist) {
-		parsed, err := a.wa.ParseWebMessage(pm.Chat, hist)
-		if err != nil {
-			a.emitWarning(
-				"poll_history_parse_failed",
-				fmt.Sprintf("warning: failed to parse history poll message %s: %v", pm.ID, err),
-				map[string]any{"message_id": pm.ID, "error": err.Error()},
-			)
-			return
+func (a *App) handleHistoryPollSideEffects(ctx context.Context, pm wa.ParsedMessage, evt *events.Message, hist *waProto.WebMessageInfo) {
+	if evt == nil {
+		if normalized, parsed, ok := a.normalizeHistoryPollMessage(pm, hist); ok {
+			pm = normalized
+			evt = parsed
 		}
-		evt = parsed
-		pm = wa.ParseLiveMessage(parsed)
 	}
 	if pm.Poll != nil {
 		a.upsertPollFromParsed(ctx, pm)
@@ -70,6 +62,30 @@ func (a *App) handleHistoryPollSideEffects(ctx context.Context, pm wa.ParsedMess
 		}
 		a.handlePollVote(ctx, pm, evt)
 	}
+}
+
+func (a *App) normalizeHistoryPollMessage(pm wa.ParsedMessage, hist *waProto.WebMessageInfo) (wa.ParsedMessage, *events.Message, bool) {
+	if hist == nil || !historyPollNeedsEventParse(pm, hist) {
+		return pm, nil, false
+	}
+	parsed, err := a.wa.ParseWebMessage(pm.Chat, hist)
+	if err != nil {
+		a.emitWarning(
+			"poll_history_parse_failed",
+			fmt.Sprintf("warning: failed to parse history poll message %s: %v", pm.ID, err),
+			map[string]any{"message_id": pm.ID, "error": err.Error()},
+		)
+		return pm, nil, false
+	}
+	normalized := wa.ParseLiveMessage(parsed)
+	if normalized.Poll == nil && normalized.PollVote == nil {
+		return pm, parsed, false
+	}
+	if pm.StarredKnown {
+		normalized.StarredKnown = true
+		normalized.Starred = pm.Starred
+	}
+	return normalized, parsed, true
 }
 
 func historyPollNeedsEventParse(pm wa.ParsedMessage, hist *waProto.WebMessageInfo) bool {

--- a/internal/app/sync_polls.go
+++ b/internal/app/sync_polls.go
@@ -1,0 +1,199 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/openclaw/wacli/internal/store"
+	"github.com/openclaw/wacli/internal/wa"
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+)
+
+// handlePollSideEffects writes Poll / PollVote rows after the underlying
+// message has been persisted to the messages table.
+func (a *App) handlePollSideEffects(ctx context.Context, pm wa.ParsedMessage, evt *events.Message) {
+	if pm.Poll != nil {
+		a.upsertPollFromParsed(pm)
+	}
+	if pm.PollVote != nil && evt != nil {
+		a.handlePollVote(ctx, pm, evt)
+	}
+}
+
+// handleHistoryPollSideEffects mirrors handlePollSideEffects for messages
+// arriving via HistorySync, where we have a *waProto.WebMessageInfo rather
+// than an events.Message. Vote decryption requires an events.Message-shaped
+// input, which we reconstruct via ParseWebMessage.
+func (a *App) handleHistoryPollSideEffects(ctx context.Context, pm wa.ParsedMessage, hist *waProto.WebMessageInfo) {
+	if pm.Poll != nil {
+		a.upsertPollFromParsed(pm)
+	}
+	if pm.PollVote != nil && hist != nil {
+		evt, err := a.wa.ParseWebMessage(pm.Chat, hist)
+		if err != nil {
+			a.emitWarning(
+				"poll_vote_parse_failed",
+				fmt.Sprintf("warning: failed to parse history poll vote %s: %v", pm.ID, err),
+				map[string]any{"message_id": pm.ID, "error": err.Error()},
+			)
+			return
+		}
+		a.handlePollVote(ctx, pm, evt)
+	}
+}
+
+func (a *App) upsertPollFromParsed(pm wa.ParsedMessage) {
+	if a.db == nil || pm.Poll == nil {
+		return
+	}
+	chatJID := canonicalJIDString(pm.Chat)
+	if chatJID == "" {
+		return
+	}
+	if err := a.db.UpsertPoll(store.Poll{
+		ChatJID:         chatJID,
+		MsgID:           pm.ID,
+		SenderJID:       pm.SenderJID,
+		Question:        pm.Poll.Question,
+		Options:         pm.Poll.Options,
+		SelectableCount: pm.Poll.SelectableCount,
+		CreatedAt:       pm.Timestamp,
+	}); err != nil {
+		a.emitWarning(
+			"poll_upsert_failed",
+			fmt.Sprintf("warning: failed to store poll %s: %v", pm.ID, err),
+			map[string]any{"message_id": pm.ID, "error": err.Error()},
+		)
+	}
+}
+
+func (a *App) handlePollVote(ctx context.Context, pm wa.ParsedMessage, evt *events.Message) {
+	if a.db == nil || pm.PollVote == nil || evt == nil {
+		return
+	}
+	chatJID, pollMsgID, err := resolvePollKey(pm)
+	if err != nil {
+		a.emitWarning(
+			"poll_vote_unknown_key",
+			fmt.Sprintf("warning: poll vote %s has invalid key: %v", pm.ID, err),
+			map[string]any{"message_id": pm.ID, "error": err.Error()},
+		)
+		return
+	}
+
+	poll, err := a.db.GetPoll(chatJID, pollMsgID)
+	if err != nil {
+		// Fall back to msg-id-only lookup. WhatsApp re-keys self-poll
+		// votes under the LID rather than the phone-number JID, so the
+		// (chat, id) tuple in the vote event won't match the row we
+		// stored when the poll was sent.
+		if alt, altErr := a.db.FindPollByMsgID(pollMsgID); altErr == nil {
+			poll = alt
+			chatJID = alt.ChatJID
+		} else {
+			a.emitWarning(
+				"poll_vote_unknown_poll",
+				fmt.Sprintf("warning: poll vote %s references unknown poll %s/%s: %v", pm.ID, chatJID, pollMsgID, err),
+				map[string]any{
+					"message_id":    pm.ID,
+					"poll_chat_jid": chatJID,
+					"poll_msg_id":   pollMsgID,
+					"error":         err.Error(),
+				},
+			)
+			return
+		}
+	}
+
+	decrypted, err := a.wa.DecryptPollVote(ctx, evt)
+	if err != nil {
+		a.emitWarning(
+			"poll_vote_decrypt_failed",
+			fmt.Sprintf("warning: failed to decrypt poll vote %s: %v", pm.ID, err),
+			map[string]any{"message_id": pm.ID, "error": err.Error()},
+		)
+		return
+	}
+
+	selected := matchPollOptions(poll.Options, decrypted.GetSelectedOptions())
+
+	voterJID := strings.TrimSpace(pm.SenderJID)
+	if voterJID == "" && pm.FromMe {
+		voterJID = a.wa.LinkedJID()
+	}
+	if parsed, err := types.ParseJID(voterJID); err == nil {
+		voterJID = canonicalJIDString(a.wa.ResolveLIDToPN(ctx, parsed))
+	}
+	if voterJID == "" {
+		a.emitWarning(
+			"poll_vote_no_voter",
+			fmt.Sprintf("warning: poll vote %s has no voter JID", pm.ID),
+			map[string]any{"message_id": pm.ID},
+		)
+		return
+	}
+
+	if err := a.db.UpsertPollVote(store.PollVote{
+		ChatJID:   chatJID,
+		PollMsgID: pollMsgID,
+		VoterJID:  voterJID,
+		VoteMsgID: pm.ID,
+		Selected:  selected,
+		VotedAt:   pm.Timestamp,
+	}); err != nil {
+		a.emitWarning(
+			"poll_vote_store_failed",
+			fmt.Sprintf("warning: failed to store poll vote %s: %v", pm.ID, err),
+			map[string]any{"message_id": pm.ID, "error": err.Error()},
+		)
+	}
+}
+
+// resolvePollKey returns the (chat, msg_id) for the poll referenced by a
+// PollUpdateMessage. The PollCreationMessageKey embeds chat (RemoteJID) and
+// msg id; we trust that.
+func resolvePollKey(pm wa.ParsedMessage) (string, string, error) {
+	if pm.PollVote == nil {
+		return "", "", fmt.Errorf("not a poll vote")
+	}
+	rawChat := strings.TrimSpace(pm.PollVote.PollChatJID)
+	chatJID := ""
+	if rawChat != "" {
+		if jid, err := types.ParseJID(rawChat); err == nil {
+			chatJID = canonicalJIDString(jid)
+		}
+	}
+	if chatJID == "" {
+		chatJID = canonicalJIDString(pm.Chat)
+	}
+	pollMsgID := strings.TrimSpace(pm.PollVote.PollMessageID)
+	if chatJID == "" || pollMsgID == "" {
+		return "", "", fmt.Errorf("missing poll chat or id")
+	}
+	return chatJID, pollMsgID, nil
+}
+
+// matchPollOptions maps SHA-256 vote hashes back to option names by hashing
+// the stored option list (whatsmeow.HashPollOptions) and matching by bytes.
+// Unknown hashes are dropped silently.
+func matchPollOptions(stored []string, hashes [][]byte) []string {
+	if len(hashes) == 0 {
+		return []string{}
+	}
+	storedHashes := whatsmeow.HashPollOptions(stored)
+	out := make([]string, 0, len(hashes))
+	for _, h := range hashes {
+		for i, sh := range storedHashes {
+			if bytes.Equal(h, sh) {
+				out = append(out, stored[i])
+				break
+			}
+		}
+	}
+	return out
+}

--- a/internal/app/sync_polls_test.go
+++ b/internal/app/sync_polls_test.go
@@ -1,0 +1,207 @@
+package app
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestLiveSyncStoresPollCreation(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "555", Server: types.DefaultUserServer}
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat},
+			ID:            "POLL-1",
+			Timestamp:     time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{
+			PollCreationMessageV3: &waProto.PollCreationMessage{
+				Name: proto.String("Pizza?"),
+				Options: []*waProto.PollCreationMessage_Option{
+					{OptionName: proto.String("Yes")},
+					{OptionName: proto.String("No")},
+				},
+				SelectableOptionsCount: proto.Uint32(1),
+			},
+		},
+	}
+
+	var messagesStored atomic.Int64
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, evt, &messagesStored, func(string, string) {}, nil)
+
+	if messagesStored.Load() != 1 {
+		t.Fatalf("messagesStored = %d", messagesStored.Load())
+	}
+	poll, err := a.db.GetPoll(chat.String(), "POLL-1")
+	if err != nil {
+		t.Fatalf("GetPoll: %v", err)
+	}
+	if poll.Question != "Pizza?" {
+		t.Fatalf("question = %q", poll.Question)
+	}
+	if len(poll.Options) != 2 || poll.Options[0] != "Yes" || poll.Options[1] != "No" {
+		t.Fatalf("options = %v", poll.Options)
+	}
+	if poll.SelectableCount != 1 {
+		t.Fatalf("selectable = %d", poll.SelectableCount)
+	}
+}
+
+func TestLiveSyncDecryptsAndStoresPollVote(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "555", Server: types.DefaultUserServer}
+	pollMsgID := "POLL-1"
+	options := []string{"Yes", "No", "Maybe"}
+
+	// Persist the poll first.
+	creationEvt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat, IsFromMe: true},
+			ID:            pollMsgID,
+			Timestamp:     time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{
+			PollCreationMessageV3: &waProto.PollCreationMessage{
+				Name:                   proto.String("Pizza?"),
+				Options:                []*waProto.PollCreationMessage_Option{{OptionName: proto.String("Yes")}, {OptionName: proto.String("No")}, {OptionName: proto.String("Maybe")}},
+				SelectableOptionsCount: proto.Uint32(2),
+			},
+		},
+	}
+	var messagesStored atomic.Int64
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, creationEvt, &messagesStored, func(string, string) {}, nil)
+
+	// Voter votes for Yes + Maybe.
+	voter := types.JID{User: "777", Server: types.DefaultUserServer}
+	hashes := whatsmeow.HashPollOptions([]string{"Yes", "Maybe"})
+	f.decryptPollVoteFunc = func(_ *events.Message) (*waE2E.PollVoteMessage, error) {
+		return &waE2E.PollVoteMessage{SelectedOptions: hashes}, nil
+	}
+
+	voteEvt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: voter},
+			ID:            "VOTE-1",
+			Timestamp:     time.Date(2026, 5, 9, 12, 5, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{
+			PollUpdateMessage: &waProto.PollUpdateMessage{
+				PollCreationMessageKey: &waProto.MessageKey{
+					ID:          proto.String(pollMsgID),
+					RemoteJID:   proto.String(chat.String()),
+					Participant: proto.String(chat.String()),
+					FromMe:      proto.Bool(true),
+				},
+			},
+		},
+	}
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, voteEvt, &messagesStored, func(string, string) {}, nil)
+
+	votes, err := a.db.ListPollVotes(chat.String(), pollMsgID)
+	if err != nil {
+		t.Fatalf("ListPollVotes: %v", err)
+	}
+	if len(votes) != 1 {
+		t.Fatalf("vote count = %d", len(votes))
+	}
+	if votes[0].VoterJID != voter.String() {
+		t.Fatalf("voter = %q", votes[0].VoterJID)
+	}
+	want := []string{"Yes", "Maybe"}
+	if !sameStringSet(votes[0].Selected, want) {
+		t.Fatalf("selected = %v want %v", votes[0].Selected, want)
+	}
+	_ = options
+}
+
+func TestLiveSyncWarnsWhenPollVoteRefersToUnknownPoll(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+	f.decryptPollVoteFunc = func(_ *events.Message) (*waE2E.PollVoteMessage, error) {
+		return &waE2E.PollVoteMessage{}, nil
+	}
+
+	chat := types.JID{User: "555", Server: types.DefaultUserServer}
+	voteEvt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat},
+			ID:            "VOTE-X",
+			Timestamp:     time.Now(),
+		},
+		Message: &waProto.Message{
+			PollUpdateMessage: &waProto.PollUpdateMessage{
+				PollCreationMessageKey: &waProto.MessageKey{
+					ID:        proto.String("UNKNOWN-POLL"),
+					RemoteJID: proto.String(chat.String()),
+				},
+			},
+		},
+	}
+
+	var messagesStored atomic.Int64
+	out := captureStderr(t, func() {
+		a.handleLiveSyncMessage(context.Background(), SyncOptions{}, voteEvt, &messagesStored, func(string, string) {}, nil)
+	})
+	if !contains(out, "poll_vote_unknown_poll") && !contains(out, "warning: poll vote") {
+		t.Fatalf("expected unknown-poll warning, got:\n%s", out)
+	}
+	votes, err := a.db.ListPollVotes(chat.String(), "UNKNOWN-POLL")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(votes) != 0 {
+		t.Fatalf("expected no votes stored, got %d", len(votes))
+	}
+}
+
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	count := func(s []string, v string) int {
+		n := 0
+		for _, x := range s {
+			if x == v {
+				n++
+			}
+		}
+		return n
+	}
+	for _, v := range a {
+		if count(a, v) != count(b, v) {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(s, sub string) bool {
+	if len(sub) == 0 {
+		return true
+	}
+	if len(s) < len(sub) {
+		return false
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/sync_polls_test.go
+++ b/internal/app/sync_polls_test.go
@@ -278,6 +278,99 @@ func TestHistorySyncStoresPollVoteBeforeCreation(t *testing.T) {
 	}
 }
 
+func TestLiveSyncDecryptsPollAddOptionBeforeVote(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "555", Server: types.DefaultUserServer}
+	pollMsgID := "POLL-ADD"
+	created := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+
+	creationEvt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat},
+			ID:            pollMsgID,
+			Timestamp:     created,
+		},
+		Message: &waProto.Message{
+			PollCreationMessageV3: &waProto.PollCreationMessage{
+				Name:                   proto.String("Dinner?"),
+				Options:                []*waProto.PollCreationMessage_Option{{OptionName: proto.String("Yes")}, {OptionName: proto.String("No")}},
+				SelectableOptionsCount: proto.Uint32(1),
+			},
+		},
+	}
+	var messagesStored atomic.Int64
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, creationEvt, &messagesStored, func(string, string) {}, nil)
+
+	f.decryptSecretFunc = func(_ *events.Message) (*waE2E.Message, error) {
+		return &waE2E.Message{
+			PollAddOptionMessage: &waE2E.PollAddOptionMessage{
+				PollCreationMessageKey: &waCommon.MessageKey{
+					ID:        proto.String(pollMsgID),
+					RemoteJID: proto.String(chat.String()),
+				},
+				AddOption: &waE2E.PollCreationMessage_Option{OptionName: proto.String("Maybe")},
+			},
+		}, nil
+	}
+	addEvt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat},
+			ID:            "ADD-1",
+			Timestamp:     created.Add(time.Minute),
+		},
+		Message: &waProto.Message{
+			SecretEncryptedMessage: &waE2E.SecretEncryptedMessage{
+				TargetMessageKey: &waCommon.MessageKey{
+					ID:        proto.String(pollMsgID),
+					RemoteJID: proto.String(chat.String()),
+				},
+				SecretEncType: waE2E.SecretEncryptedMessage_POLL_ADD_OPTION.Enum(),
+			},
+		},
+	}
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, addEvt, &messagesStored, func(string, string) {}, nil)
+
+	poll, err := a.db.GetPoll(chat.String(), pollMsgID)
+	if err != nil {
+		t.Fatalf("GetPoll: %v", err)
+	}
+	if !sameStringSet(poll.Options, []string{"Yes", "No", "Maybe"}) {
+		t.Fatalf("options = %v", poll.Options)
+	}
+
+	f.decryptPollVoteFunc = func(_ *events.Message) (*waE2E.PollVoteMessage, error) {
+		return &waE2E.PollVoteMessage{SelectedOptions: whatsmeow.HashPollOptions([]string{"Maybe"})}, nil
+	}
+	voter := types.JID{User: "777", Server: types.DefaultUserServer}
+	voteEvt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: voter},
+			ID:            "VOTE-ADD",
+			Timestamp:     created.Add(2 * time.Minute),
+		},
+		Message: &waProto.Message{
+			PollUpdateMessage: &waProto.PollUpdateMessage{
+				PollCreationMessageKey: &waCommon.MessageKey{
+					ID:        proto.String(pollMsgID),
+					RemoteJID: proto.String(chat.String()),
+				},
+			},
+		},
+	}
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, voteEvt, &messagesStored, func(string, string) {}, nil)
+
+	votes, err := a.db.ListPollVotes(chat.String(), pollMsgID)
+	if err != nil {
+		t.Fatalf("ListPollVotes: %v", err)
+	}
+	if len(votes) != 1 || !sameStringSet(votes[0].Selected, []string{"Maybe"}) {
+		t.Fatalf("votes = %+v", votes)
+	}
+}
+
 func TestLiveSyncDecryptsAndStoresPollVote(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/app/sync_polls_test.go
+++ b/internal/app/sync_polls_test.go
@@ -59,6 +59,50 @@ func TestLiveSyncStoresPollCreation(t *testing.T) {
 	}
 }
 
+func TestLiveSyncStoresPollCreationUnderCanonicalPN(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	lid := types.JID{User: "999", Server: types.HiddenUserServer}
+	pn := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+	senderLID := types.JID{User: "777", Server: types.HiddenUserServer}
+	senderPN := types.JID{User: "15557654321", Server: types.DefaultUserServer}
+	f.lids[lid] = pn
+	f.lids[senderLID] = senderPN
+
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: lid, Sender: senderLID},
+			ID:            "POLL-LID",
+			Timestamp:     time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{
+			PollCreationMessageV3: &waProto.PollCreationMessage{
+				Name: proto.String("Canonical?"),
+				Options: []*waProto.PollCreationMessage_Option{
+					{OptionName: proto.String("Yes")},
+					{OptionName: proto.String("No")},
+				},
+			},
+		},
+	}
+
+	var messagesStored atomic.Int64
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, evt, &messagesStored, func(string, string) {}, nil)
+
+	poll, err := a.db.GetPoll(pn.String(), "POLL-LID")
+	if err != nil {
+		t.Fatalf("GetPoll canonical PN: %v", err)
+	}
+	if poll.SenderJID != senderPN.String() {
+		t.Fatalf("SenderJID = %q, want %q", poll.SenderJID, senderPN.String())
+	}
+	if _, err := a.db.GetPoll(lid.String(), "POLL-LID"); err == nil {
+		t.Fatalf("poll was also stored under raw LID")
+	}
+}
+
 func TestLiveSyncDecryptsAndStoresPollVote(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/app/sync_polls_test.go
+++ b/internal/app/sync_polls_test.go
@@ -8,7 +8,10 @@ import (
 
 	"go.mau.fi/whatsmeow"
 	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/proto/waCommon"
 	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/proto/waHistorySync"
+	"go.mau.fi/whatsmeow/proto/waWeb"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	"google.golang.org/protobuf/proto"
@@ -100,6 +103,61 @@ func TestLiveSyncStoresPollCreationUnderCanonicalPN(t *testing.T) {
 	}
 	if _, err := a.db.GetPoll(lid.String(), "POLL-LID"); err == nil {
 		t.Fatalf("poll was also stored under raw LID")
+	}
+}
+
+func TestHistorySyncStoresWrappedSelfPollWithLinkedSender(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "555", Server: types.DefaultUserServer}
+	created := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	hist := &waWeb.WebMessageInfo{
+		Key: &waCommon.MessageKey{
+			RemoteJID: proto.String(chat.String()),
+			FromMe:    proto.Bool(true),
+			ID:        proto.String("POLL-HIST"),
+		},
+		MessageTimestamp: proto.Uint64(uint64(created.Unix())),
+		Message: &waProto.Message{
+			EphemeralMessage: &waProto.FutureProofMessage{
+				Message: &waProto.Message{
+					PollCreationMessageV3: &waProto.PollCreationMessage{
+						Name: proto.String("Wrapped?"),
+						Options: []*waProto.PollCreationMessage_Option{
+							{OptionName: proto.String("Yes")},
+							{OptionName: proto.String("No")},
+						},
+						SelectableOptionsCount: proto.Uint32(1),
+					},
+				},
+			},
+		},
+	}
+	history := &events.HistorySync{
+		Data: &waHistorySync.HistorySync{
+			SyncType: waHistorySync.HistorySync_FULL.Enum(),
+			Conversations: []*waHistorySync.Conversation{{
+				ID:       proto.String(chat.String()),
+				Messages: []*waHistorySync.HistorySyncMsg{{Message: hist}},
+			}},
+		},
+	}
+
+	var messagesStored atomic.Int64
+	var lastEvent atomic.Int64
+	a.handleHistorySync(context.Background(), SyncOptions{}, history, &messagesStored, &lastEvent, func(string, string) {})
+
+	poll, err := a.db.GetPoll(chat.String(), "POLL-HIST")
+	if err != nil {
+		t.Fatalf("GetPoll: %v", err)
+	}
+	if poll.Question != "Wrapped?" {
+		t.Fatalf("Question = %q", poll.Question)
+	}
+	if poll.SenderJID != f.LinkedJID() {
+		t.Fatalf("SenderJID = %q, want %q", poll.SenderJID, f.LinkedJID())
 	}
 }
 

--- a/internal/app/sync_polls_test.go
+++ b/internal/app/sync_polls_test.go
@@ -441,6 +441,71 @@ func TestLiveSyncDecryptsAndStoresPollVote(t *testing.T) {
 	_ = options
 }
 
+func TestLiveSyncKeepsNewerSameSecondPollVote(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "555", Server: types.DefaultUserServer}
+	voter := types.JID{User: "777", Server: types.DefaultUserServer}
+	pollMsgID := "POLL-1"
+	base := time.Date(2026, 5, 9, 12, 5, 0, 0, time.UTC)
+	var messagesStored atomic.Int64
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat, IsFromMe: true},
+			ID:            pollMsgID,
+			Timestamp:     base.Add(-time.Minute),
+		},
+		Message: &waProto.Message{
+			PollCreationMessageV3: &waProto.PollCreationMessage{
+				Name: proto.String("Pizza?"),
+				Options: []*waProto.PollCreationMessage_Option{
+					{OptionName: proto.String("Old")},
+					{OptionName: proto.String("New")},
+				},
+				SelectableOptionsCount: proto.Uint32(1),
+			},
+		},
+	}, &messagesStored, func(string, string) {}, nil)
+
+	f.decryptPollVoteFunc = func(evt *events.Message) (*waE2E.PollVoteMessage, error) {
+		selected := []string{"Old"}
+		if evt.Info.ID == "VOTE-NEW" {
+			selected = []string{"New"}
+		}
+		return &waE2E.PollVoteMessage{SelectedOptions: whatsmeow.HashPollOptions(selected)}, nil
+	}
+	makeVote := func(id string, senderTs time.Time) *events.Message {
+		return &events.Message{
+			Info: types.MessageInfo{
+				MessageSource: types.MessageSource{Chat: chat, Sender: voter},
+				ID:            id,
+				Timestamp:     base,
+			},
+			Message: &waProto.Message{
+				PollUpdateMessage: &waProto.PollUpdateMessage{
+					PollCreationMessageKey: &waProto.MessageKey{
+						ID:        proto.String(pollMsgID),
+						RemoteJID: proto.String(chat.String()),
+					},
+					SenderTimestampMS: proto.Int64(senderTs.UnixMilli()),
+				},
+			},
+		}
+	}
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, makeVote("VOTE-NEW", base.Add(900*time.Millisecond)), &messagesStored, func(string, string) {}, nil)
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, makeVote("VOTE-OLD", base.Add(100*time.Millisecond)), &messagesStored, func(string, string) {}, nil)
+
+	votes, err := a.db.ListPollVotes(chat.String(), pollMsgID)
+	if err != nil {
+		t.Fatalf("ListPollVotes: %v", err)
+	}
+	if len(votes) != 1 || votes[0].VoteMsgID != "VOTE-NEW" || !sameStringSet(votes[0].Selected, []string{"New"}) {
+		t.Fatalf("votes = %+v", votes)
+	}
+}
+
 func TestLiveSyncWarnsWhenPollVoteRefersToUnknownPoll(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/app/sync_polls_test.go
+++ b/internal/app/sync_polls_test.go
@@ -356,10 +356,6 @@ func TestLiveSyncDecryptsPollAddOptionBeforeVote(t *testing.T) {
 	f.decryptSecretFunc = func(_ *events.Message) (*waE2E.Message, error) {
 		return &waE2E.Message{
 			PollAddOptionMessage: &waE2E.PollAddOptionMessage{
-				PollCreationMessageKey: &waCommon.MessageKey{
-					ID:        proto.String(pollMsgID),
-					RemoteJID: proto.String(chat.String()),
-				},
 				AddOption: &waE2E.PollCreationMessage_Option{OptionName: proto.String("Maybe")},
 			},
 		}, nil

--- a/internal/app/sync_polls_test.go
+++ b/internal/app/sync_polls_test.go
@@ -204,6 +204,55 @@ func TestHistorySyncStoresWrappedSelfPollWithLinkedSender(t *testing.T) {
 	}
 }
 
+func TestHistorySyncStoresSelfGroupPollWithLIDSender(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	group := types.JID{User: "120363001234567890", Server: types.GroupServer}
+	ownPN := types.JID{User: "1234567890", Server: types.DefaultUserServer}
+	ownLID := types.JID{User: "999123456789", Server: types.HiddenUserServer}
+	f.groups[group] = &types.GroupInfo{JID: group, AddressingMode: types.AddressingModeLID}
+	f.lids[ownLID] = ownPN
+
+	created := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	hist := &waWeb.WebMessageInfo{
+		Key: &waCommon.MessageKey{
+			RemoteJID: proto.String(group.String()),
+			FromMe:    proto.Bool(true),
+			ID:        proto.String("POLL-GROUP-HIST"),
+		},
+		MessageTimestamp: proto.Uint64(uint64(created.Unix())),
+		Message: &waProto.Message{
+			PollCreationMessageV3: &waProto.PollCreationMessage{
+				Name:    proto.String("Group history?"),
+				Options: []*waProto.PollCreationMessage_Option{{OptionName: proto.String("Yes")}, {OptionName: proto.String("No")}},
+			},
+		},
+	}
+	history := &events.HistorySync{
+		Data: &waHistorySync.HistorySync{
+			SyncType: waHistorySync.HistorySync_FULL.Enum(),
+			Conversations: []*waHistorySync.Conversation{{
+				ID:       proto.String(group.String()),
+				Messages: []*waHistorySync.HistorySyncMsg{{Message: hist}},
+			}},
+		},
+	}
+
+	var messagesStored atomic.Int64
+	var lastEvent atomic.Int64
+	a.handleHistorySync(context.Background(), SyncOptions{}, history, &messagesStored, &lastEvent, func(string, string) {})
+
+	poll, err := a.db.GetPoll(group.String(), "POLL-GROUP-HIST")
+	if err != nil {
+		t.Fatalf("GetPoll: %v", err)
+	}
+	if poll.SenderJID != ownLID.String() {
+		t.Fatalf("SenderJID = %q, want LID %q", poll.SenderJID, ownLID.String())
+	}
+}
+
 func TestHistorySyncStoresPollVoteBeforeCreation(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/app/sync_polls_test.go
+++ b/internal/app/sync_polls_test.go
@@ -159,6 +159,13 @@ func TestHistorySyncStoresWrappedSelfPollWithLinkedSender(t *testing.T) {
 	if poll.SenderJID != f.LinkedJID() {
 		t.Fatalf("SenderJID = %q, want %q", poll.SenderJID, f.LinkedJID())
 	}
+	msg, err := a.db.GetMessage(chat.String(), "POLL-HIST")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if msg.Text != "Poll: Wrapped?" || msg.DisplayText != "Poll: Wrapped?" {
+		t.Fatalf("message text/display = %q/%q", msg.Text, msg.DisplayText)
+	}
 }
 
 func TestLiveSyncDecryptsAndStoresPollVote(t *testing.T) {

--- a/internal/app/sync_polls_test.go
+++ b/internal/app/sync_polls_test.go
@@ -106,6 +106,42 @@ func TestLiveSyncStoresPollCreationUnderCanonicalPN(t *testing.T) {
 	}
 }
 
+func TestLiveSyncPreservesRawGroupPollSender(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "12345", Server: types.GroupServer}
+	senderLID := types.JID{User: "777", Server: types.HiddenUserServer}
+	senderPN := types.JID{User: "15557654321", Server: types.DefaultUserServer}
+	f.lids[senderLID] = senderPN
+
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: senderLID, IsGroup: true},
+			ID:            "POLL-GROUP-LID",
+			Timestamp:     time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{
+			PollCreationMessageV3: &waProto.PollCreationMessage{
+				Name:    proto.String("Group?"),
+				Options: []*waProto.PollCreationMessage_Option{{OptionName: proto.String("Yes")}},
+			},
+		},
+	}
+
+	var messagesStored atomic.Int64
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, evt, &messagesStored, func(string, string) {}, nil)
+
+	poll, err := a.db.GetPoll(chat.String(), "POLL-GROUP-LID")
+	if err != nil {
+		t.Fatalf("GetPoll: %v", err)
+	}
+	if poll.SenderJID != senderLID.String() {
+		t.Fatalf("SenderJID = %q, want raw %q", poll.SenderJID, senderLID.String())
+	}
+}
+
 func TestHistorySyncStoresWrappedSelfPollWithLinkedSender(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/app/sync_polls_test.go
+++ b/internal/app/sync_polls_test.go
@@ -551,6 +551,66 @@ func TestLiveSyncKeepsNewerSameSecondPollVote(t *testing.T) {
 	}
 }
 
+func TestLiveSyncDeletesRetractedPollVote(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "555", Server: types.DefaultUserServer}
+	voter := types.JID{User: "777", Server: types.DefaultUserServer}
+	pollMsgID := "POLL-RETRACT"
+	base := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	var messagesStored atomic.Int64
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat},
+			ID:            pollMsgID,
+			Timestamp:     base,
+		},
+		Message: &waProto.Message{
+			PollCreationMessageV3: &waProto.PollCreationMessage{
+				Name:    proto.String("Lunch?"),
+				Options: []*waProto.PollCreationMessage_Option{{OptionName: proto.String("Yes")}, {OptionName: proto.String("No")}},
+			},
+		},
+	}, &messagesStored, func(string, string) {}, nil)
+
+	f.decryptPollVoteFunc = func(evt *events.Message) (*waE2E.PollVoteMessage, error) {
+		if evt.Info.ID == "VOTE-CLEAR" {
+			return &waE2E.PollVoteMessage{}, nil
+		}
+		return &waE2E.PollVoteMessage{SelectedOptions: whatsmeow.HashPollOptions([]string{"Yes"})}, nil
+	}
+	makeVote := func(id string, ts time.Time) *events.Message {
+		return &events.Message{
+			Info: types.MessageInfo{
+				MessageSource: types.MessageSource{Chat: chat, Sender: voter},
+				ID:            id,
+				Timestamp:     ts,
+			},
+			Message: &waProto.Message{
+				PollUpdateMessage: &waProto.PollUpdateMessage{
+					PollCreationMessageKey: &waCommon.MessageKey{
+						ID:        proto.String(pollMsgID),
+						RemoteJID: proto.String(chat.String()),
+					},
+					SenderTimestampMS: proto.Int64(ts.UnixMilli()),
+				},
+			},
+		}
+	}
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, makeVote("VOTE-YES", base.Add(time.Minute)), &messagesStored, func(string, string) {}, nil)
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, makeVote("VOTE-CLEAR", base.Add(2*time.Minute)), &messagesStored, func(string, string) {}, nil)
+
+	votes, err := a.db.ListPollVotes(chat.String(), pollMsgID)
+	if err != nil {
+		t.Fatalf("ListPollVotes: %v", err)
+	}
+	if len(votes) != 0 {
+		t.Fatalf("votes after retraction = %+v", votes)
+	}
+}
+
 func TestLiveSyncWarnsWhenPollVoteRefersToUnknownPoll(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/app/sync_polls_test.go
+++ b/internal/app/sync_polls_test.go
@@ -168,6 +168,80 @@ func TestHistorySyncStoresWrappedSelfPollWithLinkedSender(t *testing.T) {
 	}
 }
 
+func TestHistorySyncStoresPollVoteBeforeCreation(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "555", Server: types.DefaultUserServer}
+	voter := types.JID{User: "777", Server: types.DefaultUserServer}
+	pollMsgID := "POLL-HIST-ORDER"
+	created := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	f.decryptPollVoteFunc = func(_ *events.Message) (*waE2E.PollVoteMessage, error) {
+		return &waE2E.PollVoteMessage{SelectedOptions: whatsmeow.HashPollOptions([]string{"Yes"})}, nil
+	}
+
+	vote := &waWeb.WebMessageInfo{
+		Key: &waCommon.MessageKey{
+			RemoteJID: proto.String(chat.String()),
+			FromMe:    proto.Bool(false),
+			ID:        proto.String("VOTE-HIST-ORDER"),
+		},
+		Participant:      proto.String(voter.String()),
+		MessageTimestamp: proto.Uint64(uint64(created.Add(time.Minute).Unix())),
+		Message: &waProto.Message{
+			PollUpdateMessage: &waProto.PollUpdateMessage{
+				PollCreationMessageKey: &waCommon.MessageKey{
+					ID:        proto.String(pollMsgID),
+					RemoteJID: proto.String(chat.String()),
+				},
+			},
+		},
+	}
+	creation := &waWeb.WebMessageInfo{
+		Key: &waCommon.MessageKey{
+			RemoteJID: proto.String(chat.String()),
+			FromMe:    proto.Bool(false),
+			ID:        proto.String(pollMsgID),
+		},
+		MessageTimestamp: proto.Uint64(uint64(created.Unix())),
+		Message: &waProto.Message{
+			PollCreationMessageV3: &waProto.PollCreationMessage{
+				Name: proto.String("Dinner?"),
+				Options: []*waProto.PollCreationMessage_Option{
+					{OptionName: proto.String("Yes")},
+					{OptionName: proto.String("No")},
+				},
+				SelectableOptionsCount: proto.Uint32(1),
+			},
+		},
+	}
+	history := &events.HistorySync{
+		Data: &waHistorySync.HistorySync{
+			SyncType: waHistorySync.HistorySync_FULL.Enum(),
+			Conversations: []*waHistorySync.Conversation{{
+				ID:       proto.String(chat.String()),
+				Messages: []*waHistorySync.HistorySyncMsg{{Message: vote}, {Message: creation}},
+			}},
+		},
+	}
+
+	var messagesStored atomic.Int64
+	var lastEvent atomic.Int64
+	a.handleHistorySync(context.Background(), SyncOptions{}, history, &messagesStored, &lastEvent, func(string, string) {})
+
+	votes, err := a.db.ListPollVotes(chat.String(), pollMsgID)
+	if err != nil {
+		t.Fatalf("ListPollVotes: %v", err)
+	}
+	if len(votes) != 1 {
+		t.Fatalf("vote count = %d", len(votes))
+	}
+	if votes[0].VoterJID != voter.String() || !sameStringSet(votes[0].Selected, []string{"Yes"}) {
+		t.Fatalf("vote = %+v", votes[0])
+	}
+}
+
 func TestLiveSyncDecryptsAndStoresPollVote(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -579,6 +579,9 @@ func TestSyncDownloadsHistoryNotificationBeforeProcessing(t *testing.T) {
 	if res.MessagesStored != 1 {
 		t.Fatalf("messages stored = %d, want 1", res.MessagesStored)
 	}
+	if got := f.deleteHistoryCalls; len(got) != 1 || got[0] != notif {
+		t.Fatalf("delete history calls = %v, want notification %p", got, notif)
+	}
 	if got := f.manualHistorySyncCalls; len(got) != 2 || !got[0] || got[1] {
 		t.Fatalf("manual history calls = %v", got)
 	}

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -540,6 +540,50 @@ func TestSyncStoresLiveAndHistoryMessages(t *testing.T) {
 	}
 }
 
+func TestSyncDownloadsHistoryNotificationBeforeProcessing(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "555", Server: types.DefaultUserServer}
+	base := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	syncType := waE2E.HistorySyncType_INITIAL_BOOTSTRAP
+	notif := &waE2E.HistorySyncNotification{SyncType: &syncType}
+	f.connectEvents = []interface{}{&events.Message{
+		Message: &waProto.Message{
+			ProtocolMessage: &waProto.ProtocolMessage{
+				HistorySyncNotification: notif,
+			},
+		},
+	}}
+	downloadCalls := 0
+	f.downloadHistory = func(got *waE2E.HistorySyncNotification) (*waHistorySync.HistorySync, error) {
+		downloadCalls++
+		if got != notif {
+			t.Fatalf("DownloadHistorySync notification = %p, want %p", got, notif)
+		}
+		return historySyncWithTextMessages(chat, base, "m-hist").Data, nil
+	}
+
+	res, err := a.Sync(context.Background(), SyncOptions{
+		Mode:     SyncModeOnce,
+		AllowQR:  false,
+		IdleExit: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if downloadCalls != 1 {
+		t.Fatalf("download calls = %d, want 1", downloadCalls)
+	}
+	if res.MessagesStored != 1 {
+		t.Fatalf("messages stored = %d, want 1", res.MessagesStored)
+	}
+	if got := f.manualHistorySyncCalls; len(got) != 2 || !got[0] || got[1] {
+		t.Fatalf("manual history calls = %v", got)
+	}
+}
+
 func TestStoreParsedMessageNormalizesDefaultUserADJIDs(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/store/chats.go
+++ b/internal/store/chats.go
@@ -149,35 +149,75 @@ func (d *DB) DeleteChat(jid string) error {
 	if jid == "" {
 		return fmt.Errorf("chat JID is required")
 	}
-	_, err := d.sql.Exec(`DELETE FROM chats WHERE jid = ?`, jid)
-	return err
+	tx, err := d.sql.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if tx != nil {
+			_ = tx.Rollback()
+		}
+	}()
+	if _, err := tx.Exec(`DELETE FROM poll_votes WHERE chat_jid = ?`, jid); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DELETE FROM polls WHERE chat_jid = ?`, jid); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DELETE FROM chats WHERE jid = ?`, jid); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	tx = nil
+	return nil
 }
+
+const staleChatJIDsSQL = `
+	SELECT jid FROM (
+		SELECT
+			c.jid,
+			CASE
+				WHEN COALESCE(MAX(m.ts), 0) > COALESCE(c.last_message_ts, 0) THEN COALESCE(MAX(m.ts), 0)
+				ELSE COALESCE(c.last_message_ts, 0)
+			END AS activity_ts
+		FROM chats c
+		LEFT JOIN messages m ON m.chat_jid = c.jid
+		GROUP BY c.jid
+	)
+	WHERE activity_ts > 0 AND activity_ts < ?
+`
 
 func (d *DB) DeleteChatsOlderThan(days int) (int64, error) {
 	if days <= 0 {
 		return 0, fmt.Errorf("days must be positive")
 	}
 	cutoff := nowUTC().AddDate(0, 0, -days)
-	res, err := d.sql.Exec(`
-		DELETE FROM chats
-		WHERE jid IN (
-			SELECT jid FROM (
-				SELECT
-					c.jid,
-					CASE
-						WHEN COALESCE(MAX(m.ts), 0) > COALESCE(c.last_message_ts, 0) THEN COALESCE(MAX(m.ts), 0)
-						ELSE COALESCE(c.last_message_ts, 0)
-					END AS activity_ts
-				FROM chats c
-				LEFT JOIN messages m ON m.chat_jid = c.jid
-				GROUP BY c.jid
-			)
-			WHERE activity_ts > 0 AND activity_ts < ?
-		)
-	`, unix(cutoff))
+	cutoffUnix := unix(cutoff)
+	tx, err := d.sql.Begin()
 	if err != nil {
 		return 0, err
 	}
+	defer func() {
+		if tx != nil {
+			_ = tx.Rollback()
+		}
+	}()
+	if _, err := tx.Exec(`DELETE FROM poll_votes WHERE chat_jid IN (`+staleChatJIDsSQL+`)`, cutoffUnix); err != nil {
+		return 0, err
+	}
+	if _, err := tx.Exec(`DELETE FROM polls WHERE chat_jid IN (`+staleChatJIDsSQL+`)`, cutoffUnix); err != nil {
+		return 0, err
+	}
+	res, err := tx.Exec(`DELETE FROM chats WHERE jid IN (`+staleChatJIDsSQL+`)`, cutoffUnix)
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	tx = nil
 	return res.RowsAffected()
 }
 

--- a/internal/store/cleanup_test.go
+++ b/internal/store/cleanup_test.go
@@ -21,6 +21,25 @@ func TestDeleteChat(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertMessage: %v", err)
 	}
+	if err := db.UpsertPoll(Poll{
+		ChatJID:   "123@s.whatsapp.net",
+		MsgID:     "poll1",
+		Question:  "Q?",
+		Options:   []string{"yes", "no"},
+		CreatedAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertPoll: %v", err)
+	}
+	if err := db.UpsertPollVote(PollVote{
+		ChatJID:   "123@s.whatsapp.net",
+		PollMsgID: "poll1",
+		VoterJID:  "voter@s.whatsapp.net",
+		VoteMsgID: "vote1",
+		Selected:  []string{"yes"},
+		VotedAt:   now,
+	}); err != nil {
+		t.Fatalf("UpsertPollVote: %v", err)
+	}
 
 	msgCount, err := db.CountChatMessages("123@s.whatsapp.net")
 	if err != nil {
@@ -45,6 +64,12 @@ func TestDeleteChat(t *testing.T) {
 	}
 	if msgCount != 0 {
 		t.Fatalf("expected 0 messages after delete, got %d", msgCount)
+	}
+	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM polls WHERE chat_jid = ?", "123@s.whatsapp.net"); got != 0 {
+		t.Fatalf("expected polls deleted, got %d", got)
+	}
+	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM poll_votes WHERE chat_jid = ?", "123@s.whatsapp.net"); got != 0 {
+		t.Fatalf("expected poll votes deleted, got %d", got)
 	}
 }
 
@@ -78,6 +103,34 @@ func TestDeleteChatsOlderThan(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertMessage recent: %v", err)
 	}
+	if err := db.UpsertPoll(Poll{
+		ChatJID:   "old@s.whatsapp.net",
+		MsgID:     "old-poll",
+		Question:  "Old?",
+		Options:   []string{"yes", "no"},
+		CreatedAt: old,
+	}); err != nil {
+		t.Fatalf("UpsertPoll old: %v", err)
+	}
+	if err := db.UpsertPollVote(PollVote{
+		ChatJID:   "old@s.whatsapp.net",
+		PollMsgID: "old-poll",
+		VoterJID:  "voter@s.whatsapp.net",
+		VoteMsgID: "old-vote",
+		Selected:  []string{"yes"},
+		VotedAt:   old,
+	}); err != nil {
+		t.Fatalf("UpsertPollVote old: %v", err)
+	}
+	if err := db.UpsertPoll(Poll{
+		ChatJID:   "recent@s.whatsapp.net",
+		MsgID:     "recent-poll",
+		Question:  "Recent?",
+		Options:   []string{"yes", "no"},
+		CreatedAt: recent,
+	}); err != nil {
+		t.Fatalf("UpsertPoll recent: %v", err)
+	}
 
 	deleted, err := db.DeleteChatsOlderThan(180)
 	if err != nil {
@@ -98,6 +151,15 @@ func TestDeleteChatsOlderThan(t *testing.T) {
 	}
 	if c.JID != "recent@s.whatsapp.net" {
 		t.Fatalf("expected recent chat to survive, got %s", c.JID)
+	}
+	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM polls WHERE chat_jid = ?", "old@s.whatsapp.net"); got != 0 {
+		t.Fatalf("expected old polls deleted, got %d", got)
+	}
+	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM poll_votes WHERE chat_jid = ?", "old@s.whatsapp.net"); got != 0 {
+		t.Fatalf("expected old poll votes deleted, got %d", got)
+	}
+	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM polls WHERE chat_jid = ?", "recent@s.whatsapp.net"); got != 1 {
+		t.Fatalf("expected recent poll to survive, got %d", got)
 	}
 }
 

--- a/internal/store/cleanup_test.go
+++ b/internal/store/cleanup_test.go
@@ -269,6 +269,25 @@ func TestDeleteGroupLocalDataDeletesGroupChatAndMessages(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertMessage: %v", err)
 	}
+	if err := db.UpsertPoll(Poll{
+		ChatJID:   "12345@g.us",
+		MsgID:     "poll1",
+		Question:  "Lunch?",
+		Options:   []string{"yes", "no"},
+		CreatedAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertPoll: %v", err)
+	}
+	if err := db.UpsertPollVote(PollVote{
+		ChatJID:   "12345@g.us",
+		PollMsgID: "poll1",
+		VoterJID:  "voter@s.whatsapp.net",
+		VoteMsgID: "vote1",
+		Selected:  []string{"yes"},
+		VotedAt:   now,
+	}); err != nil {
+		t.Fatalf("UpsertPollVote: %v", err)
+	}
 
 	if err := db.DeleteGroupLocalData("12345@g.us"); err != nil {
 		t.Fatalf("DeleteGroupLocalData: %v", err)
@@ -283,6 +302,12 @@ func TestDeleteGroupLocalDataDeletesGroupChatAndMessages(t *testing.T) {
 	}
 	if got := countRows(t, db.sql, `SELECT COUNT(1) FROM messages WHERE chat_jid = ?`, "12345@g.us"); got != 0 {
 		t.Fatalf("expected messages deleted, got %d", got)
+	}
+	if got := countRows(t, db.sql, `SELECT COUNT(1) FROM polls WHERE chat_jid = ?`, "12345@g.us"); got != 0 {
+		t.Fatalf("expected polls deleted, got %d", got)
+	}
+	if got := countRows(t, db.sql, `SELECT COUNT(1) FROM poll_votes WHERE chat_jid = ?`, "12345@g.us"); got != 0 {
+		t.Fatalf("expected poll votes deleted, got %d", got)
 	}
 }
 

--- a/internal/store/groups.go
+++ b/internal/store/groups.go
@@ -182,6 +182,12 @@ func (d *DB) DeleteGroupLocalData(jid string) (err error) {
 	if _, err = tx.Exec(`DELETE FROM groups WHERE jid = ?`, jid); err != nil {
 		return err
 	}
+	if _, err = tx.Exec(`DELETE FROM poll_votes WHERE chat_jid = ?`, jid); err != nil {
+		return err
+	}
+	if _, err = tx.Exec(`DELETE FROM polls WHERE chat_jid = ?`, jid); err != nil {
+		return err
+	}
 	if _, err = tx.Exec(`DELETE FROM chats WHERE jid = ?`, jid); err != nil {
 		return err
 	}

--- a/internal/store/lid_migration.go
+++ b/internal/store/lid_migration.go
@@ -7,7 +7,7 @@ import (
 )
 
 // HistoricalLIDJIDs returns distinct hidden-user JIDs stored in chat and
-// message identity columns. The app layer resolves these through whatsmeow.
+// message/poll identity columns. The app layer resolves these through whatsmeow.
 func (d *DB) HistoricalLIDJIDs() ([]string, error) {
 	rows, err := d.sql.Query(`
 		SELECT jid FROM chats WHERE jid GLOB '*@lid'
@@ -15,6 +15,14 @@ func (d *DB) HistoricalLIDJIDs() ([]string, error) {
 		SELECT chat_jid FROM messages WHERE chat_jid GLOB '*@lid'
 		UNION
 		SELECT sender_jid FROM messages WHERE sender_jid GLOB '*@lid'
+		UNION
+		SELECT chat_jid FROM polls WHERE chat_jid GLOB '*@lid'
+		UNION
+		SELECT sender_jid FROM polls WHERE sender_jid GLOB '*@lid'
+		UNION
+		SELECT chat_jid FROM poll_votes WHERE chat_jid GLOB '*@lid'
+		UNION
+		SELECT voter_jid FROM poll_votes WHERE voter_jid GLOB '*@lid'
 		ORDER BY 1
 	`)
 	if err != nil {
@@ -67,6 +75,9 @@ func (d *DB) MigrateLIDToPN(lidJID, pnJID string) error {
 		return err
 	}
 	if err := migrateLIDSenderToPN(tx, lidJID, pnJID); err != nil {
+		return err
+	}
+	if err := migrateLIDPollsToPN(tx, lidJID, pnJID); err != nil {
 		return err
 	}
 	if err := deleteLIDChat(tx, lidJID); err != nil {
@@ -222,6 +233,57 @@ func migrateLIDMessagesToPN(tx *sql.Tx, lidJID, pnJID string) error {
 func migrateLIDSenderToPN(tx *sql.Tx, lidJID, pnJID string) error {
 	if _, err := tx.Exec(`UPDATE messages SET sender_jid = ? WHERE sender_jid = ?`, pnJID, lidJID); err != nil {
 		return fmt.Errorf("rewrite lid message senders: %w", err)
+	}
+	return nil
+}
+
+func migrateLIDPollsToPN(tx *sql.Tx, lidJID, pnJID string) error {
+	if _, err := tx.Exec(`
+		INSERT INTO polls(chat_jid, msg_id, sender_jid, question, options_json, selectable_count, created_ts)
+		SELECT
+			CASE WHEN chat_jid = ? THEN ? ELSE chat_jid END,
+			msg_id,
+			CASE WHEN sender_jid = ? THEN ? ELSE sender_jid END,
+			question,
+			options_json,
+			selectable_count,
+			created_ts
+		FROM polls
+		WHERE chat_jid = ? OR sender_jid = ?
+		ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
+			sender_jid = COALESCE(NULLIF(excluded.sender_jid, ''), polls.sender_jid),
+			question = excluded.question,
+			options_json = excluded.options_json,
+			selectable_count = excluded.selectable_count,
+			created_ts = max(polls.created_ts, excluded.created_ts)
+	`, lidJID, pnJID, lidJID, pnJID, lidJID, lidJID); err != nil {
+		return fmt.Errorf("merge lid polls into pn rows: %w", err)
+	}
+	if _, err := tx.Exec(`DELETE FROM polls WHERE chat_jid = ? OR sender_jid = ?`, lidJID, lidJID); err != nil {
+		return fmt.Errorf("delete migrated lid polls: %w", err)
+	}
+
+	if _, err := tx.Exec(`
+		INSERT INTO poll_votes(chat_jid, poll_msg_id, voter_jid, vote_msg_id, selected_options_json, ts)
+		SELECT
+			CASE WHEN chat_jid = ? THEN ? ELSE chat_jid END,
+			poll_msg_id,
+			CASE WHEN voter_jid = ? THEN ? ELSE voter_jid END,
+			vote_msg_id,
+			selected_options_json,
+			ts
+		FROM poll_votes
+		WHERE chat_jid = ? OR voter_jid = ?
+		ON CONFLICT(chat_jid, poll_msg_id, voter_jid) DO UPDATE SET
+			vote_msg_id = excluded.vote_msg_id,
+			selected_options_json = excluded.selected_options_json,
+			ts = excluded.ts
+		WHERE excluded.ts >= poll_votes.ts
+	`, lidJID, pnJID, lidJID, pnJID, lidJID, lidJID); err != nil {
+		return fmt.Errorf("merge lid poll votes into pn rows: %w", err)
+	}
+	if _, err := tx.Exec(`DELETE FROM poll_votes WHERE chat_jid = ? OR voter_jid = ?`, lidJID, lidJID); err != nil {
+		return fmt.Errorf("delete migrated lid poll votes: %w", err)
 	}
 	return nil
 }

--- a/internal/store/lid_migration.go
+++ b/internal/store/lid_migration.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -18,7 +19,7 @@ func (d *DB) HistoricalLIDJIDs() ([]string, error) {
 		UNION
 		SELECT chat_jid FROM polls WHERE chat_jid GLOB '*@lid'
 		UNION
-		SELECT sender_jid FROM polls WHERE sender_jid GLOB '*@lid'
+		SELECT sender_jid FROM polls WHERE sender_jid GLOB '*@lid' AND chat_jid NOT GLOB '*@g.us'
 		UNION
 		SELECT chat_jid FROM poll_votes WHERE chat_jid GLOB '*@lid'
 		UNION
@@ -238,28 +239,10 @@ func migrateLIDSenderToPN(tx *sql.Tx, lidJID, pnJID string) error {
 }
 
 func migrateLIDPollsToPN(tx *sql.Tx, lidJID, pnJID string) error {
-	if _, err := tx.Exec(`
-		INSERT INTO polls(chat_jid, msg_id, sender_jid, question, options_json, selectable_count, created_ts)
-		SELECT
-			CASE WHEN chat_jid = ? THEN ? ELSE chat_jid END,
-			msg_id,
-			CASE WHEN sender_jid = ? THEN ? ELSE sender_jid END,
-			question,
-			options_json,
-			selectable_count,
-			created_ts
-		FROM polls
-		WHERE chat_jid = ? OR sender_jid = ?
-		ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
-			sender_jid = COALESCE(NULLIF(excluded.sender_jid, ''), polls.sender_jid),
-			question = excluded.question,
-			options_json = excluded.options_json,
-			selectable_count = excluded.selectable_count,
-			created_ts = max(polls.created_ts, excluded.created_ts)
-	`, lidJID, pnJID, lidJID, pnJID, lidJID, lidJID); err != nil {
-		return fmt.Errorf("merge lid polls into pn rows: %w", err)
+	if err := migrateLIDPollRowsToPN(tx, lidJID, pnJID); err != nil {
+		return err
 	}
-	if _, err := tx.Exec(`DELETE FROM polls WHERE chat_jid = ? OR sender_jid = ?`, lidJID, lidJID); err != nil {
+	if _, err := tx.Exec(`DELETE FROM polls WHERE chat_jid = ? OR (sender_jid = ? AND chat_jid NOT GLOB '*@g.us')`, lidJID, lidJID); err != nil {
 		return fmt.Errorf("delete migrated lid polls: %w", err)
 	}
 
@@ -286,6 +269,105 @@ func migrateLIDPollsToPN(tx *sql.Tx, lidJID, pnJID string) error {
 		return fmt.Errorf("delete migrated lid poll votes: %w", err)
 	}
 	return nil
+}
+
+func migrateLIDPollRowsToPN(tx *sql.Tx, lidJID, pnJID string) error {
+	rows, err := tx.Query(`
+		SELECT chat_jid, msg_id, COALESCE(sender_jid,''), question, options_json, selectable_count, created_ts
+		FROM polls
+		WHERE chat_jid = ? OR (sender_jid = ? AND chat_jid NOT GLOB '*@g.us')
+	`, lidJID, lidJID)
+	if err != nil {
+		return fmt.Errorf("load lid polls: %w", err)
+	}
+	defer rows.Close()
+
+	type pollRow struct {
+		chatJID         string
+		msgID           string
+		senderJID       string
+		question        string
+		optionsJSON     string
+		selectableCount int64
+		createdTS       int64
+	}
+	var polls []pollRow
+	for rows.Next() {
+		var p pollRow
+		if err := rows.Scan(&p.chatJID, &p.msgID, &p.senderJID, &p.question, &p.optionsJSON, &p.selectableCount, &p.createdTS); err != nil {
+			return fmt.Errorf("scan lid poll: %w", err)
+		}
+		polls = append(polls, p)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	for _, p := range polls {
+		destChat := p.chatJID
+		if destChat == lidJID {
+			destChat = pnJID
+		}
+		destSender := p.senderJID
+		if destSender == lidJID && !strings.HasSuffix(p.chatJID, "@g.us") {
+			destSender = pnJID
+		}
+		optionsJSON, err := mergedPollOptionsJSONTx(tx, destChat, p.msgID, p.optionsJSON)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`
+			INSERT INTO polls(chat_jid, msg_id, sender_jid, question, options_json, selectable_count, created_ts)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
+				sender_jid = COALESCE(NULLIF(excluded.sender_jid, ''), polls.sender_jid),
+				question = excluded.question,
+				options_json = excluded.options_json,
+				selectable_count = excluded.selectable_count,
+				created_ts = max(polls.created_ts, excluded.created_ts)
+		`, destChat, p.msgID, destSender, p.question, optionsJSON, p.selectableCount, p.createdTS); err != nil {
+			return fmt.Errorf("merge lid poll into pn row: %w", err)
+		}
+	}
+	return nil
+}
+
+func mergedPollOptionsJSONTx(tx *sql.Tx, chatJID, msgID, incomingJSON string) (string, error) {
+	incoming, err := decodePollOptionsJSON(incomingJSON)
+	if err != nil {
+		return "", err
+	}
+	var existingJSON string
+	err = tx.QueryRow(`SELECT options_json FROM polls WHERE chat_jid = ? AND msg_id = ?`, chatJID, msgID).Scan(&existingJSON)
+	if err == nil {
+		existing, err := decodePollOptionsJSON(existingJSON)
+		if err != nil {
+			return "", err
+		}
+		incoming = mergePollOptions(incoming, existing)
+	} else if !isNoRows(err) {
+		return "", err
+	}
+	out, err := json.Marshal(incoming)
+	if err != nil {
+		return "", fmt.Errorf("marshal migrated poll options: %w", err)
+	}
+	return string(out), nil
+}
+
+func decodePollOptionsJSON(raw string) ([]string, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var options []string
+	if err := json.Unmarshal([]byte(raw), &options); err != nil {
+		return nil, fmt.Errorf("unmarshal migrated poll options: %w", err)
+	}
+	return options, nil
+}
+
+func isNoRows(err error) bool {
+	return err == sql.ErrNoRows
 }
 
 func deleteLIDChat(tx *sql.Tx, lidJID string) error {

--- a/internal/store/lid_migration_test.go
+++ b/internal/store/lid_migration_test.go
@@ -134,6 +134,17 @@ func TestMigrateLIDToPNMergesChatsAndMessages(t *testing.T) {
 		t.Fatalf("UpsertPoll lid: %v", err)
 	}
 	if err := db.UpsertPoll(Poll{
+		ChatJID:         pn,
+		MsgID:           "poll",
+		SenderJID:       pn,
+		Question:        "Dinner?",
+		Options:         []string{"yes", "no", "maybe"},
+		SelectableCount: 1,
+		CreatedAt:       base.Add(9 * time.Second),
+	}); err != nil {
+		t.Fatalf("UpsertPoll pn: %v", err)
+	}
+	if err := db.UpsertPoll(Poll{
 		ChatJID:         group,
 		MsgID:           "group-poll",
 		SenderJID:       lid,
@@ -181,7 +192,7 @@ func TestMigrateLIDToPNMergesChatsAndMessages(t *testing.T) {
 	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM messages WHERE sender_jid = ?", lid); got != 0 {
 		t.Fatalf("lid sender rows = %d, want 0", got)
 	}
-	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM polls WHERE chat_jid = ? OR sender_jid = ?", lid, lid); got != 0 {
+	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM polls WHERE chat_jid = ? OR (sender_jid = ? AND chat_jid NOT GLOB '*@g.us')", lid, lid); got != 0 {
 		t.Fatalf("lid poll rows = %d, want 0", got)
 	}
 	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM poll_votes WHERE chat_jid = ? OR voter_jid = ?", lid, lid); got != 0 {
@@ -231,12 +242,15 @@ func TestMigrateLIDToPNMergesChatsAndMessages(t *testing.T) {
 	if poll.SenderJID != pn {
 		t.Fatalf("migrated poll sender = %q, want %q", poll.SenderJID, pn)
 	}
+	if !reflect.DeepEqual(poll.Options, []string{"yes", "no", "maybe"}) {
+		t.Fatalf("migrated poll options = %#v, want yes/no/maybe", poll.Options)
+	}
 	groupPoll, err := db.GetPoll(group, "group-poll")
 	if err != nil {
 		t.Fatalf("GetPoll group: %v", err)
 	}
-	if groupPoll.SenderJID != pn {
-		t.Fatalf("group poll sender = %q, want %q", groupPoll.SenderJID, pn)
+	if groupPoll.SenderJID != lid {
+		t.Fatalf("group poll sender = %q, want %q", groupPoll.SenderJID, lid)
 	}
 	votes, err := db.ListPollVotes(pn, "poll")
 	if err != nil {

--- a/internal/store/lid_migration_test.go
+++ b/internal/store/lid_migration_test.go
@@ -36,6 +36,26 @@ func TestHistoricalLIDJIDsFindsChatAndMessageColumns(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertMessage group sender: %v", err)
 	}
+	if err := db.UpsertPoll(Poll{
+		ChatJID:   lid,
+		MsgID:     "lid-poll",
+		SenderJID: lid,
+		Question:  "LID?",
+		Options:   []string{"yes", "no"},
+		CreatedAt: base,
+	}); err != nil {
+		t.Fatalf("UpsertPoll lid: %v", err)
+	}
+	if err := db.UpsertPollVote(PollVote{
+		ChatJID:   group,
+		PollMsgID: "group-poll",
+		VoterJID:  lid,
+		VoteMsgID: "lid-vote",
+		Selected:  []string{"yes"},
+		VotedAt:   base,
+	}); err != nil {
+		t.Fatalf("UpsertPollVote lid: %v", err)
+	}
 
 	got, err := db.HistoricalLIDJIDs()
 	if err != nil {
@@ -102,6 +122,48 @@ func TestMigrateLIDToPNMergesChatsAndMessages(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertMessage group: %v", err)
 	}
+	if err := db.UpsertPoll(Poll{
+		ChatJID:         lid,
+		MsgID:           "poll",
+		SenderJID:       lid,
+		Question:        "Dinner?",
+		Options:         []string{"yes", "no"},
+		SelectableCount: 1,
+		CreatedAt:       base.Add(8 * time.Second),
+	}); err != nil {
+		t.Fatalf("UpsertPoll lid: %v", err)
+	}
+	if err := db.UpsertPoll(Poll{
+		ChatJID:         group,
+		MsgID:           "group-poll",
+		SenderJID:       lid,
+		Question:        "Group?",
+		Options:         []string{"yes", "no"},
+		SelectableCount: 1,
+		CreatedAt:       base.Add(8 * time.Second),
+	}); err != nil {
+		t.Fatalf("UpsertPoll group: %v", err)
+	}
+	if err := db.UpsertPollVote(PollVote{
+		ChatJID:   lid,
+		PollMsgID: "poll",
+		VoterJID:  lid,
+		VoteMsgID: "older-vote",
+		Selected:  []string{"yes"},
+		VotedAt:   base.Add(8 * time.Second),
+	}); err != nil {
+		t.Fatalf("UpsertPollVote lid: %v", err)
+	}
+	if err := db.UpsertPollVote(PollVote{
+		ChatJID:   pn,
+		PollMsgID: "poll",
+		VoterJID:  pn,
+		VoteMsgID: "newer-vote",
+		Selected:  []string{"no"},
+		VotedAt:   base.Add(9 * time.Second),
+	}); err != nil {
+		t.Fatalf("UpsertPollVote pn: %v", err)
+	}
 
 	if err := db.MigrateLIDToPN(lid, pn); err != nil {
 		t.Fatalf("MigrateLIDToPN: %v", err)
@@ -118,6 +180,12 @@ func TestMigrateLIDToPNMergesChatsAndMessages(t *testing.T) {
 	}
 	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM messages WHERE sender_jid = ?", lid); got != 0 {
 		t.Fatalf("lid sender rows = %d, want 0", got)
+	}
+	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM polls WHERE chat_jid = ? OR sender_jid = ?", lid, lid); got != 0 {
+		t.Fatalf("lid poll rows = %d, want 0", got)
+	}
+	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM poll_votes WHERE chat_jid = ? OR voter_jid = ?", lid, lid); got != 0 {
+		t.Fatalf("lid poll vote rows = %d, want 0", got)
 	}
 	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM messages WHERE chat_jid = ?", pn); got != 2 {
 		t.Fatalf("pn message rows = %d, want 2", got)
@@ -154,6 +222,28 @@ func TestMigrateLIDToPNMergesChatsAndMessages(t *testing.T) {
 	}
 	if groupMsg.SenderJID != pn {
 		t.Fatalf("group sender = %q, want %q", groupMsg.SenderJID, pn)
+	}
+
+	poll, err := db.GetPoll(pn, "poll")
+	if err != nil {
+		t.Fatalf("GetPoll migrated: %v", err)
+	}
+	if poll.SenderJID != pn {
+		t.Fatalf("migrated poll sender = %q, want %q", poll.SenderJID, pn)
+	}
+	groupPoll, err := db.GetPoll(group, "group-poll")
+	if err != nil {
+		t.Fatalf("GetPoll group: %v", err)
+	}
+	if groupPoll.SenderJID != pn {
+		t.Fatalf("group poll sender = %q, want %q", groupPoll.SenderJID, pn)
+	}
+	votes, err := db.ListPollVotes(pn, "poll")
+	if err != nil {
+		t.Fatalf("ListPollVotes migrated: %v", err)
+	}
+	if len(votes) != 1 || votes[0].VoterJID != pn || votes[0].VoteMsgID != "newer-vote" || !reflect.DeepEqual(votes[0].Selected, []string{"no"}) {
+		t.Fatalf("migrated votes = %+v", votes)
 	}
 
 	lids, err := db.HistoricalLIDJIDs()

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -27,6 +27,7 @@ var schemaMigrations = []migration{
 	{version: 11, name: "group hierarchy columns", up: migrateGroupHierarchyColumns},
 	{version: 12, name: "contacts system_name column", up: migrateContactsSystemNameColumn},
 	{version: 13, name: "messages buttons column", up: migrateMessagesButtonsColumn},
+	{version: 14, name: "polls and poll_votes", up: migratePolls},
 }
 
 func (d *DB) ensureSchema() error {
@@ -256,6 +257,36 @@ func migrateMessagesButtonsColumn(d *DB) error {
 	}
 	if _, err := d.sql.Exec(`ALTER TABLE messages ADD COLUMN buttons TEXT`); err != nil {
 		return fmt.Errorf("add messages.buttons column: %w", err)
+	}
+	return nil
+}
+
+func migratePolls(d *DB) error {
+	if _, err := d.sql.Exec(`
+		CREATE TABLE IF NOT EXISTS polls (
+			chat_jid          TEXT NOT NULL,
+			msg_id            TEXT NOT NULL,
+			sender_jid        TEXT,
+			question          TEXT NOT NULL,
+			options_json      TEXT NOT NULL,
+			selectable_count  INTEGER NOT NULL DEFAULT 1,
+			created_ts        INTEGER NOT NULL,
+			PRIMARY KEY (chat_jid, msg_id)
+		);
+		CREATE INDEX IF NOT EXISTS idx_polls_chat_ts ON polls(chat_jid, created_ts);
+
+		CREATE TABLE IF NOT EXISTS poll_votes (
+			chat_jid              TEXT NOT NULL,
+			poll_msg_id           TEXT NOT NULL,
+			voter_jid             TEXT NOT NULL,
+			vote_msg_id           TEXT NOT NULL,
+			selected_options_json TEXT NOT NULL,
+			ts                    INTEGER NOT NULL,
+			PRIMARY KEY (chat_jid, poll_msg_id, voter_jid)
+		);
+		CREATE INDEX IF NOT EXISTS idx_poll_votes_poll ON poll_votes(chat_jid, poll_msg_id);
+	`); err != nil {
+		return fmt.Errorf("create polls tables: %w", err)
 	}
 	return nil
 }

--- a/internal/store/polls.go
+++ b/internal/store/polls.go
@@ -49,7 +49,13 @@ func (d *DB) UpsertPoll(p Poll) error {
 	if p.Options == nil {
 		p.Options = []string{}
 	}
-	optsJSON, err := json.Marshal(p.Options)
+	options := p.Options
+	if existing, err := d.pollOptions(p.ChatJID, p.MsgID); err == nil {
+		options = mergePollOptions(options, existing)
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	optsJSON, err := json.Marshal(options)
 	if err != nil {
 		return fmt.Errorf("marshal options: %w", err)
 	}
@@ -268,7 +274,7 @@ func (d *DB) UpsertPollVote(v PollVote) error {
 		v.VoterJID,
 		v.VoteMsgID,
 		string(selJSON),
-		ts.UTC().Unix(),
+		ts.UTC().UnixMilli(),
 	)
 	if err != nil {
 		return fmt.Errorf("upsert poll vote: %w", err)
@@ -302,7 +308,7 @@ func (d *DB) ListPollVotes(chatJID, pollMsgID string) ([]PollVote, error) {
 		if err := rows.Scan(&v.ChatJID, &v.PollMsgID, &v.VoterJID, &v.VoteMsgID, &selRaw, &tsEpoch); err != nil {
 			return nil, fmt.Errorf("scan poll vote: %w", err)
 		}
-		v.VotedAt = time.Unix(tsEpoch, 0).UTC()
+		v.VotedAt = time.UnixMilli(tsEpoch).UTC()
 		if selRaw != "" {
 			if err := json.Unmarshal([]byte(selRaw), &v.Selected); err != nil {
 				return nil, fmt.Errorf("unmarshal selected: %w", err)
@@ -314,6 +320,37 @@ func (d *DB) ListPollVotes(chatJID, pollMsgID string) ([]PollVote, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+func (d *DB) pollOptions(chatJID, msgID string) ([]string, error) {
+	row := d.sql.QueryRow(`SELECT options_json FROM polls WHERE chat_jid = ? AND msg_id = ?`, chatJID, msgID)
+	var raw string
+	if err := row.Scan(&raw); err != nil {
+		return nil, err
+	}
+	var options []string
+	if raw != "" {
+		if err := json.Unmarshal([]byte(raw), &options); err != nil {
+			return nil, fmt.Errorf("unmarshal existing options: %w", err)
+		}
+	}
+	return options, nil
+}
+
+func mergePollOptions(incoming, existing []string) []string {
+	out := append([]string(nil), incoming...)
+	seen := make(map[string]struct{}, len(out)+len(existing))
+	for _, option := range out {
+		seen[option] = struct{}{}
+	}
+	for _, option := range existing {
+		if _, ok := seen[option]; ok {
+			continue
+		}
+		out = append(out, option)
+		seen[option] = struct{}{}
+	}
+	return out
 }
 
 // DeletePoll removes a poll and all its votes (votes are cascaded by

--- a/internal/store/polls.go
+++ b/internal/store/polls.go
@@ -88,9 +88,11 @@ func (d *DB) GetPoll(chatJID, msgID string) (Poll, error) {
 		return Poll{}, fmt.Errorf("nil db")
 	}
 	row := d.sql.QueryRow(`
-		SELECT chat_jid, msg_id, COALESCE(sender_jid,''), question, options_json, selectable_count, created_ts
-		FROM polls
-		WHERE chat_jid = ? AND msg_id = ?
+		SELECT p.chat_jid, p.msg_id, COALESCE(p.sender_jid,''), p.question, p.options_json, p.selectable_count, p.created_ts
+		FROM polls p
+		LEFT JOIN messages m ON m.chat_jid = p.chat_jid AND m.msg_id = p.msg_id
+		WHERE p.chat_jid = ? AND p.msg_id = ?
+		  AND (m.msg_id IS NULL OR (m.revoked = 0 AND m.deleted_for_me = 0))
 	`, chatJID, msgID)
 
 	var (
@@ -122,10 +124,12 @@ func (d *DB) FindPollByMsgID(msgID string) (Poll, error) {
 		return Poll{}, fmt.Errorf("nil db")
 	}
 	row := d.sql.QueryRow(`
-		SELECT chat_jid, msg_id, COALESCE(sender_jid,''), question, options_json, selectable_count, created_ts
-		FROM polls
-		WHERE msg_id = ?
-		ORDER BY created_ts DESC
+		SELECT p.chat_jid, p.msg_id, COALESCE(p.sender_jid,''), p.question, p.options_json, p.selectable_count, p.created_ts
+		FROM polls p
+		LEFT JOIN messages m ON m.chat_jid = p.chat_jid AND m.msg_id = p.msg_id
+		WHERE p.msg_id = ?
+		  AND (m.msg_id IS NULL OR (m.revoked = 0 AND m.deleted_for_me = 0))
+		ORDER BY p.created_ts DESC
 		LIMIT 1
 	`, msgID)
 
@@ -153,21 +157,23 @@ func (d *DB) ListPolls(filter PollListFilter) ([]Poll, error) {
 	if d == nil {
 		return nil, fmt.Errorf("nil db")
 	}
-	q := `SELECT chat_jid, msg_id, COALESCE(sender_jid,''), question, options_json, selectable_count, created_ts
-	      FROM polls`
+	q := `SELECT p.chat_jid, p.msg_id, COALESCE(p.sender_jid,''), p.question, p.options_json, p.selectable_count, p.created_ts
+	      FROM polls p
+	      LEFT JOIN messages m ON m.chat_jid = p.chat_jid AND m.msg_id = p.msg_id
+	      WHERE (m.msg_id IS NULL OR (m.revoked = 0 AND m.deleted_for_me = 0))`
 	args := []any{}
 	chatJIDs := cleanPollFilterChatJIDs(filter)
 	switch {
 	case len(chatJIDs) == 1:
-		q += " WHERE chat_jid = ?"
+		q += " AND p.chat_jid = ?"
 		args = append(args, chatJIDs[0])
 	case len(chatJIDs) > 1:
-		q += " WHERE chat_jid IN (?" + strings.Repeat(",?", len(chatJIDs)-1) + ")"
+		q += " AND p.chat_jid IN (?" + strings.Repeat(",?", len(chatJIDs)-1) + ")"
 		for _, chatJID := range chatJIDs {
 			args = append(args, chatJID)
 		}
 	}
-	q += " ORDER BY created_ts DESC, msg_id DESC"
+	q += " ORDER BY p.created_ts DESC, p.msg_id DESC"
 	if filter.Limit > 0 {
 		q += " LIMIT ?"
 		args = append(args, filter.Limit)

--- a/internal/store/polls.go
+++ b/internal/store/polls.go
@@ -282,6 +282,28 @@ func (d *DB) UpsertPollVote(v PollVote) error {
 	return nil
 }
 
+// DeletePollVote removes one voter's current vote if the deletion is not older
+// than the stored vote row.
+func (d *DB) DeletePollVote(chatJID, pollMsgID, voterJID string, votedAt time.Time) error {
+	if d == nil {
+		return fmt.Errorf("nil db")
+	}
+	if strings.TrimSpace(chatJID) == "" || strings.TrimSpace(pollMsgID) == "" || strings.TrimSpace(voterJID) == "" {
+		return fmt.Errorf("vote requires chat_jid, poll_msg_id, voter_jid")
+	}
+	ts := votedAt
+	if ts.IsZero() {
+		ts = nowUTC()
+	}
+	if _, err := d.sql.Exec(`
+		DELETE FROM poll_votes
+		WHERE chat_jid = ? AND poll_msg_id = ? AND voter_jid = ? AND ts <= ?
+	`, chatJID, pollMsgID, voterJID, ts.UTC().UnixMilli()); err != nil {
+		return fmt.Errorf("delete poll vote: %w", err)
+	}
+	return nil
+}
+
 // ListPollVotes returns the per-voter votes for a poll, ordered by ts ASC.
 func (d *DB) ListPollVotes(chatJID, pollMsgID string) ([]PollVote, error) {
 	if d == nil {

--- a/internal/store/polls.go
+++ b/internal/store/polls.go
@@ -32,9 +32,10 @@ type PollVote struct {
 
 // PollListFilter narrows down polls returned by ListPolls.
 type PollListFilter struct {
-	ChatJID string
-	Limit   int
-	Offset  int
+	ChatJID  string
+	ChatJIDs []string
+	Limit    int
+	Offset   int
 }
 
 // UpsertPoll inserts or replaces a poll row keyed on (chat_jid, msg_id).
@@ -155,9 +156,16 @@ func (d *DB) ListPolls(filter PollListFilter) ([]Poll, error) {
 	q := `SELECT chat_jid, msg_id, COALESCE(sender_jid,''), question, options_json, selectable_count, created_ts
 	      FROM polls`
 	args := []any{}
-	if strings.TrimSpace(filter.ChatJID) != "" {
+	chatJIDs := cleanPollFilterChatJIDs(filter)
+	switch {
+	case len(chatJIDs) == 1:
 		q += " WHERE chat_jid = ?"
-		args = append(args, filter.ChatJID)
+		args = append(args, chatJIDs[0])
+	case len(chatJIDs) > 1:
+		q += " WHERE chat_jid IN (?" + strings.Repeat(",?", len(chatJIDs)-1) + ")"
+		for _, chatJID := range chatJIDs {
+			args = append(args, chatJID)
+		}
 	}
 	q += " ORDER BY created_ts DESC, msg_id DESC"
 	if filter.Limit > 0 {
@@ -198,6 +206,27 @@ func (d *DB) ListPolls(filter PollListFilter) ([]Poll, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+func cleanPollFilterChatJIDs(filter PollListFilter) []string {
+	candidates := filter.ChatJIDs
+	if len(candidates) == 0 && strings.TrimSpace(filter.ChatJID) != "" {
+		candidates = []string{filter.ChatJID}
+	}
+	out := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, chatJID := range candidates {
+		chatJID = strings.TrimSpace(chatJID)
+		if chatJID == "" {
+			continue
+		}
+		if _, ok := seen[chatJID]; ok {
+			continue
+		}
+		seen[chatJID] = struct{}{}
+		out = append(out, chatJID)
+	}
+	return out
 }
 
 // UpsertPollVote replaces the vote row for (chat, poll, voter).

--- a/internal/store/polls.go
+++ b/internal/store/polls.go
@@ -226,6 +226,7 @@ func (d *DB) UpsertPollVote(v PollVote) error {
 			vote_msg_id = excluded.vote_msg_id,
 			selected_options_json = excluded.selected_options_json,
 			ts = excluded.ts
+		WHERE excluded.ts >= poll_votes.ts
 	`,
 		v.ChatJID,
 		v.PollMsgID,

--- a/internal/store/polls.go
+++ b/internal/store/polls.go
@@ -1,0 +1,308 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Poll represents a stored PollCreationMessage.
+type Poll struct {
+	ChatJID         string
+	MsgID           string
+	SenderJID       string
+	Question        string
+	Options         []string
+	SelectableCount uint32
+	CreatedAt       time.Time
+}
+
+// PollVote represents one voter's latest vote on a poll.
+type PollVote struct {
+	ChatJID   string
+	PollMsgID string
+	VoterJID  string
+	VoteMsgID string
+	Selected  []string
+	VotedAt   time.Time
+}
+
+// PollListFilter narrows down polls returned by ListPolls.
+type PollListFilter struct {
+	ChatJID string
+	Limit   int
+	Offset  int
+}
+
+// UpsertPoll inserts or replaces a poll row keyed on (chat_jid, msg_id).
+func (d *DB) UpsertPoll(p Poll) error {
+	if d == nil {
+		return fmt.Errorf("nil db")
+	}
+	if strings.TrimSpace(p.ChatJID) == "" || strings.TrimSpace(p.MsgID) == "" {
+		return fmt.Errorf("poll requires chat_jid and msg_id")
+	}
+	if p.Options == nil {
+		p.Options = []string{}
+	}
+	optsJSON, err := json.Marshal(p.Options)
+	if err != nil {
+		return fmt.Errorf("marshal options: %w", err)
+	}
+	createdTS := p.CreatedAt
+	if createdTS.IsZero() {
+		createdTS = nowUTC()
+	}
+	_, err = d.sql.Exec(`
+		INSERT INTO polls (chat_jid, msg_id, sender_jid, question, options_json, selectable_count, created_ts)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
+			sender_jid = excluded.sender_jid,
+			question = excluded.question,
+			options_json = excluded.options_json,
+			selectable_count = excluded.selectable_count,
+			created_ts = excluded.created_ts
+	`,
+		p.ChatJID,
+		p.MsgID,
+		p.SenderJID,
+		p.Question,
+		string(optsJSON),
+		p.SelectableCount,
+		createdTS.UTC().Unix(),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert poll: %w", err)
+	}
+	return nil
+}
+
+// GetPoll fetches a single poll by (chat_jid, msg_id). Returns sql.ErrNoRows
+// if not found.
+func (d *DB) GetPoll(chatJID, msgID string) (Poll, error) {
+	if d == nil {
+		return Poll{}, fmt.Errorf("nil db")
+	}
+	row := d.sql.QueryRow(`
+		SELECT chat_jid, msg_id, COALESCE(sender_jid,''), question, options_json, selectable_count, created_ts
+		FROM polls
+		WHERE chat_jid = ? AND msg_id = ?
+	`, chatJID, msgID)
+
+	var (
+		p          Poll
+		optsRaw    string
+		createdTS  int64
+		selectable int64
+	)
+	if err := row.Scan(&p.ChatJID, &p.MsgID, &p.SenderJID, &p.Question, &optsRaw, &selectable, &createdTS); err != nil {
+		return Poll{}, err
+	}
+	p.SelectableCount = uint32(selectable)
+	p.CreatedAt = time.Unix(createdTS, 0).UTC()
+	if optsRaw != "" {
+		if err := json.Unmarshal([]byte(optsRaw), &p.Options); err != nil {
+			return Poll{}, fmt.Errorf("unmarshal options: %w", err)
+		}
+	}
+	return p, nil
+}
+
+// FindPollByMsgID returns the most recent poll matching the given msg_id
+// across any chat. Useful when the chat JID embedded in a vote event
+// (often a LID) does not match the chat under which the poll was stored
+// (often a phone-number JID for self-conversations). Returns sql.ErrNoRows
+// if not found.
+func (d *DB) FindPollByMsgID(msgID string) (Poll, error) {
+	if d == nil {
+		return Poll{}, fmt.Errorf("nil db")
+	}
+	row := d.sql.QueryRow(`
+		SELECT chat_jid, msg_id, COALESCE(sender_jid,''), question, options_json, selectable_count, created_ts
+		FROM polls
+		WHERE msg_id = ?
+		ORDER BY created_ts DESC
+		LIMIT 1
+	`, msgID)
+
+	var (
+		p          Poll
+		optsRaw    string
+		createdTS  int64
+		selectable int64
+	)
+	if err := row.Scan(&p.ChatJID, &p.MsgID, &p.SenderJID, &p.Question, &optsRaw, &selectable, &createdTS); err != nil {
+		return Poll{}, err
+	}
+	p.SelectableCount = uint32(selectable)
+	p.CreatedAt = time.Unix(createdTS, 0).UTC()
+	if optsRaw != "" {
+		if err := json.Unmarshal([]byte(optsRaw), &p.Options); err != nil {
+			return Poll{}, fmt.Errorf("unmarshal options: %w", err)
+		}
+	}
+	return p, nil
+}
+
+// ListPolls returns polls ordered most-recent-first.
+func (d *DB) ListPolls(filter PollListFilter) ([]Poll, error) {
+	if d == nil {
+		return nil, fmt.Errorf("nil db")
+	}
+	q := `SELECT chat_jid, msg_id, COALESCE(sender_jid,''), question, options_json, selectable_count, created_ts
+	      FROM polls`
+	args := []any{}
+	if strings.TrimSpace(filter.ChatJID) != "" {
+		q += " WHERE chat_jid = ?"
+		args = append(args, filter.ChatJID)
+	}
+	q += " ORDER BY created_ts DESC, msg_id DESC"
+	if filter.Limit > 0 {
+		q += " LIMIT ?"
+		args = append(args, filter.Limit)
+		if filter.Offset > 0 {
+			q += " OFFSET ?"
+			args = append(args, filter.Offset)
+		}
+	}
+	rows, err := d.sql.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query polls: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Poll
+	for rows.Next() {
+		var (
+			p          Poll
+			optsRaw    string
+			createdTS  int64
+			selectable int64
+		)
+		if err := rows.Scan(&p.ChatJID, &p.MsgID, &p.SenderJID, &p.Question, &optsRaw, &selectable, &createdTS); err != nil {
+			return nil, fmt.Errorf("scan poll: %w", err)
+		}
+		p.SelectableCount = uint32(selectable)
+		p.CreatedAt = time.Unix(createdTS, 0).UTC()
+		if optsRaw != "" {
+			if err := json.Unmarshal([]byte(optsRaw), &p.Options); err != nil {
+				return nil, fmt.Errorf("unmarshal options: %w", err)
+			}
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// UpsertPollVote replaces the vote row for (chat, poll, voter).
+func (d *DB) UpsertPollVote(v PollVote) error {
+	if d == nil {
+		return fmt.Errorf("nil db")
+	}
+	if strings.TrimSpace(v.ChatJID) == "" || strings.TrimSpace(v.PollMsgID) == "" || strings.TrimSpace(v.VoterJID) == "" {
+		return fmt.Errorf("vote requires chat_jid, poll_msg_id, voter_jid")
+	}
+	if v.Selected == nil {
+		v.Selected = []string{}
+	}
+	selJSON, err := json.Marshal(v.Selected)
+	if err != nil {
+		return fmt.Errorf("marshal selected: %w", err)
+	}
+	ts := v.VotedAt
+	if ts.IsZero() {
+		ts = nowUTC()
+	}
+	_, err = d.sql.Exec(`
+		INSERT INTO poll_votes (chat_jid, poll_msg_id, voter_jid, vote_msg_id, selected_options_json, ts)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(chat_jid, poll_msg_id, voter_jid) DO UPDATE SET
+			vote_msg_id = excluded.vote_msg_id,
+			selected_options_json = excluded.selected_options_json,
+			ts = excluded.ts
+	`,
+		v.ChatJID,
+		v.PollMsgID,
+		v.VoterJID,
+		v.VoteMsgID,
+		string(selJSON),
+		ts.UTC().Unix(),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert poll vote: %w", err)
+	}
+	return nil
+}
+
+// ListPollVotes returns the per-voter votes for a poll, ordered by ts ASC.
+func (d *DB) ListPollVotes(chatJID, pollMsgID string) ([]PollVote, error) {
+	if d == nil {
+		return nil, fmt.Errorf("nil db")
+	}
+	rows, err := d.sql.Query(`
+		SELECT chat_jid, poll_msg_id, voter_jid, vote_msg_id, selected_options_json, ts
+		FROM poll_votes
+		WHERE chat_jid = ? AND poll_msg_id = ?
+		ORDER BY ts ASC, voter_jid ASC
+	`, chatJID, pollMsgID)
+	if err != nil {
+		return nil, fmt.Errorf("query poll votes: %w", err)
+	}
+	defer rows.Close()
+
+	var out []PollVote
+	for rows.Next() {
+		var (
+			v       PollVote
+			selRaw  string
+			tsEpoch int64
+		)
+		if err := rows.Scan(&v.ChatJID, &v.PollMsgID, &v.VoterJID, &v.VoteMsgID, &selRaw, &tsEpoch); err != nil {
+			return nil, fmt.Errorf("scan poll vote: %w", err)
+		}
+		v.VotedAt = time.Unix(tsEpoch, 0).UTC()
+		if selRaw != "" {
+			if err := json.Unmarshal([]byte(selRaw), &v.Selected); err != nil {
+				return nil, fmt.Errorf("unmarshal selected: %w", err)
+			}
+		}
+		out = append(out, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// DeletePoll removes a poll and all its votes (votes are cascaded by
+// foreign key, but we issue an explicit delete since the FK isn't declared
+// at the table level).
+func (d *DB) DeletePoll(chatJID, msgID string) error {
+	if d == nil {
+		return fmt.Errorf("nil db")
+	}
+	tx, err := d.sql.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec(`DELETE FROM poll_votes WHERE chat_jid = ? AND poll_msg_id = ?`, chatJID, msgID); err != nil {
+		return fmt.Errorf("delete poll votes: %w", err)
+	}
+	if _, err := tx.Exec(`DELETE FROM polls WHERE chat_jid = ? AND msg_id = ?`, chatJID, msgID); err != nil {
+		return fmt.Errorf("delete poll: %w", err)
+	}
+	return tx.Commit()
+}
+
+// IsPollNotFound is a small convenience predicate.
+func IsPollNotFound(err error) bool {
+	return errors.Is(err, sql.ErrNoRows)
+}

--- a/internal/store/polls_test.go
+++ b/internal/store/polls_test.go
@@ -74,6 +74,34 @@ func TestUpsertPollIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestUpsertPollPreservesAddedOptionsOnCreationReplay(t *testing.T) {
+	db := openTestDB(t)
+
+	p := Poll{
+		ChatJID:         "chat@s.whatsapp.net",
+		MsgID:           "P1",
+		Question:        "v1",
+		Options:         []string{"a", "b", "c"},
+		SelectableCount: 1,
+		CreatedAt:       time.Now().UTC(),
+	}
+	if err := db.UpsertPoll(p); err != nil {
+		t.Fatal(err)
+	}
+	p.Options = []string{"a", "b"}
+	if err := db.UpsertPoll(p); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := db.GetPoll(p.ChatJID, p.MsgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got.Options, []string{"a", "b", "c"}) {
+		t.Fatalf("options = %v", got.Options)
+	}
+}
+
 func TestUpsertPollVoteReplacesPriorVote(t *testing.T) {
 	db := openTestDB(t)
 
@@ -149,6 +177,41 @@ func TestUpsertPollVoteKeepsNewerVote(t *testing.T) {
 		t.Fatalf("vote count = %d", len(votes))
 	}
 	if votes[0].VoteMsgID != "V2" || !reflect.DeepEqual(votes[0].Selected, []string{"new"}) {
+		t.Fatalf("vote = %+v", votes[0])
+	}
+}
+
+func TestUpsertPollVoteKeepsNewerSameSecondVote(t *testing.T) {
+	db := openTestDB(t)
+
+	base := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	newer := PollVote{
+		ChatJID:   "chat@s.whatsapp.net",
+		PollMsgID: "P1",
+		VoterJID:  "voter@s.whatsapp.net",
+		VoteMsgID: "V2",
+		Selected:  []string{"new"},
+		VotedAt:   base.Add(900 * time.Millisecond),
+	}
+	if err := db.UpsertPollVote(newer); err != nil {
+		t.Fatal(err)
+	}
+	older := newer
+	older.VoteMsgID = "V1"
+	older.Selected = []string{"old"}
+	older.VotedAt = base.Add(100 * time.Millisecond)
+	if err := db.UpsertPollVote(older); err != nil {
+		t.Fatal(err)
+	}
+
+	votes, err := db.ListPollVotes(newer.ChatJID, newer.PollMsgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(votes) != 1 {
+		t.Fatalf("vote count = %d", len(votes))
+	}
+	if votes[0].VoteMsgID != "V2" || !votes[0].VotedAt.Equal(newer.VotedAt) {
 		t.Fatalf("vote = %+v", votes[0])
 	}
 }

--- a/internal/store/polls_test.go
+++ b/internal/store/polls_test.go
@@ -186,6 +186,17 @@ func TestListPollsFilterAndOrder(t *testing.T) {
 	if len(onlyA) != 2 {
 		t.Fatalf("len(onlyA) = %d", len(onlyA))
 	}
+
+	combined, err := db.ListPolls(PollListFilter{ChatJIDs: []string{"b@s.whatsapp.net", "a@s.whatsapp.net", "a@s.whatsapp.net"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(combined) != 3 {
+		t.Fatalf("len(combined) = %d", len(combined))
+	}
+	if combined[0].MsgID != "P2" || combined[1].MsgID != "P3" || combined[2].MsgID != "P1" {
+		t.Fatalf("combined order = %s, %s, %s", combined[0].MsgID, combined[1].MsgID, combined[2].MsgID)
+	}
 }
 
 func TestDeletePollRemovesVotes(t *testing.T) {

--- a/internal/store/polls_test.go
+++ b/internal/store/polls_test.go
@@ -199,6 +199,61 @@ func TestListPollsFilterAndOrder(t *testing.T) {
 	}
 }
 
+func TestPollQueriesHideDeletedMessages(t *testing.T) {
+	db := openTestDB(t)
+
+	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	if err := db.UpsertChat("chat@s.whatsapp.net", "dm", "Chat", now); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	for _, p := range []Poll{
+		{ChatJID: "chat@s.whatsapp.net", MsgID: "visible", Question: "visible", Options: []string{"a"}, CreatedAt: now},
+		{ChatJID: "chat@s.whatsapp.net", MsgID: "revoked", Question: "revoked", Options: []string{"a"}, CreatedAt: now.Add(time.Minute)},
+		{ChatJID: "chat@s.whatsapp.net", MsgID: "deleted", Question: "deleted", Options: []string{"a"}, CreatedAt: now.Add(2 * time.Minute)},
+		{ChatJID: "chat@s.whatsapp.net", MsgID: "legacy", Question: "legacy", Options: []string{"a"}, CreatedAt: now.Add(3 * time.Minute)},
+	} {
+		if err := db.UpsertPoll(p); err != nil {
+			t.Fatalf("UpsertPoll %s: %v", p.MsgID, err)
+		}
+		if p.MsgID == "legacy" {
+			continue
+		}
+		if err := db.UpsertMessage(UpsertMessageParams{
+			ChatJID:   p.ChatJID,
+			MsgID:     p.MsgID,
+			Timestamp: p.CreatedAt,
+			Text:      "Poll: " + p.Question,
+		}); err != nil {
+			t.Fatalf("UpsertMessage %s: %v", p.MsgID, err)
+		}
+	}
+	if err := db.MarkMessageRevoked("chat@s.whatsapp.net", "revoked"); err != nil {
+		t.Fatalf("MarkMessageRevoked: %v", err)
+	}
+	if err := db.MarkMessageDeletedForMe("chat@s.whatsapp.net", "deleted", "", false, now); err != nil {
+		t.Fatalf("MarkMessageDeletedForMe: %v", err)
+	}
+
+	if _, err := db.GetPoll("chat@s.whatsapp.net", "revoked"); !IsPollNotFound(err) {
+		t.Fatalf("GetPoll revoked err = %v, want not found", err)
+	}
+	if _, err := db.FindPollByMsgID("deleted"); !IsPollNotFound(err) {
+		t.Fatalf("FindPollByMsgID deleted err = %v, want not found", err)
+	}
+	polls, err := db.ListPolls(PollListFilter{ChatJID: "chat@s.whatsapp.net"})
+	if err != nil {
+		t.Fatalf("ListPolls: %v", err)
+	}
+	got := make([]string, 0, len(polls))
+	for _, p := range polls {
+		got = append(got, p.MsgID)
+	}
+	want := []string{"legacy", "visible"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("poll IDs = %v, want %v", got, want)
+	}
+}
+
 func TestDeletePollRemovesVotes(t *testing.T) {
 	db := openTestDB(t)
 

--- a/internal/store/polls_test.go
+++ b/internal/store/polls_test.go
@@ -216,6 +216,43 @@ func TestUpsertPollVoteKeepsNewerSameSecondVote(t *testing.T) {
 	}
 }
 
+func TestDeletePollVoteRemovesOnlyOlderRows(t *testing.T) {
+	db := openTestDB(t)
+
+	base := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	vote := PollVote{
+		ChatJID:   "chat@s.whatsapp.net",
+		PollMsgID: "P1",
+		VoterJID:  "voter@s.whatsapp.net",
+		VoteMsgID: "V1",
+		Selected:  []string{"yes"},
+		VotedAt:   base,
+	}
+	if err := db.UpsertPollVote(vote); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.DeletePollVote(vote.ChatJID, vote.PollMsgID, vote.VoterJID, base.Add(-time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	votes, err := db.ListPollVotes(vote.ChatJID, vote.PollMsgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(votes) != 1 {
+		t.Fatalf("vote count after old delete = %d", len(votes))
+	}
+	if err := db.DeletePollVote(vote.ChatJID, vote.PollMsgID, vote.VoterJID, base.Add(time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	votes, err = db.ListPollVotes(vote.ChatJID, vote.PollMsgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(votes) != 0 {
+		t.Fatalf("vote count after new delete = %d", len(votes))
+	}
+}
+
 func TestListPollsFilterAndOrder(t *testing.T) {
 	db := openTestDB(t)
 

--- a/internal/store/polls_test.go
+++ b/internal/store/polls_test.go
@@ -1,0 +1,198 @@
+package store
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestUpsertAndGetPoll(t *testing.T) {
+	db := openTestDB(t)
+
+	created := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	in := Poll{
+		ChatJID:         "15551112222@s.whatsapp.net",
+		MsgID:           "POLL-1",
+		SenderJID:       "15553334444@s.whatsapp.net",
+		Question:        "Pizza?",
+		Options:         []string{"Yes", "No", "Maybe"},
+		SelectableCount: 2,
+		CreatedAt:       created,
+	}
+	if err := db.UpsertPoll(in); err != nil {
+		t.Fatalf("UpsertPoll: %v", err)
+	}
+
+	got, err := db.GetPoll(in.ChatJID, in.MsgID)
+	if err != nil {
+		t.Fatalf("GetPoll: %v", err)
+	}
+	if got.Question != in.Question {
+		t.Fatalf("question = %q", got.Question)
+	}
+	if !reflect.DeepEqual(got.Options, in.Options) {
+		t.Fatalf("options = %v", got.Options)
+	}
+	if got.SelectableCount != 2 {
+		t.Fatalf("selectable = %d", got.SelectableCount)
+	}
+	if !got.CreatedAt.Equal(created) {
+		t.Fatalf("created_at = %v want %v", got.CreatedAt, created)
+	}
+}
+
+func TestUpsertPollIsIdempotent(t *testing.T) {
+	db := openTestDB(t)
+
+	p := Poll{
+		ChatJID:         "chat@s.whatsapp.net",
+		MsgID:           "P1",
+		Question:        "v1",
+		Options:         []string{"a", "b"},
+		SelectableCount: 1,
+		CreatedAt:       time.Now().UTC(),
+	}
+	if err := db.UpsertPoll(p); err != nil {
+		t.Fatal(err)
+	}
+	p.Question = "v2"
+	if err := db.UpsertPoll(p); err != nil {
+		t.Fatal(err)
+	}
+	got, err := db.GetPoll(p.ChatJID, p.MsgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Question != "v2" {
+		t.Fatalf("question = %q want v2", got.Question)
+	}
+
+	n := countRows(t, db.sql, "SELECT COUNT(*) FROM polls")
+	if n != 1 {
+		t.Fatalf("polls row count = %d", n)
+	}
+}
+
+func TestUpsertPollVoteReplacesPriorVote(t *testing.T) {
+	db := openTestDB(t)
+
+	if err := db.UpsertPoll(Poll{
+		ChatJID:         "chat@s.whatsapp.net",
+		MsgID:           "P1",
+		Question:        "Q?",
+		Options:         []string{"a", "b"},
+		SelectableCount: 1,
+		CreatedAt:       time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	first := PollVote{
+		ChatJID:   "chat@s.whatsapp.net",
+		PollMsgID: "P1",
+		VoterJID:  "voter@s.whatsapp.net",
+		VoteMsgID: "V1",
+		Selected:  []string{"a"},
+		VotedAt:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	if err := db.UpsertPollVote(first); err != nil {
+		t.Fatal(err)
+	}
+	second := first
+	second.VoteMsgID = "V2"
+	second.Selected = []string{"b"}
+	second.VotedAt = time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	if err := db.UpsertPollVote(second); err != nil {
+		t.Fatal(err)
+	}
+
+	votes, err := db.ListPollVotes("chat@s.whatsapp.net", "P1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(votes) != 1 {
+		t.Fatalf("vote count = %d", len(votes))
+	}
+	if votes[0].VoteMsgID != "V2" || !reflect.DeepEqual(votes[0].Selected, []string{"b"}) {
+		t.Fatalf("vote = %+v", votes[0])
+	}
+}
+
+func TestListPollsFilterAndOrder(t *testing.T) {
+	db := openTestDB(t)
+
+	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	polls := []Poll{
+		{ChatJID: "a@s.whatsapp.net", MsgID: "P1", Question: "old a", Options: []string{"x", "y"}, CreatedAt: now.Add(-2 * time.Hour)},
+		{ChatJID: "a@s.whatsapp.net", MsgID: "P2", Question: "new a", Options: []string{"x", "y"}, CreatedAt: now},
+		{ChatJID: "b@s.whatsapp.net", MsgID: "P3", Question: "b only", Options: []string{"x", "y"}, CreatedAt: now.Add(-1 * time.Hour)},
+	}
+	for _, p := range polls {
+		if err := db.UpsertPoll(p); err != nil {
+			t.Fatalf("UpsertPoll: %v", err)
+		}
+	}
+
+	all, err := db.ListPolls(PollListFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("len(all) = %d", len(all))
+	}
+	if all[0].MsgID != "P2" {
+		t.Fatalf("expected P2 first, got %s", all[0].MsgID)
+	}
+
+	onlyA, err := db.ListPolls(PollListFilter{ChatJID: "a@s.whatsapp.net"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(onlyA) != 2 {
+		t.Fatalf("len(onlyA) = %d", len(onlyA))
+	}
+}
+
+func TestDeletePollRemovesVotes(t *testing.T) {
+	db := openTestDB(t)
+
+	if err := db.UpsertPoll(Poll{
+		ChatJID: "chat@s.whatsapp.net", MsgID: "P1",
+		Question: "Q?", Options: []string{"a", "b"}, CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertPollVote(PollVote{
+		ChatJID: "chat@s.whatsapp.net", PollMsgID: "P1", VoterJID: "v@s.whatsapp.net",
+		VoteMsgID: "V1", Selected: []string{"a"}, VotedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.DeletePoll("chat@s.whatsapp.net", "P1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.GetPoll("chat@s.whatsapp.net", "P1"); err == nil {
+		t.Fatal("expected GetPoll to return ErrNoRows after delete")
+	} else if !IsPollNotFound(err) {
+		t.Fatalf("expected sql.ErrNoRows, got %v", err)
+	}
+	votes, err := db.ListPollVotes("chat@s.whatsapp.net", "P1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(votes) != 0 {
+		t.Fatalf("expected votes wiped, got %d", len(votes))
+	}
+}
+
+func TestUpsertPollRejectsMissingKey(t *testing.T) {
+	db := openTestDB(t)
+	err := db.UpsertPoll(Poll{Question: "Q?", Options: []string{"a", "b"}})
+	if err == nil {
+		t.Fatal("expected error for missing chat/msg id")
+	}
+	if errors.Is(err, nil) {
+		t.Fatal("nil error wrapping unexpected")
+	}
+}

--- a/internal/store/polls_test.go
+++ b/internal/store/polls_test.go
@@ -119,6 +119,40 @@ func TestUpsertPollVoteReplacesPriorVote(t *testing.T) {
 	}
 }
 
+func TestUpsertPollVoteKeepsNewerVote(t *testing.T) {
+	db := openTestDB(t)
+
+	newer := PollVote{
+		ChatJID:   "chat@s.whatsapp.net",
+		PollMsgID: "P1",
+		VoterJID:  "voter@s.whatsapp.net",
+		VoteMsgID: "V2",
+		Selected:  []string{"new"},
+		VotedAt:   time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+	}
+	if err := db.UpsertPollVote(newer); err != nil {
+		t.Fatal(err)
+	}
+	older := newer
+	older.VoteMsgID = "V1"
+	older.Selected = []string{"old"}
+	older.VotedAt = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := db.UpsertPollVote(older); err != nil {
+		t.Fatal(err)
+	}
+
+	votes, err := db.ListPollVotes(newer.ChatJID, newer.PollMsgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(votes) != 1 {
+		t.Fatalf("vote count = %d", len(votes))
+	}
+	if votes[0].VoteMsgID != "V2" || !reflect.DeepEqual(votes[0].Selected, []string{"new"}) {
+		t.Fatalf("vote = %+v", votes[0])
+	}
+}
+
 func TestListPollsFilterAndOrder(t *testing.T) {
 	db := openTestDB(t)
 

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -238,6 +238,97 @@ func (c *Client) SendProtoMessageWithExtra(ctx context.Context, to types.JID, ms
 	return resp.ID, nil
 }
 
+// SendPoll builds a PollCreationMessage and sends it. selectable is the
+// maximum number of options a voter may pick (1 = single-select). The poll
+// can optionally be wrapped in an EphemeralMessage for disappearing chats.
+func (c *Client) SendPoll(ctx context.Context, to types.JID, name string, options []string, selectable int, ephemeral bool) (types.MessageID, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return "", fmt.Errorf("not connected")
+	}
+	msg := cli.BuildPollCreation(name, options, selectable)
+	if ephemeral {
+		msg = &waE2E.Message{
+			EphemeralMessage: &waE2E.FutureProofMessage{Message: msg},
+		}
+	}
+	resp, err := cli.SendMessage(ctx, to, msg)
+	if err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
+// SendPollVote builds and sends a poll vote for the poll identified by
+// pollInfo (Chat, Sender, ID of the original PollCreationMessage). The
+// option names must match exactly the strings used in the poll.
+//
+// On accounts that have migrated to LID addressing, whatsmeow's SendMessage
+// auto-rewrites the destination from a phone-number JID to the corresponding
+// LID. We pre-translate here so the PollCreationMessageKey embedded by
+// BuildPollVote matches the chat/sender on the wire — otherwise the receiver
+// can't link the vote to the poll it references.
+func (c *Client) SendPollVote(ctx context.Context, pollInfo *types.MessageInfo, options []string) (types.MessageID, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return "", fmt.Errorf("not connected")
+	}
+	if pollInfo == nil {
+		return "", fmt.Errorf("poll info is required")
+	}
+
+	info := *pollInfo
+	if cli.Store != nil && cli.Store.LIDMigrationTimestamp > 0 {
+		if info.Chat.Server == types.DefaultUserServer {
+			info.Chat = c.resolvePNToLIDLocked(ctx, cli, info.Chat)
+		}
+		if info.Sender.Server == types.DefaultUserServer {
+			info.Sender = c.resolvePNToLIDLocked(ctx, cli, info.Sender)
+		}
+	}
+
+	msg, err := cli.BuildPollVote(ctx, &info, options)
+	if err != nil {
+		return "", fmt.Errorf("build poll vote: %w", err)
+	}
+	resp, err := cli.SendMessage(ctx, info.Chat, msg)
+	if err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
+// resolvePNToLIDLocked translates a phone-number JID to its LID counterpart
+// using the active session store; falls back to the input JID if no mapping
+// exists. Caller already holds (or doesn't need) c.mu.
+func (c *Client) resolvePNToLIDLocked(ctx context.Context, cli *whatsmeow.Client, jid types.JID) types.JID {
+	if cli == nil || cli.Store == nil || cli.Store.LIDs == nil {
+		return jid
+	}
+	lid, err := cli.Store.LIDs.GetLIDForPN(ctx, jid.ToNonAD())
+	if err != nil || lid.IsEmpty() {
+		return jid
+	}
+	return lid
+}
+
+// DecryptPollVote decrypts an incoming PollUpdateMessage event and returns
+// the SHA-256 hashes of the selected options. The caller is responsible for
+// matching those hashes back to option names.
+func (c *Client) DecryptPollVote(ctx context.Context, evt *events.Message) (*waE2E.PollVoteMessage, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil {
+		return nil, fmt.Errorf("whatsapp client is not initialized")
+	}
+	return cli.DecryptPollVote(ctx, evt)
+}
+
 func (c *Client) SendReaction(ctx context.Context, chat, sender types.JID, targetID types.MessageID, reaction string) (types.MessageID, error) {
 	c.mu.Lock()
 	cli := c.client

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -349,6 +349,16 @@ func (c *Client) DecryptPollVote(ctx context.Context, evt *events.Message) (*waE
 	return cli.DecryptPollVote(ctx, evt)
 }
 
+func (c *Client) DecryptSecretEncryptedMessage(ctx context.Context, evt *events.Message) (*waE2E.Message, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil {
+		return nil, fmt.Errorf("whatsapp client is not initialized")
+	}
+	return cli.DecryptSecretEncryptedMessage(ctx, evt)
+}
+
 func (c *Client) SendReaction(ctx context.Context, chat, sender types.JID, targetID types.MessageID, reaction string) (types.MessageID, error) {
 	c.mu.Lock()
 	cli := c.client

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -273,11 +273,10 @@ func wrapEphemeralPollMessage(msg *waE2E.Message) *waE2E.Message {
 // pollInfo (Chat, Sender, ID of the original PollCreationMessage). The
 // option names must match exactly the strings used in the poll.
 //
-// On accounts that have migrated to LID addressing, whatsmeow's SendMessage
-// auto-rewrites the destination from a phone-number JID to the corresponding
-// LID. We pre-translate here so the PollCreationMessageKey embedded by
-// BuildPollVote matches the chat/sender on the wire — otherwise the receiver
-// can't link the vote to the poll it references.
+// On migrated DM accounts, whatsmeow's SendMessage auto-rewrites the
+// destination from a phone-number JID to the corresponding LID. Pre-translate
+// DMs so the PollCreationMessageKey embedded by BuildPollVote matches the
+// chat/sender on the wire.
 func (c *Client) SendPollVote(ctx context.Context, pollInfo *types.MessageInfo, options []string) (types.MessageID, error) {
 	c.mu.Lock()
 	cli := c.client
@@ -290,14 +289,7 @@ func (c *Client) SendPollVote(ctx context.Context, pollInfo *types.MessageInfo, 
 	}
 
 	info := *pollInfo
-	if cli.Store != nil && cli.Store.LIDMigrationTimestamp > 0 {
-		if info.Chat.Server == types.DefaultUserServer {
-			info.Chat = c.resolvePNToLIDLocked(ctx, cli, info.Chat)
-		}
-		if info.Sender.Server == types.DefaultUserServer {
-			info.Sender = c.resolvePNToLIDLocked(ctx, cli, info.Sender)
-		}
-	}
+	info = rewritePollVoteInfoForLID(ctx, cli, info, c.resolvePNToLIDLocked)
 
 	msg, err := cli.BuildPollVote(ctx, &info, options)
 	if err != nil {
@@ -308,6 +300,26 @@ func (c *Client) SendPollVote(ctx context.Context, pollInfo *types.MessageInfo, 
 		return "", err
 	}
 	return resp.ID, nil
+}
+
+type pollVoteLIDResolver func(context.Context, *whatsmeow.Client, types.JID) types.JID
+
+func rewritePollVoteInfoForLID(ctx context.Context, cli *whatsmeow.Client, info types.MessageInfo, resolve pollVoteLIDResolver) types.MessageInfo {
+	if cli == nil || cli.Store == nil || cli.Store.LIDMigrationTimestamp <= 0 || resolve == nil {
+		return info
+	}
+	switch info.Chat.Server {
+	case types.DefaultUserServer:
+		info.Chat = resolve(ctx, cli, info.Chat)
+		if info.Sender.Server == types.DefaultUserServer {
+			info.Sender = resolve(ctx, cli, info.Sender)
+		}
+	case types.HiddenUserServer:
+		if info.Sender.Server == types.DefaultUserServer {
+			info.Sender = resolve(ctx, cli, info.Sender)
+		}
+	}
+	return info
 }
 
 // resolvePNToLIDLocked translates a phone-number JID to its LID counterpart

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -484,7 +484,7 @@ func (c *Client) DownloadHistorySync(ctx context.Context, notif *waE2E.HistorySy
 	if cli == nil {
 		return nil, fmt.Errorf("whatsapp client is not initialized")
 	}
-	return cli.DownloadHistorySync(ctx, notif, false)
+	return cli.DownloadHistorySync(ctx, notif, true)
 }
 
 func (c *Client) RequestHistorySyncOnDemand(ctx context.Context, lastKnown types.MessageInfo, count int) (types.MessageID, error) {

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -250,15 +250,23 @@ func (c *Client) SendPoll(ctx context.Context, to types.JID, name string, option
 	}
 	msg := cli.BuildPollCreation(name, options, selectable)
 	if ephemeral {
-		msg = &waE2E.Message{
-			EphemeralMessage: &waE2E.FutureProofMessage{Message: msg},
-		}
+		msg = wrapEphemeralPollMessage(msg)
 	}
 	resp, err := cli.SendMessage(ctx, to, msg)
 	if err != nil {
 		return "", err
 	}
 	return resp.ID, nil
+}
+
+func wrapEphemeralPollMessage(msg *waE2E.Message) *waE2E.Message {
+	if msg == nil {
+		return nil
+	}
+	return &waE2E.Message{
+		EphemeralMessage:   &waE2E.FutureProofMessage{Message: msg},
+		MessageContextInfo: msg.MessageContextInfo,
+	}
 }
 
 // SendPollVote builds and sends a poll vote for the poll identified by

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -326,14 +326,29 @@ func rewritePollVoteInfoForLID(ctx context.Context, cli *whatsmeow.Client, info 
 // using the active session store; falls back to the input JID if no mapping
 // exists. Caller already holds (or doesn't need) c.mu.
 func (c *Client) resolvePNToLIDLocked(ctx context.Context, cli *whatsmeow.Client, jid types.JID) types.JID {
-	if cli == nil || cli.Store == nil || cli.Store.LIDs == nil {
+	if cli == nil || cli.Store == nil {
 		return jid
 	}
-	lid, err := cli.Store.LIDs.GetLIDForPN(ctx, jid.ToNonAD())
-	if err != nil || lid.IsEmpty() {
+	pn := jid.ToNonAD()
+	if ownPN := cli.Store.GetJID().ToNonAD(); pn == ownPN {
+		if ownLID := cli.Store.GetLID().ToNonAD(); !ownLID.IsEmpty() {
+			return ownLID
+		}
+	}
+	if cli.Store.LIDs == nil {
 		return jid
 	}
-	return lid
+	lid, err := cli.Store.LIDs.GetLIDForPN(ctx, pn)
+	if err == nil && !lid.IsEmpty() {
+		return lid
+	}
+	info, err := cli.GetUserInfo(ctx, []types.JID{pn})
+	if err == nil {
+		if resolved := info[pn].LID.ToNonAD(); !resolved.IsEmpty() {
+			return resolved
+		}
+	}
+	return jid
 }
 
 // DecryptPollVote decrypts an incoming PollUpdateMessage event and returns
@@ -357,6 +372,19 @@ func (c *Client) DecryptSecretEncryptedMessage(ctx context.Context, evt *events.
 		return nil, fmt.Errorf("whatsapp client is not initialized")
 	}
 	return cli.DecryptSecretEncryptedMessage(ctx, evt)
+}
+
+func (c *Client) DeleteHistorySyncMedia(ctx context.Context, notif *waE2E.HistorySyncNotification) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil {
+		return fmt.Errorf("whatsapp client is not initialized")
+	}
+	if notif == nil || notif.GetDirectPath() == "" {
+		return nil
+	}
+	return cli.DeleteMedia(ctx, whatsmeow.MediaHistory, notif.GetDirectPath(), notif.GetFileEncSHA256(), notif.GetEncHandle())
 }
 
 func (c *Client) SendReaction(ctx context.Context, chat, sender types.JID, targetID types.MessageID, reaction string) (types.MessageID, error) {

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -642,14 +642,7 @@ func (c *Client) ResolvePNToLID(ctx context.Context, jid types.JID) types.JID {
 	c.mu.Lock()
 	cli := c.client
 	c.mu.Unlock()
-	if cli == nil || cli.Store == nil || cli.Store.LIDs == nil {
-		return jid
-	}
-	lid, err := cli.Store.LIDs.GetLIDForPN(ctx, jid.ToNonAD())
-	if err != nil || lid.IsEmpty() {
-		return jid
-	}
-	return lid
+	return c.resolvePNToLIDLocked(ctx, cli, jid)
 }
 
 func BestContactName(info types.ContactInfo) string {

--- a/internal/wa/client_test.go
+++ b/internal/wa/client_test.go
@@ -1,6 +1,7 @@
 package wa
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/appstate"
 	waProto "go.mau.fi/whatsmeow/binary/proto"
+	waStore "go.mau.fi/whatsmeow/store"
 	"go.mau.fi/whatsmeow/types"
 	"google.golang.org/protobuf/proto"
 )
@@ -81,6 +83,53 @@ func TestWrapEphemeralPollMessagePreservesSecretOnOuterMessage(t *testing.T) {
 	}
 	if got := wrapped.GetMessageContextInfo().GetMessageSecret(); string(got) != string(secret) {
 		t.Fatalf("outer message secret = %q, want %q", got, secret)
+	}
+}
+
+func TestRewritePollVoteInfoForLIDRewritesDM(t *testing.T) {
+	chat := types.NewJID("15551234567", types.DefaultUserServer)
+	sender := types.NewJID("15557654321", types.DefaultUserServer)
+	info := types.MessageInfo{
+		MessageSource: types.MessageSource{Chat: chat, Sender: sender},
+		ID:            "poll-id",
+	}
+	cli := &whatsmeow.Client{Store: &waStore.Device{LIDMigrationTimestamp: 1}}
+
+	got := rewritePollVoteInfoForLID(context.Background(), cli, info, func(_ context.Context, _ *whatsmeow.Client, jid types.JID) types.JID {
+		return types.NewJID(jid.User+"lid", types.HiddenUserServer)
+	})
+
+	if got.Chat.Server != types.HiddenUserServer || got.Chat.User != chat.User+"lid" {
+		t.Fatalf("chat = %s", got.Chat)
+	}
+	if got.Sender.Server != types.HiddenUserServer || got.Sender.User != sender.User+"lid" {
+		t.Fatalf("sender = %s", got.Sender)
+	}
+}
+
+func TestRewritePollVoteInfoForLIDLeavesGroupSenderPN(t *testing.T) {
+	group := types.NewJID("120363001234567890", types.GroupServer)
+	sender := types.NewJID("15557654321", types.DefaultUserServer)
+	info := types.MessageInfo{
+		MessageSource: types.MessageSource{Chat: group, Sender: sender, IsGroup: true},
+		ID:            "poll-id",
+	}
+	cli := &whatsmeow.Client{Store: &waStore.Device{LIDMigrationTimestamp: 1}}
+	calls := 0
+
+	got := rewritePollVoteInfoForLID(context.Background(), cli, info, func(_ context.Context, _ *whatsmeow.Client, jid types.JID) types.JID {
+		calls++
+		return types.NewJID(jid.User+"lid", types.HiddenUserServer)
+	})
+
+	if got.Chat != group {
+		t.Fatalf("chat = %s, want %s", got.Chat, group)
+	}
+	if got.Sender != sender {
+		t.Fatalf("sender = %s, want %s", got.Sender, sender)
+	}
+	if calls != 0 {
+		t.Fatalf("resolver calls = %d, want 0", calls)
 	}
 }
 

--- a/internal/wa/client_test.go
+++ b/internal/wa/client_test.go
@@ -144,6 +144,17 @@ func TestResolvePNToLIDUsesOwnLIDWithoutCache(t *testing.T) {
 	}
 }
 
+func TestResolvePNToLIDPublicUsesOwnLIDWithoutCache(t *testing.T) {
+	pn := types.NewJID("15551234567", types.DefaultUserServer)
+	lid := types.NewJID("999123456789", types.HiddenUserServer)
+	c := &Client{client: &whatsmeow.Client{Store: &waStore.Device{ID: &pn, LID: lid, LIDMigrationTimestamp: 1}}}
+
+	got := c.ResolvePNToLID(context.Background(), pn)
+	if got != lid {
+		t.Fatalf("resolved = %s, want %s", got, lid)
+	}
+}
+
 func TestParseUserOrJID(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/wa/client_test.go
+++ b/internal/wa/client_test.go
@@ -133,6 +133,17 @@ func TestRewritePollVoteInfoForLIDLeavesGroupSenderPN(t *testing.T) {
 	}
 }
 
+func TestResolvePNToLIDUsesOwnLIDWithoutCache(t *testing.T) {
+	pn := types.NewJID("15551234567", types.DefaultUserServer)
+	lid := types.NewJID("999123456789", types.HiddenUserServer)
+	cli := &whatsmeow.Client{Store: &waStore.Device{ID: &pn, LID: lid, LIDMigrationTimestamp: 1}}
+
+	got := (&Client{}).resolvePNToLIDLocked(context.Background(), cli, pn)
+	if got != lid {
+		t.Fatalf("resolved = %s, want %s", got, lid)
+	}
+}
+
 func TestParseUserOrJID(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/wa/client_test.go
+++ b/internal/wa/client_test.go
@@ -9,7 +9,9 @@ import (
 
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/appstate"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
 	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestNewEnablesRetryMessageStore(t *testing.T) {
@@ -63,6 +65,22 @@ func TestBuildDeleteForMePatch(t *testing.T) {
 	action := mut.Value.GetDeleteMessageForMeAction()
 	if action == nil || !action.GetDeleteMedia() || action.GetMessageTimestamp() != ts.UnixMilli() {
 		t.Fatalf("delete-for-me action = %+v", action)
+	}
+}
+
+func TestWrapEphemeralPollMessagePreservesSecretOnOuterMessage(t *testing.T) {
+	secret := []byte("poll-secret")
+	inner := &waProto.Message{
+		PollCreationMessage: &waProto.PollCreationMessage{Name: proto.String("Lunch?")},
+		MessageContextInfo:  &waProto.MessageContextInfo{MessageSecret: secret},
+	}
+
+	wrapped := wrapEphemeralPollMessage(inner)
+	if wrapped.GetEphemeralMessage().GetMessage() != inner {
+		t.Fatalf("inner message not wrapped")
+	}
+	if got := wrapped.GetMessageContextInfo().GetMessageSecret(); string(got) != string(secret) {
+		t.Fatalf("outer message secret = %q, want %q", got, secret)
 	}
 }
 

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 )
@@ -46,6 +47,16 @@ type PollVoteRef struct {
 	PollSenderJID string
 }
 
+// PollAddOptionRef references an added option for an existing poll. Encrypted
+// add-option messages initially carry only the poll key; the option is filled
+// after decryption in the sync layer.
+type PollAddOptionRef struct {
+	PollMessageID string
+	PollChatJID   string
+	PollSenderJID string
+	Option        string
+}
+
 type ParsedMessage struct {
 	Chat            types.JID
 	ID              string
@@ -57,6 +68,7 @@ type ParsedMessage struct {
 	Media           *Media
 	Poll            *Poll
 	PollVote        *PollVoteRef
+	PollAdd         *PollAddOptionRef
 	PushName        string
 	ReplyToID       string
 	ReplyToDisplay  string
@@ -131,6 +143,7 @@ func extractWAProto(m *waProto.Message, pm *ParsedMessage) {
 	extractContactText(m, pm)
 	extractBusinessText(m, pm)
 	extractPoll(m, pm)
+	extractPollAddOption(m, pm)
 	extractPollUpdate(m, pm)
 
 	if ctx := contextInfoForMessage(m); ctx != nil {
@@ -269,6 +282,39 @@ func extractPollUpdate(m *waProto.Message, pm *ParsedMessage) {
 	if pm.Text == "" {
 		pm.Text = "Poll vote"
 	}
+}
+
+func extractPollAddOption(m *waProto.Message, pm *ParsedMessage) {
+	add := m.GetPollAddOptionMessage()
+	if add != nil {
+		pm.PollAdd = pollAddOptionRef(add.GetPollCreationMessageKey(), add.GetAddOption().GetOptionName())
+		if pm.Text == "" {
+			pm.Text = "Poll option added"
+		}
+		return
+	}
+	secret := m.GetSecretEncryptedMessage()
+	if secret == nil || secret.GetSecretEncType() != waE2E.SecretEncryptedMessage_POLL_ADD_OPTION {
+		return
+	}
+	pm.PollAdd = pollAddOptionRef(secret.GetTargetMessageKey(), "")
+	if pm.Text == "" {
+		pm.Text = "Poll option added"
+	}
+}
+
+func pollAddOptionRef(key interface {
+	GetID() string
+	GetRemoteJID() string
+	GetParticipant() string
+}, option string) *PollAddOptionRef {
+	ref := &PollAddOptionRef{Option: strings.TrimSpace(option)}
+	if key != nil {
+		ref.PollMessageID = strings.TrimSpace(key.GetID())
+		ref.PollChatJID = strings.TrimSpace(key.GetRemoteJID())
+		ref.PollSenderJID = strings.TrimSpace(key.GetParticipant())
+	}
+	return ref
 }
 
 func extractPlainText(m *waProto.Message, pm *ParsedMessage) {

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -31,7 +31,7 @@ type Button struct {
 }
 
 // Poll captures the question + option list extracted from an incoming
-// PollCreationMessage (any of V1/V2/V3/V4/V5).
+// PollCreationMessage (any of V1/V2/V3/V4/V5/V6).
 type Poll struct {
 	Question        string
 	Options         []string
@@ -211,7 +211,7 @@ func extractPoll(m *waProto.Message, pm *ParsedMessage) {
 }
 
 // pickPollCreation returns the inner PollCreationMessage from any of the
-// known V1/V2/V3/V4/V5 fields, including the FutureProofMessage wrappers.
+// known V1/V2/V3/V4/V5/V6 fields, including FutureProofMessage wrappers.
 func pickPollCreation(m *waProto.Message) *waProto.PollCreationMessage {
 	if m == nil {
 		return nil

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -228,6 +228,9 @@ func pickPollCreation(m *waProto.Message) *waProto.PollCreationMessage {
 	if c := m.GetPollCreationMessageV5(); c != nil {
 		return c
 	}
+	if c := m.GetPollCreationMessageV6(); c != nil {
+		return c
+	}
 	if fp := m.GetPollCreationMessageV4(); fp != nil {
 		if inner := fp.GetMessage(); inner != nil {
 			if c := inner.GetPollCreationMessage(); c != nil {
@@ -240,6 +243,9 @@ func pickPollCreation(m *waProto.Message) *waProto.PollCreationMessage {
 				return c
 			}
 			if c := inner.GetPollCreationMessageV5(); c != nil {
+				return c
+			}
+			if c := inner.GetPollCreationMessageV6(); c != nil {
 				return c
 			}
 		}

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -45,6 +45,7 @@ type PollVoteRef struct {
 	PollMessageID string
 	PollChatJID   string
 	PollSenderJID string
+	SenderTsMS    int64
 }
 
 // PollAddOptionRef references an added option for an existing poll. Encrypted
@@ -278,6 +279,7 @@ func extractPollUpdate(m *waProto.Message, pm *ParsedMessage) {
 		ref.PollChatJID = strings.TrimSpace(key.GetRemoteJID())
 		ref.PollSenderJID = strings.TrimSpace(key.GetParticipant())
 	}
+	ref.SenderTsMS = update.GetSenderTimestampMS()
 	pm.PollVote = ref
 	if pm.Text == "" {
 		pm.Text = "Poll vote"

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -30,6 +30,22 @@ type Button struct {
 	Description string `json:"description,omitempty"`
 }
 
+// Poll captures the question + option list extracted from an incoming
+// PollCreationMessage (any of V1/V2/V3/V4/V5).
+type Poll struct {
+	Question        string
+	Options         []string
+	SelectableCount uint32
+}
+
+// PollVoteRef references the original poll a PollUpdateMessage is voting on.
+// Decryption of the vote happens later in the sync handler.
+type PollVoteRef struct {
+	PollMessageID string
+	PollChatJID   string
+	PollSenderJID string
+}
+
 type ParsedMessage struct {
 	Chat            types.JID
 	ID              string
@@ -39,6 +55,8 @@ type ParsedMessage struct {
 	Text            string
 	Buttons         []Button
 	Media           *Media
+	Poll            *Poll
+	PollVote        *PollVoteRef
 	PushName        string
 	ReplyToID       string
 	ReplyToDisplay  string
@@ -112,6 +130,8 @@ func extractWAProto(m *waProto.Message, pm *ParsedMessage) {
 	extractMedia(m, pm)
 	extractContactText(m, pm)
 	extractBusinessText(m, pm)
+	extractPoll(m, pm)
+	extractPollUpdate(m, pm)
 
 	if ctx := contextInfoForMessage(m); ctx != nil {
 		if id := strings.TrimSpace(ctx.GetStanzaID()); id != "" {
@@ -167,6 +187,81 @@ func extractReaction(m *waProto.Message, pm *ParsedMessage) {
 		if key := encReaction.GetTargetMessageKey(); key != nil {
 			pm.ReactionToID = key.GetID()
 		}
+	}
+}
+
+func extractPoll(m *waProto.Message, pm *ParsedMessage) {
+	creation := pickPollCreation(m)
+	if creation == nil {
+		return
+	}
+	question := strings.TrimSpace(creation.GetName())
+	options := make([]string, 0, len(creation.GetOptions()))
+	for _, opt := range creation.GetOptions() {
+		options = append(options, opt.GetOptionName())
+	}
+	pm.Poll = &Poll{
+		Question:        question,
+		Options:         options,
+		SelectableCount: creation.GetSelectableOptionsCount(),
+	}
+	if pm.Text == "" && question != "" {
+		pm.Text = "Poll: " + question
+	}
+}
+
+// pickPollCreation returns the inner PollCreationMessage from any of the
+// known V1/V2/V3/V4/V5 fields, including the FutureProofMessage wrappers.
+func pickPollCreation(m *waProto.Message) *waProto.PollCreationMessage {
+	if m == nil {
+		return nil
+	}
+	if c := m.GetPollCreationMessage(); c != nil {
+		return c
+	}
+	if c := m.GetPollCreationMessageV2(); c != nil {
+		return c
+	}
+	if c := m.GetPollCreationMessageV3(); c != nil {
+		return c
+	}
+	if c := m.GetPollCreationMessageV5(); c != nil {
+		return c
+	}
+	if fp := m.GetPollCreationMessageV4(); fp != nil {
+		if inner := fp.GetMessage(); inner != nil {
+			if c := inner.GetPollCreationMessage(); c != nil {
+				return c
+			}
+			if c := inner.GetPollCreationMessageV2(); c != nil {
+				return c
+			}
+			if c := inner.GetPollCreationMessageV3(); c != nil {
+				return c
+			}
+			if c := inner.GetPollCreationMessageV5(); c != nil {
+				return c
+			}
+		}
+	}
+	return nil
+}
+
+func extractPollUpdate(m *waProto.Message, pm *ParsedMessage) {
+	update := m.GetPollUpdateMessage()
+	if update == nil {
+		return
+	}
+	key := update.GetPollCreationMessageKey()
+	ref := &PollVoteRef{}
+	if key != nil {
+		ref.PollMessageID = strings.TrimSpace(key.GetID())
+		ref.PollChatJID = strings.TrimSpace(key.GetRemoteJID())
+		ref.PollSenderJID = strings.TrimSpace(key.GetParticipant())
+	}
+	pm.PollVote = ref
+	if pm.Text == "" {
+		pm.Text = "Poll vote"
 	}
 }
 

--- a/internal/wa/messages_context.go
+++ b/internal/wa/messages_context.go
@@ -62,6 +62,9 @@ func contextInfoForMessage(m *waProto.Message) *waProto.ContextInfo {
 	if tbr := m.GetTemplateButtonReplyMessage(); tbr != nil {
 		return tbr.GetContextInfo()
 	}
+	if creation := pickPollCreation(m); creation != nil {
+		return creation.GetContextInfo()
+	}
 	return nil
 }
 

--- a/internal/wa/messages_context.go
+++ b/internal/wa/messages_context.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/proto/waE2E"
 )
 
 func contextInfoForMessage(m *waProto.Message) *waProto.ContextInfo {
@@ -104,6 +105,12 @@ func displayTextForProto(m *waProto.Message) string {
 	}
 	if m.GetPollUpdateMessage() != nil {
 		return "Poll vote"
+	}
+	if m.GetPollAddOptionMessage() != nil {
+		return "Poll option added"
+	}
+	if secret := m.GetSecretEncryptedMessage(); secret != nil && secret.GetSecretEncType() == waE2E.SecretEncryptedMessage_POLL_ADD_OPTION {
+		return "Poll option added"
 	}
 
 	if text := strings.TrimSpace(m.GetConversation()); text != "" {

--- a/internal/wa/messages_context.go
+++ b/internal/wa/messages_context.go
@@ -96,6 +96,15 @@ func displayTextForProto(m *waProto.Message) string {
 	if contacts := m.GetContactsArrayMessage(); contacts != nil {
 		return contactsArrayDisplayText(contacts)
 	}
+	if creation := pickPollCreation(m); creation != nil {
+		if q := strings.TrimSpace(creation.GetName()); q != "" {
+			return "Poll: " + q
+		}
+		return "Poll"
+	}
+	if m.GetPollUpdateMessage() != nil {
+		return "Poll vote"
+	}
 
 	if text := strings.TrimSpace(m.GetConversation()); text != "" {
 		return text

--- a/internal/wa/messages_test.go
+++ b/internal/wa/messages_test.go
@@ -199,6 +199,55 @@ func TestParseLiveMessageReply(t *testing.T) {
 	}
 }
 
+func TestParseLiveMessagePollReplyAndForwardedContext(t *testing.T) {
+	chat, _ := types.ParseJID("123@s.whatsapp.net")
+	sender, _ := types.ParseJID("sender@s.whatsapp.net")
+
+	ev := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     chat,
+				Sender:   sender,
+				IsFromMe: false,
+			},
+			ID:        "poll-mid",
+			Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			PushName:  "Sender",
+		},
+		Message: &waProto.Message{
+			PollCreationMessageV3: &waProto.PollCreationMessage{
+				Name: proto.String("Lunch?"),
+				Options: []*waProto.PollCreationMessage_Option{
+					{OptionName: proto.String("Pizza")},
+					{OptionName: proto.String("Sushi")},
+				},
+				ContextInfo: &waProto.ContextInfo{
+					StanzaID: proto.String("orig"),
+					QuotedMessage: &waProto.Message{
+						Conversation: proto.String("quoted text"),
+					},
+					IsForwarded:     proto.Bool(true),
+					ForwardingScore: proto.Uint32(2),
+				},
+			},
+		},
+	}
+
+	pm := ParseLiveMessage(ev)
+	if pm.Poll == nil {
+		t.Fatalf("expected poll parse, got %+v", pm)
+	}
+	if pm.ReplyToID != "orig" {
+		t.Fatalf("expected ReplyToID to be orig, got %q", pm.ReplyToID)
+	}
+	if pm.ReplyToDisplay != "quoted text" {
+		t.Fatalf("expected ReplyToDisplay to be quoted text, got %q", pm.ReplyToDisplay)
+	}
+	if !pm.IsForwarded || pm.ForwardingScore != 2 {
+		t.Fatalf("expected forwarded poll context, got forwarded=%v score=%d", pm.IsForwarded, pm.ForwardingScore)
+	}
+}
+
 func TestParseLiveMessageForwarded(t *testing.T) {
 	chat, _ := types.ParseJID("123@s.whatsapp.net")
 	sender, _ := types.ParseJID("sender@s.whatsapp.net")

--- a/internal/wa/messages_test.go
+++ b/internal/wa/messages_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	"google.golang.org/protobuf/proto"
@@ -964,6 +965,63 @@ func TestParseLiveMessagePollUpdateRefersToCreation(t *testing.T) {
 	}
 	if pm.PollVote.PollChatJID != "15551112222@s.whatsapp.net" {
 		t.Fatalf("poll chat jid = %q", pm.PollVote.PollChatJID)
+	}
+}
+
+func TestParseLiveMessagePollAddOption(t *testing.T) {
+	chat, _ := types.ParseJID("15551112222@s.whatsapp.net")
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat},
+			ID:            "ADD-1",
+			Timestamp:     time.Date(2026, 5, 9, 12, 6, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{
+			PollAddOptionMessage: &waE2E.PollAddOptionMessage{
+				PollCreationMessageKey: &waProto.MessageKey{
+					ID:        proto.String("POLL-1"),
+					RemoteJID: proto.String("15551112222@s.whatsapp.net"),
+				},
+				AddOption: &waProto.PollCreationMessage_Option{OptionName: proto.String("Maybe")},
+			},
+		},
+	}
+	pm := ParseLiveMessage(evt)
+	if pm.PollAdd == nil {
+		t.Fatalf("expected PollAdd set, got nil; pm=%+v", pm)
+	}
+	if pm.PollAdd.PollMessageID != "POLL-1" || pm.PollAdd.Option != "Maybe" {
+		t.Fatalf("poll add = %+v", pm.PollAdd)
+	}
+	if pm.Text != "Poll option added" {
+		t.Fatalf("text = %q", pm.Text)
+	}
+}
+
+func TestParseLiveMessageEncryptedPollAddOptionRef(t *testing.T) {
+	chat, _ := types.ParseJID("15551112222@s.whatsapp.net")
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat},
+			ID:            "ADD-ENC",
+			Timestamp:     time.Date(2026, 5, 9, 12, 6, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{
+			SecretEncryptedMessage: &waE2E.SecretEncryptedMessage{
+				TargetMessageKey: &waProto.MessageKey{
+					ID:        proto.String("POLL-1"),
+					RemoteJID: proto.String("15551112222@s.whatsapp.net"),
+				},
+				SecretEncType: waE2E.SecretEncryptedMessage_POLL_ADD_OPTION.Enum(),
+			},
+		},
+	}
+	pm := ParseLiveMessage(evt)
+	if pm.PollAdd == nil {
+		t.Fatalf("expected PollAdd set, got nil; pm=%+v", pm)
+	}
+	if pm.PollAdd.PollMessageID != "POLL-1" || pm.PollAdd.Option != "" {
+		t.Fatalf("poll add = %+v", pm.PollAdd)
 	}
 }
 

--- a/internal/wa/messages_test.go
+++ b/internal/wa/messages_test.go
@@ -915,6 +915,27 @@ func TestParseLiveMessagePollCreationV1(t *testing.T) {
 	}
 }
 
+func TestParseLiveMessagePollCreationV6(t *testing.T) {
+	chat, _ := types.ParseJID("15551112222@s.whatsapp.net")
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat},
+			ID:            "POLL-V6",
+			Timestamp:     time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{
+			PollCreationMessageV6: &waProto.PollCreationMessage{
+				Name:    proto.String("V6?"),
+				Options: []*waProto.PollCreationMessage_Option{{OptionName: proto.String("a")}, {OptionName: proto.String("b")}},
+			},
+		},
+	}
+	pm := ParseLiveMessage(evt)
+	if pm.Poll == nil || pm.Poll.Question != "V6?" {
+		t.Fatalf("v6 poll not parsed: %+v", pm)
+	}
+}
+
 func TestParseLiveMessagePollUpdateRefersToCreation(t *testing.T) {
 	chat, _ := types.ParseJID("15551112222@s.whatsapp.net")
 	evt := &events.Message{

--- a/internal/wa/messages_test.go
+++ b/internal/wa/messages_test.go
@@ -740,3 +740,105 @@ func TestDisplayTextForProtoBusinessTypes(t *testing.T) {
 		})
 	}
 }
+
+func TestParseLiveMessagePollCreationV3(t *testing.T) {
+	chat, _ := types.ParseJID("15551112222@s.whatsapp.net")
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat},
+			ID:            "POLL-1",
+			Timestamp:     time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{
+			PollCreationMessageV3: &waProto.PollCreationMessage{
+				Name: proto.String("Pizza?"),
+				Options: []*waProto.PollCreationMessage_Option{
+					{OptionName: proto.String("Yes")},
+					{OptionName: proto.String("No")},
+					{OptionName: proto.String("Maybe")},
+				},
+				SelectableOptionsCount: proto.Uint32(2),
+			},
+		},
+	}
+	pm := ParseLiveMessage(evt)
+	if pm.Poll == nil {
+		t.Fatalf("expected Poll set, got nil; pm=%+v", pm)
+	}
+	if pm.Poll.Question != "Pizza?" {
+		t.Fatalf("question = %q", pm.Poll.Question)
+	}
+	if got, want := pm.Poll.Options, []string{"Yes", "No", "Maybe"}; !equalStrings(got, want) {
+		t.Fatalf("options = %v want %v", got, want)
+	}
+	if pm.Poll.SelectableCount != 2 {
+		t.Fatalf("selectable = %d", pm.Poll.SelectableCount)
+	}
+	if pm.Text != "Poll: Pizza?" {
+		t.Fatalf("text = %q", pm.Text)
+	}
+}
+
+func TestParseLiveMessagePollCreationV1(t *testing.T) {
+	chat, _ := types.ParseJID("15551112222@s.whatsapp.net")
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat},
+			ID:            "POLL-V1",
+			Timestamp:     time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{
+			PollCreationMessage: &waProto.PollCreationMessage{
+				Name:    proto.String("Hello?"),
+				Options: []*waProto.PollCreationMessage_Option{{OptionName: proto.String("a")}, {OptionName: proto.String("b")}},
+			},
+		},
+	}
+	pm := ParseLiveMessage(evt)
+	if pm.Poll == nil || pm.Poll.Question != "Hello?" {
+		t.Fatalf("v1 poll not parsed: %+v", pm)
+	}
+}
+
+func TestParseLiveMessagePollUpdateRefersToCreation(t *testing.T) {
+	chat, _ := types.ParseJID("15551112222@s.whatsapp.net")
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat},
+			ID:            "VOTE-1",
+			Timestamp:     time.Date(2026, 5, 9, 12, 5, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{
+			PollUpdateMessage: &waProto.PollUpdateMessage{
+				PollCreationMessageKey: &waProto.MessageKey{
+					ID:          proto.String("POLL-1"),
+					RemoteJID:   proto.String("15551112222@s.whatsapp.net"),
+					FromMe:      proto.Bool(true),
+					Participant: proto.String("15551112222@s.whatsapp.net"),
+				},
+			},
+		},
+	}
+	pm := ParseLiveMessage(evt)
+	if pm.PollVote == nil {
+		t.Fatalf("expected PollVote set, got nil; pm=%+v", pm)
+	}
+	if pm.PollVote.PollMessageID != "POLL-1" {
+		t.Fatalf("poll msg id = %q", pm.PollVote.PollMessageID)
+	}
+	if pm.PollVote.PollChatJID != "15551112222@s.whatsapp.net" {
+		t.Fatalf("poll chat jid = %q", pm.PollVote.PollChatJID)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
Wires the whatsmeow poll API end-to-end through the existing wacli layers: send polls (single + multi-select), persist incoming polls (V1/V2/V3/V4-FutureProof/V5 variants), vote on polls, decrypt inbound vote events, and query results with per-voter breakdown. Storage: two new tables (`polls`, `poll_votes`) introduced via migration #14.

## What's new
- `wacli send poll --to … --question … --option … [--multi N] [--ephemeral]`
- `wacli poll vote --to … --id … --option …`
- `wacli poll show --to … --id …` (aggregates + per-voter list, `--json` supported)
- `wacli polls list [--chat … --limit N]`
- IPC delegate paths for `poll` and `poll_vote` so the commands work while `wacli sync` holds the lock.
- New `wa.Client` methods: `SendPoll`, `SendPollVote`, `DecryptPollVote`, plus `WAClient` interface extension.

## LID-related subtleties caught while testing live
1. Self-poll vote events arrive keyed under the LID rather than the phone JID the poll was stored under. Falling back to a msg-id lookup (`store.FindPollByMsgID`) is required for the live decrypt path.
2. Voter JIDs are normalised via `ResolveLIDToPN` before upsert so the outbound vote row and the inbound echo collapse into a single `poll_votes` row.
3. On accounts with `LIDMigrationTimestamp > 0`, whatsmeow's `SendMessage` rewrites the destination from phone JID to LID. We pre-translate `pollInfo.Chat`/`Sender` in `Client.SendPollVote` so the embedded `PollCreationMessageKey` matches the wire destination — otherwise the recipient cannot link the vote to the poll it references and the vote silently no-ops on the mobile side.
4. `MessageInfo.IsFromMe` set from `messages.from_me` so `PollCreationMessageKey.FromMe` is correct when voting on our own polls.

## Test plan
- [x] `go test ./...` passes (all 13 packages).
- [x] Live: send single-select poll → renders on mobile.
- [x] Live: send multi-select poll → mobile shows "Select up to N".
- [x] Live: vote from mobile → sync ingests, `poll show` reflects selection.
- [x] Live: vote from CLI (`wacli poll vote`) → mobile shows the vote (after the LID translation fix).
- [x] Live: change vote → upsert correctly replaces, single voter row remains.
- [ ] Live: vote from a second account on a third party's poll (not exercised; covered by unit tests).
- [ ] Live: history sync of polls + votes (not exercised live; code path mirrors the live path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)