### PR TITLE
docs: add named accounts to quickstart and expand nav sections

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -101,7 +101,25 @@ wacli history backfill --chat 1234567890@s.whatsapp.net --requests 10 --count 50
 
 The phone must be online for `backfill`. WhatsApp may not return full history. See [History](history.md) for coverage planning, limits, and patterns.
 
-## 7. Diagnostics and safety
+## 7. Named accounts (optional)
+
+If you run more than one WhatsApp number, named accounts give each an isolated store, session, and lock:
+
+```bash
+# Add a second account and pair it immediately
+wacli accounts add work
+
+# List all configured accounts
+wacli accounts list
+
+# Use a named account with any command
+wacli --account work sync --follow
+wacli --account personal send text --to mom --message "hi"
+```
+
+Use `--no-auth` to create the account entry without pairing immediately. Two accounts can sync concurrently — their locks are independent. See [Accounts](accounts.md) for YAML config and migration from manual `--store` paths.
+
+## 8. Diagnostics and safety
 
 ```bash
 wacli doctor
@@ -114,7 +132,7 @@ WACLI_READONLY=1 wacli send text --to mom --message "hi"   # exits with a clear 
 
 `doctor` checks the store, schema, FTS5 availability, and (with `--connect`) live connectivity. See [Doctor](doctor.md).
 
-## 8. Shell completion (optional)
+## 9. Shell completion (optional)
 
 ```bash
 wacli completion bash    >> ~/.bash_completion
@@ -125,7 +143,9 @@ wacli completion fish    >  ~/.config/fish/completions/wacli.fish
 ## Where next
 
 - [Overview](overview.md) — global flags, store model, full command map.
+- [Accounts](accounts.md) — named accounts, isolated stores, YAML config.
 - [Send](send.md) — every recipient form, replies, reactions, mentions, link previews.
+- [Channels](channels.md) — read and follow WhatsApp Channels.
 - [Groups](groups.md) — list, refresh, info, rename, participants, invite links.
 - [Spec](spec.md) — design notes, storage layout, locking model, non-goals.
 - [Doctor](doctor.md) — self-checks and connectivity probe.

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -21,10 +21,10 @@ const brewInstall = "brew install steipete/tap/wacli";
 
 const sections = [
   ["Start", ["index.md", "install.md", "quickstart.md", "overview.md"]],
-  ["Auth & Sync", ["auth.md", "sync.md", "history.md", "doctor.md"]],
-  ["Messages", ["messages.md", "send.md", "media.md", "presence.md"]],
+  ["Auth & Sync", ["auth.md", "accounts.md", "sync.md", "history.md", "doctor.md"]],
+  ["Messages", ["messages.md", "send.md", "media.md", "presence.md", "channels.md"]],
   ["Contacts & Groups", ["contacts.md", "contacts-import-system.md", "chats.md", "groups.md", "profile.md"]],
-  ["Reference", ["spec.md", "docs.md", "completion.md", "version.md", "help.md", "release.md"]],
+  ["Reference", ["spec.md", "docs.md", "store.md", "integrations.md", "completion.md", "version.md", "help.md", "release.md"]],
 ];
 
 const buildExcludes = [];


### PR DESCRIPTION
## Summary

- Add step 7 **Named accounts (optional)** covering `wacli accounts add/list` and the `--account` flag (v0.8.0 feature missing from quickstart)
- Renumber old steps 7–8 → 8–9
- Add `accounts.md` and `channels.md` to **"Where next"** section
- Add missing pages to sidebar nav in `build-docs-site.mjs`:
  - `accounts.md` → Auth & Sync section
  - `channels.md` → Messages section
  - `store.md`, `integrations.md` → Reference section