### PR TITLE
fix(wa): extract NativeFlowMessage buttons from InteractiveMessage

### DIFF
--- a/internal/wa/messages_business.go
+++ b/internal/wa/messages_business.go
@@ -1,6 +1,7 @@
 package wa
 
 import (
+	"encoding/json"
 	"strings"
 
 	waProto "go.mau.fi/whatsmeow/binary/proto"
@@ -82,8 +83,39 @@ func extractBusinessText(m *waProto.Message, pm *ParsedMessage) {
 		pm.Text = resp.GetSelectedDisplayText()
 	}
 
-	if im := m.GetInteractiveMessage(); im != nil && pm.Text == "" {
-		pm.Text = interactiveText(im)
+	if im := m.GetInteractiveMessage(); im != nil {
+		if pm.Text == "" {
+			pm.Text = interactiveText(im)
+		}
+		if nf := im.GetNativeFlowMessage(); nf != nil {
+			for _, nb := range nf.GetButtons() {
+				name := strings.TrimSpace(nb.GetName())
+				params := strings.TrimSpace(nb.GetButtonParamsJSON())
+				var data map[string]string
+				if err := json.Unmarshal([]byte(params), &data); err == nil {
+					switch name {
+					case "cta_url":
+						pm.Buttons = append(pm.Buttons, Button{
+							Type: "url",
+							DisplayText: data["display_text"],
+							URL: data["url"],
+						})
+					case "quick_reply":
+						pm.Buttons = append(pm.Buttons, Button{
+							Type: "quick_reply",
+							DisplayText: data["display_text"],
+							ID: data["id"],
+						})
+					case "cta_call":
+						pm.Buttons = append(pm.Buttons, Button{
+							Type: "call",
+							DisplayText: data["display_text"],
+							PhoneNumber: data["phone_number"],
+						})
+					}
+				}
+			}
+		}
 	}
 
 	if resp := m.GetInteractiveResponseMessage(); resp != nil && pm.Text == "" {


### PR DESCRIPTION
Fixes #233

## Problem
`InteractiveMessage` payloads carrying a `NativeFlowMessage` block (CTA URL, quick-reply, call buttons used by the WhatsApp Business Cloud API) were dropped: `Buttons` came back `null` even when the upstream message carried them.

## Root cause (verified against `internal/wa/messages_business.go`)

1. `NativeFlowMessage` was not handled in `extractBusinessText`. Each button there carries a `Name` field (`cta_url`, `quick_reply`, `cta_call`) plus a `ButtonParamsJSON` payload, neither of which were being parsed.
2. The interactive branch was gated by `pm.Text == ""`, which is virtually never true for these messages — so button extraction was being short-circuited.

## Fix

- Drop the `pm.Text == ""` guard around the `InteractiveMessage` branch so button extraction runs unconditionally.
- Parse `ButtonParamsJSON` and append entries to `pm.Buttons` based on `Name`:
  - `cta_url` → `Button{Type:"url", DisplayText, URL}`
  - `quick_reply` → `Button{Type:"quick_reply", DisplayText, ID}`
  - `cta_call` → `Button{Type:"call", DisplayText, PhoneNumber}`

The extracted `Text` field still falls back to `interactiveText(im)` when empty.

## Testing

- `go build ./...` — clean
- `go test ./internal/wa/...` — passes
- `go vet ./...` — clean

Happy to iterate on review feedback. Closing for now while we double-check whether the upstream prefers a different shape (e.g. a separate `NativeFlow` field on `ParsedMessage` instead of overloading `Buttons`).