### PR TITLE
Fix send target canonicalization for phone-number recipients

### DIFF
--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -105,7 +105,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 			if err := a.Connect(ctx, false, nil); err != nil {
 				return err
 			}
-			warmupRecipient(ctx, a.WA(), toJID, os.Stderr)
+			toJID = warmupRecipient(ctx, a.WA(), toJID, os.Stderr)
 			if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
 				return err
 			}

--- a/cmd/wacli/send_helpers.go
+++ b/cmd/wacli/send_helpers.go
@@ -131,10 +131,10 @@ func warnRapidSendIfNeeded(storeDir string, now time.Time, stderr io.Writer) err
 	return nil
 }
 
-// warmupRecipient resolves the recipient's user info before sending to
-// establish contact state with WhatsApp's servers. Without this, the
-// privacy token (tctoken) IQ may fail with 400: bad-request for new or
-// unknown contacts, causing messages to be silently dropped despite
+// warmupRecipient canonicalizes direct phone-number recipients and resolves
+// user info before sending to establish contact state with WhatsApp's servers.
+// Without this, the privacy token (tctoken) IQ may fail with 400: bad-request
+// for new or unknown contacts, causing messages to be silently dropped despite
 // returning sent:true.
 //
 // The warmup is best-effort: failures are logged to stderr but never
@@ -145,12 +145,28 @@ type userInfoResolver interface {
 	GetUserInfo(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error)
 }
 
-func warmupRecipient(ctx context.Context, wa userInfoResolver, jid types.JID, stderr io.Writer) {
+type whatsappRegistrationResolver interface {
+	IsOnWhatsApp(ctx context.Context, phones []string) ([]types.IsOnWhatsAppResponse, error)
+}
+
+func warmupRecipient(ctx context.Context, wa userInfoResolver, jid types.JID, stderr io.Writer) types.JID {
 	if jid.Server != types.DefaultUserServer && jid.Server != types.HiddenUserServer {
-		return
+		return jid
+	}
+	if jid.Server == types.DefaultUserServer {
+		if resolver, ok := any(wa).(whatsappRegistrationResolver); ok {
+			registrations, regErr := resolver.IsOnWhatsApp(ctx, []string{"+" + jid.User})
+			if regErr != nil {
+				fmt.Fprintf(stderr, "warn: send registration warmup for %s failed (send will proceed): %v\n", jid, regErr)
+			} else if len(registrations) > 0 && registrations[0].IsIn && !registrations[0].JID.IsEmpty() {
+				jid = registrations[0].JID.ToNonAD()
+			}
+		}
 	}
 	_, err := wa.GetUserInfo(ctx, []types.JID{jid})
 	if err != nil {
 		fmt.Fprintf(stderr, "warn: send warmup for %s failed (send will proceed): %v\n", jid, err)
+		return jid
 	}
+	return jid
 }

--- a/cmd/wacli/send_helpers_test.go
+++ b/cmd/wacli/send_helpers_test.go
@@ -160,7 +160,8 @@ func TestWarnRapidSendIfNeededSkipsOldOrInvalidMarker(t *testing.T) {
 }
 
 type mockUserInfoClient struct {
-	getUserInfo func(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error)
+	getUserInfo  func(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error)
+	isOnWhatsApp func(ctx context.Context, phones []string) ([]types.IsOnWhatsAppResponse, error)
 }
 
 func (m *mockUserInfoClient) GetUserInfo(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error) {
@@ -168,6 +169,13 @@ func (m *mockUserInfoClient) GetUserInfo(ctx context.Context, jids []types.JID) 
 		return nil, nil
 	}
 	return m.getUserInfo(ctx, jids)
+}
+
+func (m *mockUserInfoClient) IsOnWhatsApp(ctx context.Context, phones []string) ([]types.IsOnWhatsAppResponse, error) {
+	if m.isOnWhatsApp == nil {
+		return nil, nil
+	}
+	return m.isOnWhatsApp(ctx, phones)
 }
 
 func TestWarmupRecipientSkipNonUserServer(t *testing.T) {
@@ -210,6 +218,37 @@ func TestWarmupRecipientCallsGetUserInfoForUserServer(t *testing.T) {
 	warmupRecipient(context.Background(), mock, userJID, &stderr)
 	if !called {
 		t.Fatal("GetUserInfo should be called for user JIDs")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func TestWarmupRecipientCanonicalizesRegisteredPhone(t *testing.T) {
+	canonical := types.NewJID("15551234567", types.DefaultUserServer)
+	mock := &mockUserInfoClient{
+		isOnWhatsApp: func(ctx context.Context, phones []string) ([]types.IsOnWhatsAppResponse, error) {
+			if len(phones) != 1 || phones[0] != "+15559991234567" {
+				t.Fatalf("unexpected phone query: %v", phones)
+			}
+			return []types.IsOnWhatsAppResponse{{
+				JID:  canonical,
+				IsIn: true,
+			}}, nil
+		},
+		getUserInfo: func(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error) {
+			if len(jids) != 1 || jids[0] != canonical {
+				t.Fatalf("expected canonical JID %s, got %v", canonical, jids)
+			}
+			return nil, nil
+		},
+	}
+
+	var stderr bytes.Buffer
+	input := types.NewJID("15559991234567", types.DefaultUserServer)
+	got := warmupRecipient(context.Background(), mock, input, &stderr)
+	if got != canonical {
+		t.Fatalf("warmupRecipient returned %s, want %s", got, canonical)
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("unexpected stderr: %q", stderr.String())

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -439,6 +439,16 @@ func (c *Client) GetUserInfo(ctx context.Context, jids []types.JID) (map[types.J
 	return cli.GetUserInfo(ctx, jids)
 }
 
+func (c *Client) IsOnWhatsApp(ctx context.Context, phones []string) ([]types.IsOnWhatsAppResponse, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return nil, fmt.Errorf("not connected")
+	}
+	return cli.IsOnWhatsApp(ctx, phones)
+}
+
 func (c *Client) GetContact(ctx context.Context, jid types.JID) (types.ContactInfo, error) {
 	c.mu.Lock()
 	cli := c.client


### PR DESCRIPTION
## Summary
- canonicalize direct phone-number send targets through WhatsApp registration lookup before sending
- keep the existing GetUserInfo warmup, but run it against the canonical JID returned by IsOnWhatsApp
- add coverage for BR-style phone input where the raw phone JID differs from the canonical WhatsApp JID

## Problem
In #212, direct sends could return `sent:true` while logging:

```
Failed to issue privacy token ... 400: bad-request
```

In my repro, this happened for Brazilian mobile numbers where the input had the extra ninth digit. For example, the raw input shape `+55XX9XXXXXXXX` was sent as `55XX9XXXXXXXX@s.whatsapp.net`, but WhatsApp registration lookup canonicalized it to `55XXXXXXXXXX@s.whatsapp.net`.

Sending to the raw JID meant `GetUserInfo` returned no useful LID/device state, the trusted-contact token request failed, and the message was not visible/delivered despite stdout reporting success.

## Fix
The send warmup now:
1. detects direct PN recipients
2. calls `IsOnWhatsApp("+" + jid.User)`
3. replaces the destination with the returned canonical JID when the number is registered
4. runs `GetUserInfo` against that canonical JID before sending

## Validation
- `go test ./...`
- local live retest against the previously failing direct BR recipients: sends used canonical JIDs and no longer emitted the privacy-token 400

Fixes #212

## Human note

I don't know golang, I asked my claw to try fix it and it did, then I asked to open a PR and it probably has slop. Feel free to close but you can use it as a reference to actually fix the problem.