### PR TITLE
fix: resolve privacy token failure for new contacts by warming up recipient before send

### DIFF
--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -105,6 +105,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 			if err := a.Connect(ctx, false, nil); err != nil {
 				return err
 			}
+			warmupRecipient(ctx, a.WA(), toJID, os.Stderr)
 			if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
 				return err
 			}

--- a/cmd/wacli/send_file_cmd.go
+++ b/cmd/wacli/send_file_cmd.go
@@ -77,6 +77,7 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 			if err := a.Connect(ctx, false, nil); err != nil {
 				return err
 			}
+			warmupRecipient(ctx, a.WA(), toJID, os.Stderr)
 			if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
 				return err
 			}

--- a/cmd/wacli/send_helpers.go
+++ b/cmd/wacli/send_helpers.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openclaw/wacli/internal/app"
 	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
 )
 
 const sendAttemptTimeout = 45 * time.Second
@@ -128,4 +129,28 @@ func warnRapidSendIfNeeded(storeDir string, now time.Time, stderr io.Writer) err
 		return fmt.Errorf("chmod last send marker: %w", err)
 	}
 	return nil
+}
+
+// warmupRecipient resolves the recipient's user info before sending to
+// establish contact state with WhatsApp's servers. Without this, the
+// privacy token (tctoken) IQ may fail with 400: bad-request for new or
+// unknown contacts, causing messages to be silently dropped despite
+// returning sent:true.
+//
+// The warmup is best-effort: failures are logged to stderr but never
+// block the send.
+//
+// userInfoResolver is satisfied by app.WAClient.
+type userInfoResolver interface {
+	GetUserInfo(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error)
+}
+
+func warmupRecipient(ctx context.Context, wa userInfoResolver, jid types.JID, stderr io.Writer) {
+	if jid.Server != types.DefaultUserServer && jid.Server != types.HiddenUserServer {
+		return
+	}
+	_, err := wa.GetUserInfo(ctx, []types.JID{jid})
+	if err != nil {
+		fmt.Fprintf(stderr, "warn: send warmup for %s failed (send will proceed): %v\n", jid, err)
+	}
 }

--- a/cmd/wacli/send_helpers_test.go
+++ b/cmd/wacli/send_helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
 )
 
 func TestRunSendOperationRetriesRetryableError(t *testing.T) {
@@ -155,5 +156,80 @@ func TestWarnRapidSendIfNeededSkipsOldOrInvalidMarker(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("invalid marker warned: %q", stderr.String())
+	}
+}
+
+type mockUserInfoClient struct {
+	getUserInfo func(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error)
+}
+
+func (m *mockUserInfoClient) GetUserInfo(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error) {
+	if m.getUserInfo == nil {
+		return nil, nil
+	}
+	return m.getUserInfo(ctx, jids)
+}
+
+func TestWarmupRecipientSkipNonUserServer(t *testing.T) {
+	called := false
+	mock := &mockUserInfoClient{
+		getUserInfo: func(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error) {
+			called = true
+			return nil, nil
+		},
+	}
+
+	var stderr bytes.Buffer
+	groupJID := types.NewJID("12345", types.GroupServer)
+	warmupRecipient(context.Background(), mock, groupJID, &stderr)
+	if called {
+		t.Fatal("GetUserInfo should not be called for group JIDs")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func TestWarmupRecipientCallsGetUserInfoForUserServer(t *testing.T) {
+	called := false
+	mock := &mockUserInfoClient{
+		getUserInfo: func(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error) {
+			called = true
+			if len(jids) != 1 {
+				t.Fatalf("expected 1 JID, got %d", len(jids))
+			}
+			if jids[0].String() != "15551234567@s.whatsapp.net" {
+				t.Fatalf("unexpected JID: %s", jids[0].String())
+			}
+			return nil, nil
+		},
+	}
+
+	var stderr bytes.Buffer
+	userJID := types.NewJID("15551234567", types.DefaultUserServer)
+	warmupRecipient(context.Background(), mock, userJID, &stderr)
+	if !called {
+		t.Fatal("GetUserInfo should be called for user JIDs")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func TestWarmupRecipientLogsErrorToStderr(t *testing.T) {
+	mock := &mockUserInfoClient{
+		getUserInfo: func(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error) {
+			return nil, errors.New("simulated failure")
+		},
+	}
+
+	var stderr bytes.Buffer
+	userJID := types.NewJID("15551234567", types.DefaultUserServer)
+	warmupRecipient(context.Background(), mock, userJID, &stderr)
+	if stderr.Len() == 0 {
+		t.Fatal("expected stderr output on error")
+	}
+	if !strings.Contains(stderr.String(), "warn: send warmup for") {
+		t.Fatalf("expected warning in stderr, got: %q", stderr.String())
 	}
 }

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -202,6 +202,7 @@ func executeDelegatedText(ctx context.Context, a *app.App, req sendDelegateReque
 	if err != nil {
 		return sendDelegateResponse{}, err
 	}
+	warmupDelegatedRecipient(ctx, a, toJID)
 	mentionedJIDs, err := parseMentionedJIDs(req.Mentions)
 	if err != nil {
 		return sendDelegateResponse{}, err
@@ -237,6 +238,7 @@ func executeDelegatedFile(ctx context.Context, a *app.App, req sendDelegateReque
 	if err != nil {
 		return sendDelegateResponse{}, err
 	}
+	warmupDelegatedRecipient(ctx, a, toJID)
 	if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
 		return sendDelegateResponse{}, err
 	}
@@ -266,6 +268,7 @@ func executeDelegatedSticker(ctx context.Context, a *app.App, req sendDelegateRe
 	if err != nil {
 		return sendDelegateResponse{}, err
 	}
+	warmupDelegatedRecipient(ctx, a, toJID)
 	if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
 		return sendDelegateResponse{}, err
 	}
@@ -291,6 +294,7 @@ func executeDelegatedReact(ctx context.Context, a *app.App, req sendDelegateRequ
 	if err != nil {
 		return sendDelegateResponse{}, err
 	}
+	warmupDelegatedRecipient(ctx, a, chat)
 	if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
 		return sendDelegateResponse{}, err
 	}
@@ -336,6 +340,10 @@ func writeDelegatedSendOutput(flags *rootFlags, kind string, resp sendDelegateRe
 		fmt.Fprintf(os.Stdout, "Sent to %s (id %s)\n", resp.To, resp.ID)
 	}
 	return nil
+}
+
+func warmupDelegatedRecipient(ctx context.Context, a *app.App, jid types.JID) {
+	warmupRecipient(ctx, a.WA(), jid, os.Stderr)
 }
 
 func durationMillis(d time.Duration) int64 {

--- a/cmd/wacli/send_react_cmd.go
+++ b/cmd/wacli/send_react_cmd.go
@@ -66,6 +66,7 @@ func newSendReactCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			warmupRecipient(ctx, a.WA(), chat, os.Stderr)
 			if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
 				return err
 			}

--- a/cmd/wacli/send_sticker_cmd.go
+++ b/cmd/wacli/send_sticker_cmd.go
@@ -69,6 +69,7 @@ func newSendStickerCmd(flags *rootFlags) *cobra.Command {
 			if err := a.Connect(ctx, false, nil); err != nil {
 				return err
 			}
+			warmupRecipient(ctx, a.WA(), toJID, os.Stderr)
 			if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
 				return err
 			}

--- a/cmd/wacli/send_voice_cmd.go
+++ b/cmd/wacli/send_voice_cmd.go
@@ -71,6 +71,7 @@ func newSendVoiceCmd(flags *rootFlags) *cobra.Command {
 			if err := a.Connect(ctx, false, nil); err != nil {
 				return err
 			}
+			warmupRecipient(ctx, a.WA(), toJID, os.Stderr)
 			if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
 				return err
 			}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -34,6 +34,7 @@ type WAClient interface {
 	ResolveChatName(ctx context.Context, chat types.JID, pushName string) string
 	ResolveLIDToPN(ctx context.Context, jid types.JID) types.JID
 	ResolvePNToLID(ctx context.Context, jid types.JID) types.JID
+	GetUserInfo(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error)
 	GetContact(ctx context.Context, jid types.JID) (types.ContactInfo, error)
 	GetAllContacts(ctx context.Context) (map[types.JID]types.ContactInfo, error)
 

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -226,6 +226,10 @@ func (f *fakeWA) ResolvePNToLID(ctx context.Context, jid types.JID) types.JID {
 	return jid
 }
 
+func (f *fakeWA) GetUserInfo(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error) {
+	return map[types.JID]types.UserInfo{}, nil
+}
+
 func (f *fakeWA) GetContact(ctx context.Context, jid types.JID) (types.ContactInfo, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -429,6 +429,16 @@ func (c *Client) FetchAppState(ctx context.Context, name string, fullSync, onlyI
 	return cli.FetchAppState(ctx, appstate.WAPatchName(name), fullSync, onlyIfNotSynced)
 }
 
+func (c *Client) GetUserInfo(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return nil, fmt.Errorf("not connected")
+	}
+	return cli.GetUserInfo(ctx, jids)
+}
+
 func (c *Client) GetContact(ctx context.Context, jid types.JID) (types.ContactInfo, error) {
 	c.mu.Lock()
 	cli := c.client


### PR DESCRIPTION
## Summary

Fixes messages silently not being delivered to new/unknown contacts, despite `send text` returning `sent:true`.

## Problem

When sending a message to a recipient with no prior conversation state, whatsmeow's privacy token (tctoken) IQ fails with `400: bad-request`. The message is sent without the `tctoken` node and WhatsApp silently drops it.

Stderr shows:
```
Failed to issue privacy token for 55XXXXXXXXXXX@s.whatsapp.net: info query returned status 400: bad-request
```

## Root cause

The privacy token IQ fails because WhatsApp's server has no prior state (LID mapping, device list) for the recipient. Users who already have an existing chat/contact history do not encounter this issue.

## Fix

Call `GetUserInfo` (which issues a `usync` query) on the recipient before sending to establish the required server-side state. After the usync resolves the recipient's devices and LID mapping, the subsequent privacy token issuance succeeds.

Key design:
- **Best-effort**: failures are logged to stderr but never block the send
- **Scoped to user JIDs**: skips groups, newsletters, broadcast lists
- **All send commands covered**: `text`, `file`, `sticker`, `voice`, `react`

## Testing

- Build: `pnpm build` — passes
- Lint: `pnpm lint` — passes
- Format: `pnpm format:check` — passes
- All tests: `pnpm test` — passes (3 new regression tests added)

Closes #212