### PR TITLE
fix: include disappearing context for ephemeral text

### DIFF
--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -42,6 +43,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 	var replyToSender string
 	var noPreview bool
 	var ephemeral bool
+	var ephemeralDuration string
 	var messageEscapes bool
 	postSendWait := postSendRetryReceiptWait
 
@@ -62,6 +64,14 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 				}
 				message = decoded
 			}
+			ephemeralOpts := textEphemeralOptions{
+				Enabled:     ephemeral,
+				Duration:    ephemeralDuration,
+				DurationSet: cmd.Flags().Changed("ephemeral-duration"),
+			}
+			if err := validateTextEphemeralOptions(ephemeralOpts); err != nil {
+				return err
+			}
 
 			ctx, cancel := withTimeout(context.Background(), flags)
 			defer cancel()
@@ -69,16 +79,18 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 			a, lk, err := newApp(ctx, flags, true, false)
 			if err != nil {
 				resp, delegated, delegateErr := tryDelegateSend(ctx, flags, err, sendDelegateRequest{
-					Kind:           "text",
-					To:             to,
-					Pick:           pick,
-					Message:        message,
-					Mentions:       mentions,
-					ReplyTo:        replyTo,
-					ReplyToSender:  replyToSender,
-					NoPreview:      noPreview,
-					Ephemeral:      ephemeral,
-					PostSendWaitMS: durationMillis(postSendWait),
+					Kind:                 "text",
+					To:                   to,
+					Pick:                 pick,
+					Message:              message,
+					Mentions:             mentions,
+					ReplyTo:              replyTo,
+					ReplyToSender:        replyToSender,
+					NoPreview:            noPreview,
+					Ephemeral:            ephemeralOpts.Enabled,
+					EphemeralDuration:    ephemeralOpts.Duration,
+					EphemeralDurationSet: ephemeralOpts.DurationSet,
+					PostSendWaitMS:       durationMillis(postSendWait),
 				})
 				if delegated {
 					if delegateErr != nil {
@@ -112,7 +124,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 
 			preview := fetchLinkPreview(ctx, message, noPreview)
 			msgID, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (types.MessageID, error) {
-				return sendTextMessage(ctx, a, toJID, message, replyTo, replyToSender, preview, mentionedJIDs, ephemeral)
+				return sendTextMessage(ctx, a, toJID, message, replyTo, replyToSender, preview, mentionedJIDs, ephemeralOpts)
 			})
 			if err != nil {
 				return err
@@ -155,7 +167,8 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&replyTo, "reply-to", "", "message ID to quote/reply to")
 	cmd.Flags().StringVar(&replyToSender, "reply-to-sender", "", "sender JID of the quoted message (required for unsynced group replies)")
 	cmd.Flags().BoolVar(&noPreview, "no-preview", false, "disable automatic link previews for the first URL in text")
-	cmd.Flags().BoolVar(&ephemeral, "ephemeral", false, "wrap outgoing text in EphemeralMessage for disappearing-message chats")
+	cmd.Flags().BoolVar(&ephemeral, "ephemeral", false, "send with the disappearing-message timer for this chat")
+	cmd.Flags().StringVar(&ephemeralDuration, "ephemeral-duration", "", "disappearing-message timer override (for example 24h, 7d, 90d, 168h)")
 	cmd.Flags().BoolVar(&messageEscapes, "message-escapes", false, `interpret backslash escapes in --message (\n, \r, \t, \\, \")`)
 	cmd.Flags().DurationVar(&postSendWait, "post-send-wait", postSendRetryReceiptWait, "keep the connection alive after send so retry receipts can be handled (0 disables)")
 	return cmd
@@ -169,34 +182,135 @@ type sendTextApp interface {
 type textMessageSender interface {
 	SendText(ctx context.Context, to types.JID, text string) (types.MessageID, error)
 	SendProtoMessage(ctx context.Context, to types.JID, msg *waProto.Message) (types.MessageID, error)
+	GetGroupInfo(ctx context.Context, jid types.JID) (*types.GroupInfo, error)
 }
 
-func sendTextMessage(ctx context.Context, a sendTextApp, to types.JID, text, replyTo, replyToSender string, preview *linkpreview.Preview, mentionedJIDs []string, ephemeral bool) (types.MessageID, error) {
+type textEphemeralOptions struct {
+	Enabled     bool
+	Duration    string
+	DurationSet bool
+}
+
+type resolvedTextEphemeral struct {
+	enabled       bool
+	hasExpiration bool
+	expiration    uint32
+}
+
+const defaultEphemeralExpiration uint32 = 7 * 24 * 60 * 60
+
+func sendTextMessage(ctx context.Context, a sendTextApp, to types.JID, text, replyTo, replyToSender string, preview *linkpreview.Preview, mentionedJIDs []string, ephemeral textEphemeralOptions) (types.MessageID, error) {
 	return sendTextMessageWithSender(ctx, a.WA(), a.DB(), to, text, replyTo, replyToSender, preview, mentionedJIDs, ephemeral)
 }
 
-func sendTextMessageWithSender(ctx context.Context, sender textMessageSender, db *store.DB, to types.JID, text, replyTo, replyToSender string, preview *linkpreview.Preview, mentionedJIDs []string, ephemeral bool) (types.MessageID, error) {
+func sendTextMessageWithSender(ctx context.Context, sender textMessageSender, db *store.DB, to types.JID, text, replyTo, replyToSender string, preview *linkpreview.Preview, mentionedJIDs []string, ephemeral textEphemeralOptions) (types.MessageID, error) {
 	msg, plainText, err := buildTextMessage(db, to, text, replyTo, replyToSender, preview, mentionedJIDs)
 	if err != nil {
 		return "", err
 	}
-	if plainText && !ephemeral {
+	resolved, err := resolveTextEphemeral(ctx, sender, to, ephemeral)
+	if err != nil {
+		return "", err
+	}
+	if plainText && !resolved.enabled {
 		return sender.SendText(ctx, to, text)
 	}
 	if plainText {
-		msg = &waProto.Message{Conversation: proto.String(text)}
+		msg = &waProto.Message{
+			ExtendedTextMessage: &waProto.ExtendedTextMessage{
+				Text: proto.String(text),
+			},
+		}
 	}
-	if ephemeral {
-		msg = wrapEphemeralMessage(msg)
+	if resolved.hasExpiration {
+		applyEphemeralContext(msg, resolved.expiration)
 	}
 	return sender.SendProtoMessage(ctx, to, msg)
 }
 
-func wrapEphemeralMessage(msg *waProto.Message) *waProto.Message {
-	return &waProto.Message{
-		EphemeralMessage: &waProto.FutureProofMessage{
-			Message: msg,
-		},
+func resolveTextEphemeral(ctx context.Context, sender textMessageSender, to types.JID, opts textEphemeralOptions) (resolvedTextEphemeral, error) {
+	if err := validateTextEphemeralOptions(opts); err != nil {
+		return resolvedTextEphemeral{}, err
+	}
+	duration := strings.TrimSpace(opts.Duration)
+	if duration != "" {
+		expiration, err := parseEphemeralExpiration(duration)
+		if err != nil {
+			return resolvedTextEphemeral{}, err
+		}
+		return resolvedTextEphemeral{enabled: true, hasExpiration: true, expiration: expiration}, nil
+	}
+	if !opts.Enabled {
+		return resolvedTextEphemeral{}, nil
+	}
+	if to.Server == types.GroupServer {
+		info, _ := sender.GetGroupInfo(ctx, to)
+		if info != nil && info.IsEphemeral && info.DisappearingTimer > 0 {
+			return resolvedTextEphemeral{enabled: true, hasExpiration: true, expiration: info.DisappearingTimer}, nil
+		}
+	}
+	return resolvedTextEphemeral{enabled: true, hasExpiration: true, expiration: defaultEphemeralExpiration}, nil
+}
+
+func validateTextEphemeralOptions(opts textEphemeralOptions) error {
+	duration := strings.TrimSpace(opts.Duration)
+	if !opts.DurationSet && duration == "" {
+		return nil
+	}
+	if duration == "" {
+		return fmt.Errorf("--ephemeral-duration must be a positive duration such as 24h, 7d, 90d, or 168h")
+	}
+	_, err := parseEphemeralExpiration(duration)
+	return err
+}
+
+func parseEphemeralExpiration(s string) (uint32, error) {
+	d, err := parseEphemeralDuration(s)
+	if err != nil {
+		return 0, err
+	}
+	seconds := int64(d / time.Second)
+	if seconds <= 0 || seconds > int64(^uint32(0)) {
+		return 0, fmt.Errorf("--ephemeral-duration must fit in uint32 seconds")
+	}
+	return uint32(seconds), nil
+}
+
+func parseEphemeralDuration(s string) (time.Duration, error) {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return 0, fmt.Errorf("--ephemeral-duration is required")
+	}
+	switch strings.ReplaceAll(s, " ", "") {
+	case "1d", "1day", "day":
+		return 24 * time.Hour, nil
+	case "7d", "7day", "7days", "1w", "1week", "week":
+		return 7 * 24 * time.Hour, nil
+	case "90d", "90day", "90days":
+		return 90 * 24 * time.Hour, nil
+	}
+	if strings.HasSuffix(s, "d") {
+		days, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimSuffix(s, "d")), 64)
+		if err == nil && days > 0 {
+			return time.Duration(days * float64(24*time.Hour)), nil
+		}
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return 0, fmt.Errorf("--ephemeral-duration must be a positive duration such as 24h, 7d, 90d, or 168h")
+	}
+	return d, nil
+}
+
+func applyEphemeralContext(msg *waProto.Message, expiration uint32) {
+	if msg == nil || expiration == 0 {
+		return
+	}
+	if ext := msg.GetExtendedTextMessage(); ext != nil {
+		if ext.ContextInfo == nil {
+			ext.ContextInfo = &waProto.ContextInfo{}
+		}
+		ext.ContextInfo.Expiration = proto.Uint32(expiration)
 	}
 }
 

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -26,26 +26,28 @@ const (
 var errSendDelegateUnavailable = errors.New("send delegate unavailable")
 
 type sendDelegateRequest struct {
-	Version        int      `json:"version"`
-	Kind           string   `json:"kind"`
-	To             string   `json:"to,omitempty"`
-	Pick           int      `json:"pick,omitempty"`
-	Message        string   `json:"message,omitempty"`
-	Mentions       []string `json:"mentions,omitempty"`
-	ReplyTo        string   `json:"reply_to,omitempty"`
-	ReplyToSender  string   `json:"reply_to_sender,omitempty"`
-	NoPreview      bool     `json:"no_preview,omitempty"`
-	Ephemeral      bool     `json:"ephemeral,omitempty"`
-	File           string   `json:"file,omitempty"`
-	Filename       string   `json:"filename,omitempty"`
-	Caption        string   `json:"caption,omitempty"`
-	MIME           string   `json:"mime,omitempty"`
-	PTT            bool     `json:"ptt,omitempty"`
-	ID             string   `json:"id,omitempty"`
-	Reaction       string   `json:"reaction,omitempty"`
-	Sender         string   `json:"sender,omitempty"`
-	PostSendWaitMS int64    `json:"post_send_wait_ms,omitempty"`
-	TimeoutMS      int64    `json:"timeout_ms,omitempty"`
+	Version              int      `json:"version"`
+	Kind                 string   `json:"kind"`
+	To                   string   `json:"to,omitempty"`
+	Pick                 int      `json:"pick,omitempty"`
+	Message              string   `json:"message,omitempty"`
+	Mentions             []string `json:"mentions,omitempty"`
+	ReplyTo              string   `json:"reply_to,omitempty"`
+	ReplyToSender        string   `json:"reply_to_sender,omitempty"`
+	NoPreview            bool     `json:"no_preview,omitempty"`
+	Ephemeral            bool     `json:"ephemeral,omitempty"`
+	EphemeralDuration    string   `json:"ephemeral_duration,omitempty"`
+	EphemeralDurationSet bool     `json:"ephemeral_duration_set,omitempty"`
+	File                 string   `json:"file,omitempty"`
+	Filename             string   `json:"filename,omitempty"`
+	Caption              string   `json:"caption,omitempty"`
+	MIME                 string   `json:"mime,omitempty"`
+	PTT                  bool     `json:"ptt,omitempty"`
+	ID                   string   `json:"id,omitempty"`
+	Reaction             string   `json:"reaction,omitempty"`
+	Sender               string   `json:"sender,omitempty"`
+	PostSendWaitMS       int64    `json:"post_send_wait_ms,omitempty"`
+	TimeoutMS            int64    `json:"timeout_ms,omitempty"`
 }
 
 type sendDelegateResponse struct {
@@ -198,6 +200,14 @@ func executeDelegatedSend(parent context.Context, a *app.App, req sendDelegateRe
 }
 
 func executeDelegatedText(ctx context.Context, a *app.App, req sendDelegateRequest) (sendDelegateResponse, error) {
+	ephemeral := textEphemeralOptions{
+		Enabled:     req.Ephemeral,
+		Duration:    req.EphemeralDuration,
+		DurationSet: req.EphemeralDurationSet,
+	}
+	if err := validateTextEphemeralOptions(ephemeral); err != nil {
+		return sendDelegateResponse{}, err
+	}
 	toJID, err := resolveRecipient(a, req.To, recipientOptions{pick: req.Pick, asJSON: true})
 	if err != nil {
 		return sendDelegateResponse{}, err
@@ -212,7 +222,7 @@ func executeDelegatedText(ctx context.Context, a *app.App, req sendDelegateReque
 	}
 	preview := fetchLinkPreview(ctx, req.Message, req.NoPreview)
 	msgID, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (types.MessageID, error) {
-		return sendTextMessage(ctx, a, toJID, req.Message, req.ReplyTo, req.ReplyToSender, preview, mentionedJIDs, req.Ephemeral)
+		return sendTextMessage(ctx, a, toJID, req.Message, req.ReplyTo, req.ReplyToSender, preview, mentionedJIDs, ephemeral)
 	})
 	if err != nil {
 		return sendDelegateResponse{}, err

--- a/cmd/wacli/send_ipc_test.go
+++ b/cmd/wacli/send_ipc_test.go
@@ -51,16 +51,24 @@ func TestExecuteDelegatedSendRejectsBadVersionBeforeAppUse(t *testing.T) {
 
 func TestSendDelegateRequestPreservesEphemeralInJSON(t *testing.T) {
 	raw, err := json.Marshal(sendDelegateRequest{
-		Version:   sendDelegateVersion,
-		Kind:      "text",
-		Message:   "hello",
-		Ephemeral: true,
+		Version:              sendDelegateVersion,
+		Kind:                 "text",
+		Message:              "hello",
+		Ephemeral:            true,
+		EphemeralDuration:    "7d",
+		EphemeralDurationSet: true,
 	})
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
 	}
 	if !strings.Contains(string(raw), `"ephemeral":true`) {
 		t.Fatalf("encoded request missing ephemeral flag: %s", raw)
+	}
+	if !strings.Contains(string(raw), `"ephemeral_duration":"7d"`) {
+		t.Fatalf("encoded request missing ephemeral duration: %s", raw)
+	}
+	if !strings.Contains(string(raw), `"ephemeral_duration_set":true`) {
+		t.Fatalf("encoded request missing ephemeral duration set flag: %s", raw)
 	}
 
 	var got sendDelegateRequest
@@ -69,6 +77,12 @@ func TestSendDelegateRequestPreservesEphemeralInJSON(t *testing.T) {
 	}
 	if !got.Ephemeral {
 		t.Fatalf("Ephemeral = false, want true")
+	}
+	if got.EphemeralDuration != "7d" {
+		t.Fatalf("EphemeralDuration = %q, want 7d", got.EphemeralDuration)
+	}
+	if !got.EphemeralDurationSet {
+		t.Fatalf("EphemeralDurationSet = false, want true")
 	}
 }
 

--- a/cmd/wacli/send_test.go
+++ b/cmd/wacli/send_test.go
@@ -39,6 +39,8 @@ type recordingTextSender struct {
 	textRecipient  types.JID
 	nextTextID     types.MessageID
 	nextProtoMsgID types.MessageID
+	groupInfo      *types.GroupInfo
+	groupInfoCalls int
 }
 
 func (s *recordingTextSender) SendText(_ context.Context, to types.JID, text string) (types.MessageID, error) {
@@ -59,6 +61,23 @@ func (s *recordingTextSender) SendProtoMessage(_ context.Context, to types.JID, 
 		return s.nextProtoMsgID, nil
 	}
 	return "proto-id", nil
+}
+
+func (s *recordingTextSender) GetGroupInfo(_ context.Context, _ types.JID) (*types.GroupInfo, error) {
+	s.groupInfoCalls++
+	return s.groupInfo, nil
+}
+
+func requireExtendedText(t *testing.T, msg *waProto.Message) *waProto.ExtendedTextMessage {
+	t.Helper()
+	if msg.GetEphemeralMessage() != nil {
+		t.Fatalf("unexpected EphemeralMessage wrapper")
+	}
+	ext := msg.GetExtendedTextMessage()
+	if ext == nil {
+		t.Fatalf("missing ExtendedTextMessage")
+	}
+	return ext
 }
 
 func TestResolveRecipientFallsBackToFormattedPhone(t *testing.T) {
@@ -321,6 +340,12 @@ func TestSendTextCommandExposesEphemeralFlag(t *testing.T) {
 	if cmd.Flags().Lookup("ephemeral") == nil {
 		t.Fatalf("missing --ephemeral flag")
 	}
+	if cmd.Flags().Lookup("ephemeral-duration") == nil {
+		t.Fatalf("missing --ephemeral-duration flag")
+	}
+	if got := cmd.Flags().Lookup("ephemeral-duration").DefValue; got != "" {
+		t.Fatalf("ephemeral-duration default = %q, want empty", got)
+	}
 }
 
 func TestSendTextCommandExposesMentionFlag(t *testing.T) {
@@ -391,7 +416,7 @@ func TestSendTextMessageKeepsPlainTextFastPathWithoutEphemeral(t *testing.T) {
 	chat := types.JID{User: "15551234567", Server: types.DefaultUserServer}
 	sender := &recordingTextSender{}
 
-	id, err := sendTextMessageWithSender(context.Background(), sender, db, chat, "hello", "", "", nil, nil, false)
+	id, err := sendTextMessageWithSender(context.Background(), sender, db, chat, "hello", "", "", nil, nil, textEphemeralOptions{})
 	if err != nil {
 		t.Fatalf("sendTextMessageWithSender: %v", err)
 	}
@@ -406,52 +431,156 @@ func TestSendTextMessageKeepsPlainTextFastPathWithoutEphemeral(t *testing.T) {
 	}
 }
 
-func TestSendTextMessageWrapsPlainTextAsEphemeralWhenRequested(t *testing.T) {
+func TestSendTextMessageUsesDefaultEphemeralExpirationForPrivateEphemeralWithoutDuration(t *testing.T) {
 	db := openSendTestDB(t)
 	chat := types.JID{User: "15551234567", Server: types.DefaultUserServer}
 	sender := &recordingTextSender{}
 
-	id, err := sendTextMessageWithSender(context.Background(), sender, db, chat, "hello", "", "", nil, nil, true)
+	_, err := sendTextMessageWithSender(context.Background(), sender, db, chat, "hello", "", "", nil, nil, textEphemeralOptions{Enabled: true})
 	if err != nil {
 		t.Fatalf("sendTextMessageWithSender: %v", err)
-	}
-	if id != "proto-id" {
-		t.Fatalf("id = %q, want proto-id", id)
 	}
 	if sender.textCalls != 0 || sender.protoCalls != 1 {
 		t.Fatalf("calls: SendText=%d SendProtoMessage=%d, want 0/1", sender.textCalls, sender.protoCalls)
 	}
-	if sender.protoRecipient != chat {
-		t.Fatalf("proto recipient = %s, want %s", sender.protoRecipient, chat)
+	ext := requireExtendedText(t, sender.protoMsg)
+	if ext.GetText() != "hello" {
+		t.Fatalf("extended text = %q, want hello", ext.GetText())
 	}
-	inner := sender.protoMsg.GetEphemeralMessage().GetMessage()
-	if inner.GetConversation() != "hello" {
-		t.Fatalf("ephemeral conversation = %q, want hello", inner.GetConversation())
+	if got := ext.GetContextInfo().GetExpiration(); got != defaultEphemeralExpiration {
+		t.Fatalf("expiration = %d, want %d", got, defaultEphemeralExpiration)
+	}
+	if sender.groupInfoCalls != 0 {
+		t.Fatalf("GetGroupInfo calls = %d, want 0", sender.groupInfoCalls)
 	}
 }
 
-func TestSendTextMessageWrapsExtendedTextAsEphemeralWhenRequested(t *testing.T) {
+func TestSendTextMessageRejectsExplicitZeroDuration(t *testing.T) {
+	db := openSendTestDB(t)
+	chat := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+	sender := &recordingTextSender{}
+
+	_, err := sendTextMessageWithSender(context.Background(), sender, db, chat, "hello", "", "", nil, nil, textEphemeralOptions{Duration: "0", DurationSet: true})
+	if err == nil || !strings.Contains(err.Error(), "positive duration") {
+		t.Fatalf("sendTextMessageWithSender error = %v", err)
+	}
+	if sender.textCalls != 0 || sender.protoCalls != 0 {
+		t.Fatalf("calls: SendText=%d SendProtoMessage=%d, want 0/0", sender.textCalls, sender.protoCalls)
+	}
+	if sender.groupInfoCalls != 0 {
+		t.Fatalf("GetGroupInfo calls = %d, want 0", sender.groupInfoCalls)
+	}
+}
+
+func TestSendTextMessageAppliesEphemeralDuration(t *testing.T) {
+	db := openSendTestDB(t)
+	chat := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+	sender := &recordingTextSender{}
+
+	_, err := sendTextMessageWithSender(context.Background(), sender, db, chat, "hello", "", "", nil, nil, textEphemeralOptions{Enabled: true, Duration: "7d"})
+	if err != nil {
+		t.Fatalf("sendTextMessageWithSender: %v", err)
+	}
+	if sender.textCalls != 0 || sender.protoCalls != 1 {
+		t.Fatalf("calls: SendText=%d SendProtoMessage=%d, want 0/1", sender.textCalls, sender.protoCalls)
+	}
+	ext := requireExtendedText(t, sender.protoMsg)
+	if ext.GetText() != "hello" {
+		t.Fatalf("extended text = %q, want hello", ext.GetText())
+	}
+	if got := ext.GetContextInfo().GetExpiration(); got != 604800 {
+		t.Fatalf("expiration = %d, want 604800", got)
+	}
+	if sender.groupInfoCalls != 0 {
+		t.Fatalf("GetGroupInfo calls = %d, want 0", sender.groupInfoCalls)
+	}
+}
+
+func TestSendTextMessagePreservesExtendedTextWithEphemeralExpiration(t *testing.T) {
 	db := openSendTestDB(t)
 	chat := types.JID{User: "15551234567", Server: types.DefaultUserServer}
 	preview := &linkpreview.Preview{URL: "https://example.com", Title: "Example"}
 	sender := &recordingTextSender{}
 
-	_, err := sendTextMessageWithSender(context.Background(), sender, db, chat, "hello https://example.com", "", "", preview, nil, true)
+	_, err := sendTextMessageWithSender(context.Background(), sender, db, chat, "hello https://example.com", "", "", preview, nil, textEphemeralOptions{Enabled: true, Duration: "7d"})
 	if err != nil {
 		t.Fatalf("sendTextMessageWithSender: %v", err)
 	}
 	if sender.textCalls != 0 || sender.protoCalls != 1 {
 		t.Fatalf("calls: SendText=%d SendProtoMessage=%d, want 0/1", sender.textCalls, sender.protoCalls)
 	}
-	ext := sender.protoMsg.GetEphemeralMessage().GetMessage().GetExtendedTextMessage()
-	if ext == nil {
-		t.Fatalf("ephemeral message did not preserve extended text")
-	}
+	ext := requireExtendedText(t, sender.protoMsg)
 	if ext.GetText() != "hello https://example.com" {
 		t.Fatalf("extended text = %q", ext.GetText())
 	}
 	if ext.GetMatchedText() != preview.URL || ext.GetTitle() != preview.Title {
 		t.Fatalf("preview fields = (%q, %q), want (%q, %q)", ext.GetMatchedText(), ext.GetTitle(), preview.URL, preview.Title)
+	}
+	if got := ext.GetContextInfo().GetExpiration(); got != 604800 {
+		t.Fatalf("expiration = %d, want 604800", got)
+	}
+	if sender.groupInfoCalls != 0 {
+		t.Fatalf("GetGroupInfo calls = %d, want 0", sender.groupInfoCalls)
+	}
+}
+
+func TestSendTextMessageUsesGroupEphemeralTimer(t *testing.T) {
+	db := openSendTestDB(t)
+	chat := types.JID{User: "12345", Server: types.GroupServer}
+	sender := &recordingTextSender{
+		groupInfo: &types.GroupInfo{
+			GroupEphemeral: types.GroupEphemeral{
+				IsEphemeral:       true,
+				DisappearingTimer: 604800,
+			},
+		},
+	}
+
+	_, err := sendTextMessageWithSender(context.Background(), sender, db, chat, "hello", "", "", nil, nil, textEphemeralOptions{Enabled: true})
+	if err != nil {
+		t.Fatalf("sendTextMessageWithSender: %v", err)
+	}
+	ext := requireExtendedText(t, sender.protoMsg)
+	if got := ext.GetContextInfo().GetExpiration(); got != 604800 {
+		t.Fatalf("expiration = %d, want 604800", got)
+	}
+	if sender.groupInfoCalls != 1 {
+		t.Fatalf("GetGroupInfo calls = %d, want 1", sender.groupInfoCalls)
+	}
+}
+
+func TestSendTextMessageUsesDefaultEphemeralExpirationWhenGroupTimerUnavailable(t *testing.T) {
+	db := openSendTestDB(t)
+	chat := types.JID{User: "12345", Server: types.GroupServer}
+	sender := &recordingTextSender{}
+
+	_, err := sendTextMessageWithSender(context.Background(), sender, db, chat, "hello", "", "", nil, nil, textEphemeralOptions{Enabled: true})
+	if err != nil {
+		t.Fatalf("sendTextMessageWithSender: %v", err)
+	}
+	if sender.textCalls != 0 || sender.protoCalls != 1 {
+		t.Fatalf("calls: SendText=%d SendProtoMessage=%d, want 0/1", sender.textCalls, sender.protoCalls)
+	}
+	ext := requireExtendedText(t, sender.protoMsg)
+	if got := ext.GetContextInfo().GetExpiration(); got != defaultEphemeralExpiration {
+		t.Fatalf("expiration = %d, want %d", got, defaultEphemeralExpiration)
+	}
+	if sender.groupInfoCalls != 1 {
+		t.Fatalf("GetGroupInfo calls = %d, want 1", sender.groupInfoCalls)
+	}
+}
+
+func TestValidateTextEphemeralOptionsRejectsInvalidDuration(t *testing.T) {
+	err := validateTextEphemeralOptions(textEphemeralOptions{Duration: "forever", DurationSet: true})
+	if err == nil || !strings.Contains(err.Error(), "--ephemeral-duration") {
+		t.Fatalf("validateTextEphemeralOptions error = %v", err)
+	}
+}
+
+func TestValidateTextEphemeralOptionsRejectsZeroDuration(t *testing.T) {
+	err := validateTextEphemeralOptions(textEphemeralOptions{Duration: "0", DurationSet: true})
+	if err == nil || !strings.Contains(err.Error(), "positive duration") {
+		t.Fatalf("validateTextEphemeralOptions error = %v", err)
 	}
 }
 

--- a/docs/send.md
+++ b/docs/send.md
@@ -9,7 +9,7 @@ When `sync --follow` is already running for the same store, send commands delega
 ## Commands
 
 ```bash
-wacli send text --to RECIPIENT --message TEXT [--message-escapes] [--pick N] [--mention USER] [--no-preview] [--ephemeral] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
+wacli send text --to RECIPIENT --message TEXT [--message-escapes] [--pick N] [--mention USER] [--no-preview] [--ephemeral] [--ephemeral-duration DURATION] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send file --to RECIPIENT --file PATH [--pick N] [--caption TEXT] [--filename NAME] [--mime TYPE] [--ptt] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send sticker --to RECIPIENT --file PATH [--pick N] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send voice --to RECIPIENT --file PATH [--pick N] [--mime TYPE] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
@@ -29,7 +29,7 @@ wacli send react --to PHONE_OR_JID --id MSG_ID [--reaction TEXT] [--sender JID] 
 - `send text` fetches Open Graph metadata for the first `http://` or `https://` URL and sends it as a WhatsApp link preview.
 - Preview metadata fetches time out after 10 seconds and fall back to plain text.
 - Pass `--no-preview` to disable link-preview fetching.
-- Pass `--ephemeral` to wrap outgoing text in `EphemeralMessage` for disappearing-message chats.
+- `--ephemeral` sends text with `ContextInfo.Expiration`, matching the disappearing-send path. For groups, wacli uses the live group timer when available; otherwise it falls back to a 7-day default. Set `--ephemeral-duration` to choose an explicit expiration.
 - `--message` is literal by default. Pass `--message-escapes` to interpret `\n`, `\r`, `\t`, `\\`, and `\"` before sending.
 - Use repeatable `--mention USER` with a phone number or user JID to add WhatsApp mentions to `send text`.
 - `--reply-to` quotes a stored message ID.
@@ -58,6 +58,8 @@ wacli send react --to PHONE_OR_JID --id MSG_ID [--reaction TEXT] [--sender JID] 
 ```bash
 wacli send text --to mom --message "landed"
 wacli send text --to mom --message "auto delete this" --ephemeral
+wacli send text --to mom --message "auto delete this in 7 days" --ephemeral-duration 7d
+wacli send text --to "Family" --message "auto delete this" --ephemeral
 wacli send text --to mom --message "line1\nline2" --message-escapes
 wacli send text --to "Family" --pick 2 --message "on my way"
 wacli send text --to "Family" --message "hey @15551234567" --mention +15551234567


### PR DESCRIPTION
## Summary
- add disappearing-message context metadata when `send text --ephemeral` is used
- send plain ephemeral text as extended text so the context can be attached
- cover both plain and link-preview ephemeral text in tests
- update send docs to mention the extra disappearing context

## Test Plan
- `gofmt -l .`
- `go vet ./...`
- `go test ./...`
- `go test -tags sqlite_fts5 ./...`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/lock -o /tmp/wacli-lock-windows.test.exe`
- `CGO_ENABLED=0 go build ./cmd/wacli` fails with the expected CGO-required sentinel
- `CGO_ENABLED=1 CGO_CFLAGS="-Wno-error=missing-braces" go build -tags sqlite_fts5 -o dist/wacli ./cmd/wacli`
- `git diff --check`
