### PR TITLE
feat: extract buttons from InteractiveMessage NativeFlowMessage

### DIFF
--- a/internal/wa/messages_business.go
+++ b/internal/wa/messages_business.go
@@ -1,6 +1,7 @@
 package wa
 
 import (
+	"encoding/json"
 	"strings"
 
 	waProto "go.mau.fi/whatsmeow/binary/proto"
@@ -82,8 +83,15 @@ func extractBusinessText(m *waProto.Message, pm *ParsedMessage) {
 		pm.Text = resp.GetSelectedDisplayText()
 	}
 
-	if im := m.GetInteractiveMessage(); im != nil && pm.Text == "" {
-		pm.Text = interactiveText(im)
+	if im := m.GetInteractiveMessage(); im != nil {
+		if pm.Text == "" {
+			pm.Text = interactiveText(im)
+		}
+		if nf := im.GetNativeFlowMessage(); nf != nil {
+			for _, btn := range nf.GetButtons() {
+				pm.Buttons = append(pm.Buttons, nativeFlowButton(btn)...)
+			}
+		}
 	}
 
 	if resp := m.GetInteractiveResponseMessage(); resp != nil && pm.Text == "" {
@@ -141,6 +149,41 @@ func hydratedTemplate(tmpl *waProto.TemplateMessage) *waProto.TemplateMessage_Hy
 		return h
 	}
 	return tmpl.GetHydratedTemplate()
+}
+
+func nativeFlowButton(btn *waProto.InteractiveMessage_NativeFlowMessage_NativeFlowButton) []Button {
+	name := strings.TrimSpace(btn.GetName())
+	raw := strings.TrimSpace(btn.GetButtonParamsJSON())
+	if raw == "" {
+		return nil
+	}
+	switch name {
+	case "cta_url":
+		var p struct {
+			DisplayText string `json:"display_text"`
+			URL         string `json:"url"`
+		}
+		if json.Unmarshal([]byte(raw), &p) == nil && (p.DisplayText != "" || p.URL != "") {
+			return []Button{{Type: "url", DisplayText: strings.TrimSpace(p.DisplayText), URL: strings.TrimSpace(p.URL)}}
+		}
+	case "quick_reply":
+		var p struct {
+			DisplayText string `json:"display_text"`
+			ID          string `json:"id"`
+		}
+		if json.Unmarshal([]byte(raw), &p) == nil && p.DisplayText != "" {
+			return []Button{{Type: "quick_reply", DisplayText: strings.TrimSpace(p.DisplayText), ID: strings.TrimSpace(p.ID)}}
+		}
+	case "cta_call":
+		var p struct {
+			DisplayText string `json:"display_text"`
+			PhoneNumber string `json:"phone_number"`
+		}
+		if json.Unmarshal([]byte(raw), &p) == nil && p.DisplayText != "" {
+			return []Button{{Type: "call", DisplayText: strings.TrimSpace(p.DisplayText), PhoneNumber: strings.TrimSpace(p.PhoneNumber)}}
+		}
+	}
+	return nil
 }
 
 func interactiveText(im *waProto.InteractiveMessage) string {

--- a/internal/wa/messages_test.go
+++ b/internal/wa/messages_test.go
@@ -547,6 +547,56 @@ func TestParseInteractiveMessage(t *testing.T) {
 	}
 }
 
+func TestParseInteractiveMessageWithNativeFlowButtons(t *testing.T) {
+	chat, _ := types.ParseJID("123@s.whatsapp.net")
+	sender, _ := types.ParseJID("biz@s.whatsapp.net")
+
+	ev := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat: chat, Sender: sender, IsFromMe: false,
+			},
+			ID:        "native1",
+			Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{
+			InteractiveMessage: &waProto.InteractiveMessage{
+				Body: &waProto.InteractiveMessage_Body{
+					Text: proto.String("Complete your payment"),
+				},
+				InteractiveMessage: &waProto.InteractiveMessage_NativeFlowMessage_{
+					NativeFlowMessage: &waProto.InteractiveMessage_NativeFlowMessage{
+						Buttons: []*waProto.InteractiveMessage_NativeFlowMessage_NativeFlowButton{
+							{
+								Name:             proto.String("cta_url"),
+								ButtonParamsJSON: proto.String(`{"display_text":"Pay now","url":"https://pay.example.com"}`),
+							},
+							{
+								Name:             proto.String("quick_reply"),
+								ButtonParamsJSON: proto.String(`{"display_text":"Cancel","id":"cancel"}`),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pm := ParseLiveMessage(ev)
+	if pm.Text != "Complete your payment" {
+		t.Fatalf("unexpected text: %q", pm.Text)
+	}
+	if len(pm.Buttons) != 2 {
+		t.Fatalf("expected 2 buttons, got %d: %+v", len(pm.Buttons), pm.Buttons)
+	}
+	if pm.Buttons[0].Type != "url" || pm.Buttons[0].DisplayText != "Pay now" || pm.Buttons[0].URL != "https://pay.example.com" {
+		t.Fatalf("unexpected button[0]: %+v", pm.Buttons[0])
+	}
+	if pm.Buttons[1].Type != "quick_reply" || pm.Buttons[1].DisplayText != "Cancel" || pm.Buttons[1].ID != "cancel" {
+		t.Fatalf("unexpected button[1]: %+v", pm.Buttons[1])
+	}
+}
+
 func TestParseListMessage(t *testing.T) {
 	chat, _ := types.ParseJID("123@s.whatsapp.net")
 	sender, _ := types.ParseJID("biz@s.whatsapp.net")


### PR DESCRIPTION
  NativeFlowMessage is the newer WhatsApp interactive type used for CTA
  URL, quick-reply, and call buttons. Two fixes:

  1. The pm.Text == "" guard on the InteractiveMessage block was skipping button extraction entirely whenever plain text was already set. Text and button extraction are now independent.

  2. Add nativeFlowButton() to parse NativeFlowMessage buttons by decoding ButtonParamsJSON for cta_url, quick_reply, and cta_call button name values.