### PR TITLE
Persist WhatsApp call events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.9.1 - Unreleased
 
+### Added
+
+- Calls: persist WhatsApp call signaling and call-log metadata, and add `wacli calls list`.
+
 ## 0.9.0 - 2026-05-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ More recipes — replies, mentions, stickers, voice, reactions, channels, histor
 | Area | Pages |
 | --- | --- |
 | **Setup** | [overview](docs/overview.md) · [auth](docs/auth.md) · [accounts](docs/accounts.md) · [sync](docs/sync.md) · [doctor](docs/doctor.md) |
-| **Messaging** | [messages](docs/messages.md) · [send](docs/send.md) · [media](docs/media.md) · [presence](docs/presence.md) |
+| **Messaging** | [messages](docs/messages.md) · [calls](docs/calls.md) · [send](docs/send.md) · [media](docs/media.md) · [presence](docs/presence.md) |
 | **Address book** | [contacts](docs/contacts.md) · [chats](docs/chats.md) · [groups](docs/groups.md) · [channels](docs/channels.md) |
 | **History** | [history coverage / fill / backfill](docs/history.md) |
 | **Local store** | [store](docs/store.md) · [companion integrations](docs/integrations.md) |

--- a/cmd/wacli/calls.go
+++ b/cmd/wacli/calls.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/openclaw/wacli/internal/out"
+	"github.com/openclaw/wacli/internal/store"
+	"github.com/spf13/cobra"
+)
+
+func newCallsCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "calls",
+		Short: "List WhatsApp call events from the local DB",
+	}
+	cmd.AddCommand(newCallsListCmd(flags))
+	return cmd
+}
+
+func newCallsListCmd(flags *rootFlags) *cobra.Command {
+	var chat string
+	var limit int
+	var afterStr string
+	var beforeStr string
+	var asc bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List call events",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, false, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			var after *time.Time
+			var before *time.Time
+			if afterStr != "" {
+				t, err := parseTime(afterStr)
+				if err != nil {
+					return err
+				}
+				after = &t
+			}
+			if beforeStr != "" {
+				t, err := parseTime(beforeStr)
+				if err != nil {
+					return err
+				}
+				before = &t
+			}
+
+			chatJIDs, err := messageChatJIDFilter(ctx, a, chat)
+			if err != nil {
+				return err
+			}
+			calls, err := a.DB().ListCallEvents(store.ListCallEventsParams{
+				ChatJIDs: chatJIDs,
+				Limit:    limit,
+				After:    after,
+				Before:   before,
+				Asc:      asc,
+			})
+			if err != nil {
+				return err
+			}
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{"calls": calls})
+			}
+			return writeCallsList(os.Stdout, calls, fullTableOutput(flags.fullOutput))
+		},
+	}
+
+	cmd.Flags().StringVar(&chat, "chat", "", "filter by chat JID")
+	cmd.Flags().IntVar(&limit, "limit", 50, "max number of call events to return")
+	cmd.Flags().StringVar(&afterStr, "after", "", "only call events after time (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&beforeStr, "before", "", "only call events before time (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().BoolVar(&asc, "asc", false, "show oldest call events first (default: newest first)")
+	return cmd
+}
+
+func writeCallsList(dst io.Writer, calls []store.CallEvent, fullOutput bool) error {
+	w := newTableWriter(dst)
+	fmt.Fprintln(w, "TIME\tCHAT\tDIR\tMEDIA\tEVENT\tOUTCOME\tCALL ID")
+	for _, c := range calls {
+		chatLabel := c.ChatName
+		if chatLabel == "" {
+			chatLabel = c.ChatJID
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			c.Timestamp.Local().Format("2006-01-02 15:04:05"),
+			tableCell(chatLabel, 24, fullOutput),
+			tableCell(emptyUnknown(c.Direction), 8, fullOutput),
+			tableCell(emptyUnknown(c.Media), 8, fullOutput),
+			tableCell(c.EventType, 14, fullOutput),
+			tableCell(callOutcomeLabel(c), 18, fullOutput),
+			tableCell(c.CallID, 18, fullOutput),
+		)
+	}
+	return w.Flush()
+}
+
+func callOutcomeLabel(c store.CallEvent) string {
+	if c.Outcome != "" {
+		if c.DurationSecs > 0 {
+			return c.Outcome + " " + formatCallListDuration(c.DurationSecs)
+		}
+		return c.Outcome
+	}
+	if c.Reason != "" {
+		return c.Reason
+	}
+	return ""
+}
+
+func formatCallListDuration(seconds int64) string {
+	if seconds <= 0 {
+		return ""
+	}
+	minutes := seconds / 60
+	secs := seconds % 60
+	if minutes == 0 {
+		return fmt.Sprintf("(%ds)", secs)
+	}
+	if secs == 0 {
+		return fmt.Sprintf("(%dm)", minutes)
+	}
+	return fmt.Sprintf("(%dm%02ds)", minutes, secs)
+}
+
+func emptyUnknown(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "unknown"
+	}
+	return s
+}

--- a/cmd/wacli/messages_test.go
+++ b/cmd/wacli/messages_test.go
@@ -133,6 +133,40 @@ func TestWriteMessagesListFullOutput(t *testing.T) {
 	}
 }
 
+func TestWriteCallsList(t *testing.T) {
+	call := store.CallEvent{
+		ChatJID:      "chat@s.whatsapp.net",
+		ChatName:     "Alice",
+		CallID:       "call-1234567890",
+		EventType:    "call_log",
+		Direction:    "outbound",
+		Media:        "audio",
+		Outcome:      "connected",
+		DurationSecs: 61,
+		Timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+	}
+
+	var out bytes.Buffer
+	if err := writeCallsList(&out, []store.CallEvent{call}, true); err != nil {
+		t.Fatalf("writeCallsList: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"Alice", "outbound", "audio", "call_log", "connected (1m01s)", "call-1234567890"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestCallsListCommandHasExpectedFlags(t *testing.T) {
+	cmd := newCallsListCmd(&rootFlags{})
+	for _, name := range []string{"chat", "limit", "after", "before", "asc"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Fatalf("expected --%s flag", name)
+		}
+	}
+}
+
 func TestWriteMessageShowPrefersDisplayTextAndMediaDetails(t *testing.T) {
 	msg := store.Message{
 		ChatJID:      "chat@s.whatsapp.net",

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -59,6 +59,7 @@ func execute(args []string) error {
 	rootCmd.AddCommand(newAuthCmd(&flags))
 	rootCmd.AddCommand(newSyncCmd(&flags))
 	rootCmd.AddCommand(newMessagesCmd(&flags))
+	rootCmd.AddCommand(newCallsCmd(&flags))
 	rootCmd.AddCommand(newSendCmd(&flags))
 	rootCmd.AddCommand(newPollCmd(&flags))
 	rootCmd.AddCommand(newPollsCmd(&flags))

--- a/docs/calls.md
+++ b/docs/calls.md
@@ -1,0 +1,26 @@
+# calls
+
+Read when: listing WhatsApp call events captured by sync.
+
+`wacli calls` reads call metadata from the local store. It does not place, accept, or reject calls.
+
+## Commands
+
+```bash
+wacli calls list [--chat JID] [--asc] [--limit N] [--after DATE] [--before DATE]
+```
+
+## Data Model
+
+- Live WhatsApp call signaling events are stored separately from normal messages.
+- Historical WhatsApp call-log messages are stored as normal message rows and as structured `call_events` rows.
+- JSON output includes `chat_jid`, `call_id`, `event_type`, `direction`, `media`, `outcome`, `duration_secs`, `timestamp`, and participant metadata when WhatsApp provides it.
+- Time filters accept RFC3339 or `YYYY-MM-DD`.
+
+## Examples
+
+```bash
+wacli calls list --limit 20
+wacli calls list --chat 1234567890@s.whatsapp.net --json
+wacli calls list --after 2026-05-01 --asc
+```

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -6,7 +6,7 @@ Read when: building a local analytics, search, CRM, or agent-side companion tool
 
 ## Integration surfaces
 
-- Use `--json` for one-shot command output from `chats`, `contacts`, `groups`, `messages`, and `doctor`.
+- Use `--json` for one-shot command output from `chats`, `contacts`, `groups`, `messages`, `calls`, and `doctor`.
 - Use `--events` for line-delimited lifecycle events from long-running `auth`, `sync`, and `history backfill` commands.
 - Use `sync --webhook` for live-message delivery to another process or service.
 - Use a read-only SQLite connection to `<store>/wacli.db` for local analytics that need joins, cursors, or incremental scans.
@@ -25,7 +25,7 @@ Override with `--store DIR` or `WACLI_STORE_DIR`. Named accounts live in `config
 The store contains two SQLite databases:
 
 - `session.db`: owned by `whatsmeow`; contains linked-device identity and keys.
-- `wacli.db`: owned by `wacli`; contains chats, contacts, groups, messages, media metadata, and local state.
+- `wacli.db`: owned by `wacli`; contains chats, contacts, groups, messages, call events, media metadata, and local state.
 
 Companion tools should not read or write `session.db` unless they are explicitly working on WhatsApp session internals. Never write to `wacli.db` from a companion tool.
 
@@ -94,6 +94,15 @@ FROM messages
 WHERE rowid > ?
 ORDER BY rowid ASC
 LIMIT 1000;
+```
+
+Recent WhatsApp call events:
+
+```sql
+SELECT chat_jid, call_id, event_type, direction, media, outcome, duration_secs, ts
+FROM call_events
+ORDER BY ts DESC
+LIMIT 100;
 ```
 
 Known chats by newest activity:

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -25,6 +25,7 @@ Read when: you need the user-facing command map, global flags, store model, or l
 - [accounts](accounts.md) - create and select named account stores.
 - [sync](sync.md) - sync messages, contacts, groups, channels, and optional media.
 - [messages](messages.md) - list, search, show, and contextualize stored messages.
+- [calls](calls.md) - list stored WhatsApp call events.
 - [send](send.md) - send text, files, stickers, replies, and reactions.
 - [media](media.md) - download media attached to stored messages.
 - [contacts](contacts.md) - search contacts and manage local aliases/tags.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -30,6 +30,7 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--max-mes
 - While `sync --follow` is running, `send text`, `send file`, `send sticker`, `send voice`, and `send react` commands for the same store are delegated to the running sync process so they do not fail on the store lock.
 - After connecting, sync fetches WhatsApp chat app-state deltas (`regular_high` and `regular_low`) so starred, delete-for-me, mute, archive, pin, and mark-read changes made while `wacli` was offline are caught up instead of relying only on live push notifications.
 - If whatsmeow reports an app-state LTHash mismatch, sync asks the primary device for the official recovery snapshot once for that app-state collection. If recovery also fails, the warning is printed and sync keeps handling normal message/history events.
+- Sync stores WhatsApp call signaling and call-log metadata in `call_events`; inspect it with `wacli calls list`.
 - In an interactive terminal, routine connected/history/progress updates share one updating stderr status line. Warnings and errors still print as separate lines so they remain visible.
 - `--events` emits one NDJSON lifecycle event per stderr line for machine consumers. Routine human progress/status lines, interrupt prompts, and command errors are emitted as events while events are enabled.
 

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -413,6 +413,18 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 	}); err != nil {
 		return err
 	}
+	if pm.Call != nil {
+		pm.Call.Chat = pm.Chat
+		if pm.Call.SenderJID == "" {
+			pm.Call.SenderJID = senderJID
+		}
+		if pm.Call.Timestamp.IsZero() {
+			pm.Call.Timestamp = pm.Timestamp
+		}
+		if err := a.storeParsedCallEvent(ctx, *pm.Call, chatName, senderName); err != nil {
+			return err
+		}
+	}
 	if pm.StarredKnown {
 		return a.db.SetStarred(store.SetStarredParams{
 			ChatJID:   chatJID,
@@ -424,6 +436,68 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 		})
 	}
 	return nil
+}
+
+func (a *App) storeParsedCallEvent(ctx context.Context, call wa.ParsedCallEvent, chatName, senderName string) error {
+	call.Chat = a.canonicalStoreJID(ctx, call.Chat)
+	chatJID := canonicalJIDString(call.Chat)
+	if chatJID == "" {
+		return fmt.Errorf("call chat JID is required")
+	}
+	if chatName == "" {
+		chatName = a.wa.ResolveChatName(ctx, call.Chat, "")
+	}
+	if err := a.db.UpsertChat(chatJID, chatKind(call.Chat), chatName, call.Timestamp); err != nil {
+		return err
+	}
+
+	senderJID := strings.TrimSpace(call.SenderJID)
+	if senderJID != "" {
+		if jid, err := types.ParseJID(senderJID); err == nil {
+			contactJID := a.canonicalStoreJID(ctx, jid)
+			senderJID = contactJID.String()
+			if senderName == "" {
+				if info, err := a.wa.GetContact(ctx, contactJID); err == nil {
+					senderName = wa.BestContactName(info)
+				}
+			}
+		}
+	}
+
+	participants := make([]store.CallParticipant, 0, len(call.Participants))
+	for _, p := range call.Participants {
+		jid := strings.TrimSpace(p.JID)
+		if jid != "" {
+			if parsed, err := types.ParseJID(jid); err == nil {
+				jid = canonicalJIDString(a.canonicalStoreJID(ctx, parsed))
+			}
+		}
+		if jid == "" {
+			continue
+		}
+		participants = append(participants, store.CallParticipant{
+			JID:     jid,
+			Outcome: p.Outcome,
+		})
+	}
+
+	return a.db.UpsertCallEvent(store.UpsertCallEventParams{
+		ChatJID:      chatJID,
+		ChatName:     chatName,
+		SenderJID:    senderJID,
+		SenderName:   senderName,
+		CallID:       call.CallID,
+		MsgID:        call.MsgID,
+		EventType:    call.EventType,
+		Direction:    call.Direction,
+		Media:        call.Media,
+		Outcome:      call.Outcome,
+		Reason:       call.Reason,
+		CallType:     call.CallType,
+		DurationSecs: call.DurationSecs,
+		Timestamp:    call.Timestamp,
+		Participants: participants,
+	})
 }
 
 func waButtonsToStore(buttons []wa.Button) []store.Button {
@@ -484,6 +558,9 @@ func (a *App) buildDisplayText(ctx context.Context, pm wa.ParsedMessage) string 
 }
 
 func baseDisplayText(pm wa.ParsedMessage) string {
+	if pm.Call != nil {
+		return callDisplayText(*pm.Call)
+	}
 	if pm.Media != nil {
 		return "Sent " + mediaLabel(pm.Media.Type)
 	}
@@ -491,6 +568,38 @@ func baseDisplayText(pm wa.ParsedMessage) string {
 		return text
 	}
 	return ""
+}
+
+func callDisplayText(call wa.ParsedCallEvent) string {
+	parts := []string{"WhatsApp"}
+	if call.Media != "" {
+		parts = append(parts, call.Media)
+	}
+	parts = append(parts, "call")
+	if call.Outcome != "" {
+		parts = append(parts, call.Outcome)
+	} else if call.EventType != "" && call.EventType != "call_log" {
+		parts = append(parts, call.EventType)
+	}
+	if call.DurationSecs > 0 {
+		parts = append(parts, fmt.Sprintf("(%s)", formatCallDuration(call.DurationSecs)))
+	}
+	return strings.Join(parts, " ")
+}
+
+func formatCallDuration(seconds int64) string {
+	if seconds <= 0 {
+		return ""
+	}
+	minutes := seconds / 60
+	secs := seconds % 60
+	if minutes <= 0 {
+		return fmt.Sprintf("%ds", secs)
+	}
+	if secs == 0 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+	return fmt.Sprintf("%dm%02ds", minutes, secs)
 }
 
 func (a *App) lookupMessageDisplayText(chatJID, msgID string) string {

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -500,6 +500,19 @@ func (a *App) storeParsedCallEvent(ctx context.Context, call wa.ParsedCallEvent,
 	})
 }
 
+func (a *App) deleteParsedCallEvents(ctx context.Context, deleted wa.ParsedCallDelete) error {
+	chat := a.canonicalStoreJID(ctx, deleted.Chat)
+	chatJID := canonicalJIDString(chat)
+	if chatJID == "" {
+		return fmt.Errorf("call chat JID is required")
+	}
+	_, err := a.db.DeleteCallEvents(store.DeleteCallEventsParams{
+		ChatJID:   chatJID,
+		Direction: deleted.Direction,
+	})
+	return err
+}
+
 func waButtonsToStore(buttons []wa.Button) []store.Button {
 	if len(buttons) == 0 {
 		return nil

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -136,14 +136,26 @@ func (a *App) handleLiveCallEvent(ctx context.Context, evt interface{}) {
 		}
 	}
 	call, ok := wa.ParseLiveCallEvent(evt, self)
+	if ok {
+		if err := a.storeParsedCallEvent(ctx, call, "", ""); err != nil {
+			a.emitWarning(
+				"call_event_store_failed",
+				fmt.Sprintf("warning: failed to store call event %s: %v", call.EventType, err),
+				map[string]any{"event_type": call.EventType, "call_id": call.CallID, "error": err.Error()},
+			)
+		}
+		return
+	}
+
+	deleted, ok := wa.ParseCallLogDeleteEvent(evt)
 	if !ok {
 		return
 	}
-	if err := a.storeParsedCallEvent(ctx, call, "", ""); err != nil {
+	if err := a.deleteParsedCallEvents(ctx, deleted); err != nil {
 		a.emitWarning(
-			"call_event_store_failed",
-			fmt.Sprintf("warning: failed to store call event %s: %v", call.EventType, err),
-			map[string]any{"event_type": call.EventType, "call_id": call.CallID, "error": err.Error()},
+			"call_event_delete_failed",
+			fmt.Sprintf("warning: failed to delete call log events: %v", err),
+			map[string]any{"chat_jid": deleted.Chat.String(), "direction": deleted.Direction, "error": err.Error()},
 		)
 	}
 }

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -64,6 +64,11 @@ func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, message
 				return
 			}
 			a.handleLiveSyncMessage(ctx, opts, v, messagesStored, enqueueMedia, enqueueWebhook, limits)
+		case *events.CallOffer, *events.CallAccept, *events.CallPreAccept, *events.CallTransport,
+			*events.CallOfferNotice, *events.CallRelayLatency, *events.CallTerminate, *events.CallReject,
+			*events.AppState:
+			lastEvent.Store(nowUTC().UnixNano())
+			a.handleLiveCallEvent(ctx, v)
 		case *events.HistorySync:
 			lastEvent.Store(nowUTC().UnixNano())
 			a.handleHistorySync(ctx, opts, v, messagesStored, lastEvent, enqueueMedia, limits)
@@ -119,6 +124,26 @@ func (a *App) handleDeleteForMeEvent(ctx context.Context, evt *events.DeleteForM
 			"delete_for_me_store_failed",
 			fmt.Sprintf("warning: failed to store delete-for-me state for message %s: %v", evt.MessageID, err),
 			map[string]any{"message_id": evt.MessageID, "error": err.Error()},
+		)
+	}
+}
+
+func (a *App) handleLiveCallEvent(ctx context.Context, evt interface{}) {
+	self := types.JID{}
+	if linked := strings.TrimSpace(a.wa.LinkedJID()); linked != "" {
+		if jid, err := types.ParseJID(linked); err == nil {
+			self = jid
+		}
+	}
+	call, ok := wa.ParseLiveCallEvent(evt, self)
+	if !ok {
+		return
+	}
+	if err := a.storeParsedCallEvent(ctx, call, "", ""); err != nil {
+		a.emitWarning(
+			"call_event_store_failed",
+			fmt.Sprintf("warning: failed to store call event %s: %v", call.EventType, err),
+			map[string]any{"event_type": call.EventType, "call_id": call.CallID, "error": err.Error()},
 		)
 	}
 }

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -152,6 +152,44 @@ func TestLiveSyncStoresCallLogMessageAndCallEvent(t *testing.T) {
 	}
 }
 
+func TestAppStateCallLogDeleteRemovesStoredCallEvent(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.NewJID("15551234567", types.DefaultUserServer)
+	when := time.Date(2024, 1, 3, 12, 0, 0, 0, time.UTC)
+	if err := a.db.UpsertChat(chat.String(), "dm", "Alice", when); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := a.db.UpsertCallEvent(store.UpsertCallEventParams{
+		ChatJID:   chat.String(),
+		CallID:    "call-log-1",
+		EventType: "call_log",
+		Direction: "outbound",
+		Timestamp: when,
+	}); err != nil {
+		t.Fatalf("UpsertCallEvent: %v", err)
+	}
+
+	a.handleLiveCallEvent(context.Background(), &events.AppState{
+		SyncActionValue: &waSyncAction.SyncActionValue{
+			DeleteIndividualCallLog: &waSyncAction.DeleteIndividualCallLogAction{
+				PeerJID:    proto.String(chat.String()),
+				IsIncoming: proto.Bool(false),
+			},
+		},
+	})
+
+	calls, err := a.db.ListCallEvents(store.ListCallEventsParams{ChatJID: chat.String(), Limit: 10})
+	if err != nil {
+		t.Fatalf("ListCallEvents: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("calls len = %d, want 0: %+v", len(calls), calls)
+	}
+}
+
 func TestAppStateLTHashMismatchRequestsRecoveryOnce(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openclaw/wacli/internal/store"
 	"github.com/openclaw/wacli/internal/wa"
 	"go.mau.fi/whatsmeow/appstate"
+	waBinary "go.mau.fi/whatsmeow/binary"
 	waProto "go.mau.fi/whatsmeow/binary/proto"
 	"go.mau.fi/whatsmeow/proto/waCommon"
 	"go.mau.fi/whatsmeow/proto/waE2E"
@@ -67,6 +68,87 @@ func TestLiveSyncWarnsOnEncryptedReactionDecryptFailure(t *testing.T) {
 	}
 	if msg.DisplayText != "Reacted to message" {
 		t.Fatalf("expected fallback reaction display text, got %q", msg.DisplayText)
+	}
+}
+
+func TestLiveCallOfferStoresCallEvent(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	remote := types.NewJID("15551234567", types.DefaultUserServer)
+	when := time.Date(2024, 1, 3, 12, 0, 0, 0, time.UTC)
+	a.handleLiveCallEvent(context.Background(), &events.CallOffer{
+		BasicCallMeta: types.BasicCallMeta{
+			From:        remote,
+			CallCreator: remote,
+			CallID:      "call-live-1",
+			Timestamp:   when,
+		},
+		Data: &waBinary.Node{Attrs: waBinary.Attrs{"media": "video"}},
+	})
+
+	calls, err := a.db.ListCallEvents(store.ListCallEventsParams{ChatJID: remote.String(), Limit: 10})
+	if err != nil {
+		t.Fatalf("ListCallEvents: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("calls len = %d, want 1", len(calls))
+	}
+	got := calls[0]
+	if got.CallID != "call-live-1" || got.EventType != "offer" || got.Direction != "inbound" || got.Media != "video" {
+		t.Fatalf("unexpected call event: %+v", got)
+	}
+}
+
+func TestLiveSyncStoresCallLogMessageAndCallEvent(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.NewJID("15551234567", types.DefaultUserServer)
+	outcome := waProto.CallLogMessage_CONNECTED
+	callType := waProto.CallLogMessage_REGULAR
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     chat,
+				Sender:   chat,
+				IsFromMe: true,
+			},
+			ID:        "call-msg-1",
+			Timestamp: time.Date(2024, 1, 3, 12, 0, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{
+			CallLogMesssage: &waProto.CallLogMessage{
+				IsVideo:      proto.Bool(false),
+				CallOutcome:  &outcome,
+				DurationSecs: proto.Int64(61),
+				CallType:     &callType,
+			},
+		},
+	}
+
+	var messagesStored atomic.Int64
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, evt, &messagesStored, func(string, string) {}, nil)
+
+	msg, err := a.db.GetMessage(chat.String(), "call-msg-1")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if msg.DisplayText != "WhatsApp audio call connected (1m01s)" {
+		t.Fatalf("display text = %q", msg.DisplayText)
+	}
+	calls, err := a.db.ListCallEvents(store.ListCallEventsParams{ChatJID: chat.String(), Limit: 10})
+	if err != nil {
+		t.Fatalf("ListCallEvents: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("calls len = %d, want 1", len(calls))
+	}
+	got := calls[0]
+	if got.CallID != "call-msg-1" || got.MsgID != "call-msg-1" || got.EventType != "call_log" || got.Direction != "outbound" || got.Outcome != "connected" {
+		t.Fatalf("unexpected call log event: %+v", got)
 	}
 }
 

--- a/internal/store/calls.go
+++ b/internal/store/calls.go
@@ -85,6 +85,29 @@ type ListCallEventsParams struct {
 	Asc      bool
 }
 
+type DeleteCallEventsParams struct {
+	ChatJID   string
+	Direction string
+}
+
+func (d *DB) DeleteCallEvents(p DeleteCallEventsParams) (int64, error) {
+	chatJID := strings.TrimSpace(p.ChatJID)
+	if chatJID == "" {
+		return 0, fmt.Errorf("chat JID is required")
+	}
+	query := "DELETE FROM call_events WHERE chat_jid = ? AND event_type = 'call_log'"
+	args := []interface{}{chatJID}
+	if direction := strings.TrimSpace(p.Direction); direction != "" {
+		query += " AND direction = ?"
+		args = append(args, direction)
+	}
+	res, err := d.sql.Exec(query, args...)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 func (d *DB) ListCallEvents(p ListCallEventsParams) ([]CallEvent, error) {
 	if p.Limit <= 0 {
 		p.Limit = 50

--- a/internal/store/calls.go
+++ b/internal/store/calls.go
@@ -1,0 +1,139 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type UpsertCallEventParams struct {
+	ChatJID      string
+	ChatName     string
+	SenderJID    string
+	SenderName   string
+	CallID       string
+	MsgID        string
+	EventType    string
+	Direction    string
+	Media        string
+	Outcome      string
+	Reason       string
+	CallType     string
+	DurationSecs int64
+	Timestamp    time.Time
+	Participants []CallParticipant
+}
+
+func (d *DB) UpsertCallEvent(p UpsertCallEventParams) error {
+	chatJID := strings.TrimSpace(p.ChatJID)
+	eventType := strings.TrimSpace(p.EventType)
+	if chatJID == "" {
+		return fmt.Errorf("chat JID is required")
+	}
+	if eventType == "" {
+		return fmt.Errorf("call event type is required")
+	}
+	ts := unix(p.Timestamp)
+	if ts <= 0 {
+		ts = nowUTC().Unix()
+	}
+	callID := strings.TrimSpace(p.CallID)
+	if callID == "" {
+		callID = fmt.Sprintf("%s:%d", eventType, ts)
+	}
+	if p.DurationSecs < 0 {
+		p.DurationSecs = 0
+	}
+
+	var participantsJSON interface{}
+	if len(p.Participants) > 0 {
+		if b, err := json.Marshal(p.Participants); err == nil {
+			participantsJSON = string(b)
+		}
+	}
+
+	_, err := d.sql.Exec(`
+		INSERT INTO call_events(
+			chat_jid, chat_name, sender_jid, sender_name, call_id, msg_id, event_type,
+			direction, media, outcome, reason, call_type, duration_secs, ts, participants
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(chat_jid, call_id, event_type, ts) DO UPDATE SET
+			chat_name=COALESCE(NULLIF(excluded.chat_name,''), call_events.chat_name),
+			sender_jid=COALESCE(NULLIF(excluded.sender_jid,''), call_events.sender_jid),
+			sender_name=COALESCE(NULLIF(excluded.sender_name,''), call_events.sender_name),
+			msg_id=COALESCE(NULLIF(excluded.msg_id,''), call_events.msg_id),
+			direction=COALESCE(NULLIF(excluded.direction,''), call_events.direction),
+			media=COALESCE(NULLIF(excluded.media,''), call_events.media),
+			outcome=COALESCE(NULLIF(excluded.outcome,''), call_events.outcome),
+			reason=COALESCE(NULLIF(excluded.reason,''), call_events.reason),
+			call_type=COALESCE(NULLIF(excluded.call_type,''), call_events.call_type),
+			duration_secs=CASE WHEN excluded.duration_secs > 0 THEN excluded.duration_secs ELSE call_events.duration_secs END,
+			participants=COALESCE(NULLIF(excluded.participants,''), call_events.participants)
+	`, chatJID, nullIfEmpty(p.ChatName), nullIfEmpty(p.SenderJID), nullIfEmpty(p.SenderName),
+		callID, nullIfEmpty(p.MsgID), eventType, nullIfEmpty(p.Direction), nullIfEmpty(p.Media),
+		nullIfEmpty(p.Outcome), nullIfEmpty(p.Reason), nullIfEmpty(p.CallType), p.DurationSecs, ts, participantsJSON)
+	return err
+}
+
+type ListCallEventsParams struct {
+	ChatJID  string
+	ChatJIDs []string
+	Limit    int
+	Before   *time.Time
+	After    *time.Time
+	Asc      bool
+}
+
+func (d *DB) ListCallEvents(p ListCallEventsParams) ([]CallEvent, error) {
+	if p.Limit <= 0 {
+		p.Limit = 50
+	}
+	query := `
+		SELECT rowid, chat_jid, COALESCE(chat_name,''), COALESCE(sender_jid,''), COALESCE(sender_name,''),
+		       call_id, COALESCE(msg_id,''), event_type, COALESCE(direction,''), COALESCE(media,''),
+		       COALESCE(outcome,''), COALESCE(reason,''), COALESCE(call_type,''), duration_secs,
+		       ts, COALESCE(participants,'')
+		FROM call_events
+		WHERE 1=1`
+	var args []interface{}
+	query, args = appendStringFilter(query, args, "chat_jid", p.ChatJID, p.ChatJIDs)
+	if p.After != nil {
+		query += " AND ts > ?"
+		args = append(args, unix(*p.After))
+	}
+	if p.Before != nil {
+		query += " AND ts < ?"
+		args = append(args, unix(*p.Before))
+	}
+	if p.Asc {
+		query += " ORDER BY ts ASC, rowid ASC LIMIT ?"
+	} else {
+		query += " ORDER BY ts DESC, rowid DESC LIMIT ?"
+	}
+	args = append(args, p.Limit)
+
+	rows, err := d.sql.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []CallEvent
+	for rows.Next() {
+		var ce CallEvent
+		var ts int64
+		var participantsJSON string
+		if err := rows.Scan(&ce.rowID, &ce.ChatJID, &ce.ChatName, &ce.SenderJID, &ce.SenderName,
+			&ce.CallID, &ce.MsgID, &ce.EventType, &ce.Direction, &ce.Media, &ce.Outcome,
+			&ce.Reason, &ce.CallType, &ce.DurationSecs, &ts, &participantsJSON); err != nil {
+			return nil, err
+		}
+		ce.Timestamp = fromUnix(ts)
+		if participantsJSON != "" {
+			_ = json.Unmarshal([]byte(participantsJSON), &ce.Participants)
+		}
+		out = append(out, ce)
+	}
+	return out, rows.Err()
+}

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -124,6 +124,42 @@ func TestCallEventsUpsertAndList(t *testing.T) {
 	}
 }
 
+func TestDeleteCallEventsRemovesCallLogsOnly(t *testing.T) {
+	db := openTestDB(t)
+	chat := "123@s.whatsapp.net"
+	base := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+	if err := db.UpsertChat(chat, "dm", "Alice", base); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	for _, event := range []UpsertCallEventParams{
+		{ChatJID: chat, CallID: "out-log", EventType: "call_log", Direction: "outbound", Timestamp: base},
+		{ChatJID: chat, CallID: "in-log", EventType: "call_log", Direction: "inbound", Timestamp: base.Add(time.Second)},
+		{ChatJID: chat, CallID: "live-offer", EventType: "offer", Direction: "outbound", Timestamp: base.Add(2 * time.Second)},
+	} {
+		if err := db.UpsertCallEvent(event); err != nil {
+			t.Fatalf("UpsertCallEvent %s: %v", event.CallID, err)
+		}
+	}
+
+	deleted, err := db.DeleteCallEvents(DeleteCallEventsParams{ChatJID: chat, Direction: "outbound"})
+	if err != nil {
+		t.Fatalf("DeleteCallEvents: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+	calls, err := db.ListCallEvents(ListCallEventsParams{ChatJID: chat, Limit: 10, Asc: true})
+	if err != nil {
+		t.Fatalf("ListCallEvents: %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("calls len = %d, want 2: %+v", len(calls), calls)
+	}
+	if calls[0].CallID != "in-log" || calls[1].CallID != "live-offer" {
+		t.Fatalf("remaining calls = %+v", calls)
+	}
+}
+
 func TestListMessagesFiltersAndOrdering(t *testing.T) {
 	db := openTestDB(t)
 	chat := "chat@s.whatsapp.net"

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -68,6 +68,62 @@ func TestMessageUpsertIdempotentAndContext(t *testing.T) {
 	}
 }
 
+func TestCallEventsUpsertAndList(t *testing.T) {
+	db := openTestDB(t)
+	chat := "123@s.whatsapp.net"
+	base := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+	if err := db.UpsertChat(chat, "dm", "Alice", base); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := db.UpsertCallEvent(UpsertCallEventParams{
+		ChatJID:      chat,
+		ChatName:     "Alice",
+		SenderJID:    chat,
+		CallID:       "call-1",
+		MsgID:        "msg-1",
+		EventType:    "call_log",
+		Direction:    "outbound",
+		Media:        "audio",
+		Outcome:      "connected",
+		CallType:     "regular",
+		DurationSecs: 62,
+		Timestamp:    base,
+		Participants: []CallParticipant{{JID: chat, Outcome: "connected"}},
+	}); err != nil {
+		t.Fatalf("UpsertCallEvent: %v", err)
+	}
+	if err := db.UpsertCallEvent(UpsertCallEventParams{
+		ChatJID:      chat,
+		CallID:       "call-1",
+		EventType:    "call_log",
+		Direction:    "outbound",
+		Media:        "audio",
+		Outcome:      "connected",
+		DurationSecs: 70,
+		Timestamp:    base,
+	}); err != nil {
+		t.Fatalf("UpsertCallEvent duplicate: %v", err)
+	}
+
+	calls, err := db.ListCallEvents(ListCallEventsParams{ChatJID: chat, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListCallEvents: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("calls len = %d, want 1", len(calls))
+	}
+	got := calls[0]
+	if got.CallID != "call-1" || got.EventType != "call_log" || got.Direction != "outbound" || got.Outcome != "connected" {
+		t.Fatalf("unexpected call event: %+v", got)
+	}
+	if got.DurationSecs != 70 {
+		t.Fatalf("duration = %d, want updated 70", got.DurationSecs)
+	}
+	if len(got.Participants) != 1 || got.Participants[0].JID != chat {
+		t.Fatalf("participants = %+v", got.Participants)
+	}
+}
+
 func TestListMessagesFiltersAndOrdering(t *testing.T) {
 	db := openTestDB(t)
 	chat := "chat@s.whatsapp.net"

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -28,6 +28,7 @@ var schemaMigrations = []migration{
 	{version: 12, name: "contacts system_name column", up: migrateContactsSystemNameColumn},
 	{version: 13, name: "messages buttons column", up: migrateMessagesButtonsColumn},
 	{version: 14, name: "polls and poll_votes", up: migratePolls},
+	{version: 15, name: "call events", up: migrateCallEvents},
 }
 
 func (d *DB) ensureSchema() error {
@@ -76,6 +77,19 @@ func (d *DB) ensureSchema() error {
 		}
 	}
 
+	return d.ensureCurrentSchema()
+}
+
+func (d *DB) ensureCurrentSchema() error {
+	// Keep idempotent DDL guards here, not in query/write paths. This catches
+	// local stores from interrupted or pre-release migrations where a version
+	// row exists but the expected object does not.
+	if err := migratePolls(d); err != nil {
+		return fmt.Errorf("ensure current polls schema: %w", err)
+	}
+	if err := migrateCallEvents(d); err != nil {
+		return fmt.Errorf("ensure current call events schema: %w", err)
+	}
 	return nil
 }
 
@@ -295,6 +309,36 @@ func migratePolls(d *DB) error {
 		CREATE INDEX IF NOT EXISTS idx_poll_votes_poll ON poll_votes(chat_jid, poll_msg_id);
 	`); err != nil {
 		return fmt.Errorf("create polls tables: %w", err)
+	}
+	return nil
+}
+
+func migrateCallEvents(d *DB) error {
+	if _, err := d.sql.Exec(`
+		CREATE TABLE IF NOT EXISTS call_events (
+			rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+			chat_jid TEXT NOT NULL,
+			chat_name TEXT,
+			sender_jid TEXT,
+			sender_name TEXT,
+			call_id TEXT NOT NULL,
+			msg_id TEXT,
+			event_type TEXT NOT NULL,
+			direction TEXT,
+			media TEXT,
+			outcome TEXT,
+			reason TEXT,
+			call_type TEXT,
+			duration_secs INTEGER NOT NULL DEFAULT 0,
+			ts INTEGER NOT NULL,
+			participants TEXT,
+			UNIQUE(chat_jid, call_id, event_type, ts),
+			FOREIGN KEY (chat_jid) REFERENCES chats(jid) ON DELETE CASCADE
+		);
+		CREATE INDEX IF NOT EXISTS idx_call_events_chat_ts ON call_events(chat_jid, ts);
+		CREATE INDEX IF NOT EXISTS idx_call_events_ts ON call_events(ts);
+	`); err != nil {
+		return fmt.Errorf("create call_events table: %w", err)
 	}
 	return nil
 }

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -94,6 +94,29 @@ const coreSchemaSQL = `
 	CREATE INDEX IF NOT EXISTS idx_messages_chat_ts ON messages(chat_jid, ts);
 	CREATE INDEX IF NOT EXISTS idx_messages_ts ON messages(ts);
 
+	CREATE TABLE IF NOT EXISTS call_events (
+		rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+		chat_jid TEXT NOT NULL,
+		chat_name TEXT,
+		sender_jid TEXT,
+		sender_name TEXT,
+		call_id TEXT NOT NULL,
+		msg_id TEXT,
+		event_type TEXT NOT NULL,
+		direction TEXT,
+		media TEXT,
+		outcome TEXT,
+		reason TEXT,
+		call_type TEXT,
+		duration_secs INTEGER NOT NULL DEFAULT 0,
+		ts INTEGER NOT NULL,
+		participants TEXT,
+		UNIQUE(chat_jid, call_id, event_type, ts),
+		FOREIGN KEY (chat_jid) REFERENCES chats(jid) ON DELETE CASCADE
+	);
+	CREATE INDEX IF NOT EXISTS idx_call_events_chat_ts ON call_events(chat_jid, ts);
+	CREATE INDEX IF NOT EXISTS idx_call_events_ts ON call_events(ts);
+
 	CREATE TABLE IF NOT EXISTS starred (
 		chat_jid TEXT NOT NULL,
 		msg_id TEXT NOT NULL,

--- a/internal/store/schema_test.go
+++ b/internal/store/schema_test.go
@@ -41,6 +41,19 @@ func TestOpenCreatesExpectedSchema(t *testing.T) {
 		}
 	}
 
+	callCols, err := tableColumns(db.sql, "call_events")
+	if err != nil {
+		t.Fatalf("call_events tableColumns: %v", err)
+	}
+	for _, want := range []string{"chat_jid", "call_id", "event_type", "direction", "media", "outcome", "duration_secs", "participants"} {
+		if !callCols[want] {
+			t.Fatalf("expected call_events column %q to exist", want)
+		}
+	}
+	if !indexExists(t, db.sql, "idx_call_events_chat_ts") {
+		t.Fatalf("expected call_events chat index to exist")
+	}
+
 	starredCols, err := tableColumns(db.sql, "starred")
 	if err != nil {
 		t.Fatalf("starred tableColumns: %v", err)
@@ -70,6 +83,50 @@ func TestOpenCreatesExpectedSchema(t *testing.T) {
 	}
 	if !contactCols["system_name"] {
 		t.Fatalf("expected contacts system_name column to exist")
+	}
+}
+
+func TestOpenRepairsRecordedCallEventsMigrationMissingTable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wacli.db")
+
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	raw, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	if _, err := raw.Exec(`
+		DROP TABLE call_events;
+		INSERT OR IGNORE INTO schema_migrations(version, name, applied_at) VALUES(14, 'call events', 1);
+	`); err != nil {
+		_ = raw.Close()
+		t.Fatalf("create inconsistent schema: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw close: %v", err)
+	}
+
+	db, err = Open(path)
+	if err != nil {
+		t.Fatalf("Open repaired DB: %v", err)
+	}
+	defer db.Close()
+
+	if ok, err := db.tableExists("call_events"); err != nil || !ok {
+		t.Fatalf("call_events exists=%v err=%v", ok, err)
+	}
+	if !indexExists(t, db.sql, "idx_call_events_chat_ts") {
+		t.Fatalf("expected call_events chat index to be recreated")
+	}
+	if _, err := db.ListCallEvents(ListCallEventsParams{Limit: 1}); err != nil {
+		t.Fatalf("ListCallEvents after schema repair: %v", err)
 	}
 }
 

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -106,6 +106,30 @@ type MessageInfo struct {
 	SenderName string
 }
 
+type CallParticipant struct {
+	JID     string `json:"jid"`
+	Outcome string `json:"outcome,omitempty"`
+}
+
+type CallEvent struct {
+	ChatJID      string            `json:"chat_jid"`
+	ChatName     string            `json:"chat_name,omitempty"`
+	SenderJID    string            `json:"sender_jid,omitempty"`
+	SenderName   string            `json:"sender_name,omitempty"`
+	CallID       string            `json:"call_id"`
+	MsgID        string            `json:"msg_id,omitempty"`
+	EventType    string            `json:"event_type"`
+	Direction    string            `json:"direction,omitempty"`
+	Media        string            `json:"media,omitempty"`
+	Outcome      string            `json:"outcome,omitempty"`
+	Reason       string            `json:"reason,omitempty"`
+	CallType     string            `json:"call_type,omitempty"`
+	DurationSecs int64             `json:"duration_secs,omitempty"`
+	Timestamp    time.Time         `json:"timestamp"`
+	Participants []CallParticipant `json:"participants,omitempty"`
+	rowID        int64
+}
+
 type Contact struct {
 	JID        string    `json:"jid"`
 	Phone      string    `json:"phone"`

--- a/internal/wa/calls.go
+++ b/internal/wa/calls.go
@@ -33,6 +33,11 @@ type ParsedCallEvent struct {
 	Participants []ParsedCallParticipant
 }
 
+type ParsedCallDelete struct {
+	Chat      types.JID
+	Direction string
+}
+
 func extractCallLog(m *waProto.Message, pm *ParsedMessage) {
 	call := m.GetCallLogMesssage()
 	if call == nil {
@@ -77,6 +82,26 @@ func ParseLiveCallEvent(evt interface{}, self types.JID) (ParsedCallEvent, bool)
 	default:
 		return ParsedCallEvent{}, false
 	}
+}
+
+func ParseCallLogDeleteEvent(evt interface{}) (ParsedCallDelete, bool) {
+	v, ok := evt.(*events.AppState)
+	if !ok || v == nil || v.SyncActionValue == nil || v.GetDeleteIndividualCallLog() == nil {
+		return ParsedCallDelete{}, false
+	}
+	action := v.GetDeleteIndividualCallLog()
+	peer := strings.TrimSpace(action.GetPeerJID())
+	if peer == "" {
+		return ParsedCallDelete{}, false
+	}
+	chat, err := types.ParseJID(peer)
+	if err != nil || chat.IsEmpty() {
+		return ParsedCallDelete{}, false
+	}
+	return ParsedCallDelete{
+		Chat:      chat,
+		Direction: directionFromIncoming(action.GetIsIncoming()),
+	}, true
 }
 
 func callEventFromMeta(meta types.BasicCallMeta, self types.JID, eventType, outcome, reason, media, callType string) ParsedCallEvent {

--- a/internal/wa/calls.go
+++ b/internal/wa/calls.go
@@ -1,0 +1,294 @@
+package wa
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/proto/waSyncAction"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+type ParsedCallParticipant struct {
+	JID     string
+	Outcome string
+}
+
+type ParsedCallEvent struct {
+	Chat         types.JID
+	SenderJID    string
+	CallID       string
+	MsgID        string
+	EventType    string
+	Direction    string
+	Media        string
+	Outcome      string
+	Reason       string
+	CallType     string
+	DurationSecs int64
+	Timestamp    time.Time
+	Participants []ParsedCallParticipant
+}
+
+func extractCallLog(m *waProto.Message, pm *ParsedMessage) {
+	call := m.GetCallLogMesssage()
+	if call == nil {
+		return
+	}
+	pm.Call = &ParsedCallEvent{
+		Chat:         pm.Chat,
+		SenderJID:    pm.SenderJID,
+		CallID:       pm.ID,
+		MsgID:        pm.ID,
+		EventType:    "call_log",
+		Direction:    directionFromFromMe(pm.FromMe),
+		Media:        audioVideo(call.GetIsVideo()),
+		Outcome:      callLogMessageOutcome(call.GetCallOutcome()),
+		CallType:     callLogMessageType(call.GetCallType()),
+		DurationSecs: call.GetDurationSecs(),
+		Timestamp:    pm.Timestamp,
+		Participants: callLogMessageParticipants(call.GetParticipants()),
+	}
+}
+
+func ParseLiveCallEvent(evt interface{}, self types.JID) (ParsedCallEvent, bool) {
+	switch v := evt.(type) {
+	case *events.CallOffer:
+		return callEventFromMeta(v.BasicCallMeta, self, "offer", "", "", mediaFromCallNode(v.Data), ""), true
+	case *events.CallAccept:
+		return callEventFromMeta(v.BasicCallMeta, self, "accept", "", "", mediaFromCallNode(v.Data), ""), true
+	case *events.CallPreAccept:
+		return callEventFromMeta(v.BasicCallMeta, self, "pre_accept", "", "", mediaFromCallNode(v.Data), ""), true
+	case *events.CallTransport:
+		return callEventFromMeta(v.BasicCallMeta, self, "transport", "", "", mediaFromCallNode(v.Data), ""), true
+	case *events.CallOfferNotice:
+		return callEventFromMeta(v.BasicCallMeta, self, "offer_notice", "", "", cleanCallValue(v.Media), cleanCallValue(v.Type)), true
+	case *events.CallRelayLatency:
+		return callEventFromMeta(v.BasicCallMeta, self, "relay_latency", "", "", mediaFromCallNode(v.Data), ""), true
+	case *events.CallTerminate:
+		return callEventFromMeta(v.BasicCallMeta, self, "terminate", "", cleanCallValue(v.Reason), mediaFromCallNode(v.Data), ""), true
+	case *events.CallReject:
+		return callEventFromMeta(v.BasicCallMeta, self, "reject", "", "", mediaFromCallNode(v.Data), ""), true
+	case *events.AppState:
+		return parseCallLogAppState(v, self)
+	default:
+		return ParsedCallEvent{}, false
+	}
+}
+
+func callEventFromMeta(meta types.BasicCallMeta, self types.JID, eventType, outcome, reason, media, callType string) ParsedCallEvent {
+	chat := meta.From
+	if !meta.GroupJID.IsEmpty() {
+		chat = meta.GroupJID
+	}
+	sender := meta.From.String()
+	if !meta.CallCreator.IsEmpty() {
+		sender = meta.CallCreator.String()
+	}
+	return ParsedCallEvent{
+		Chat:      chat,
+		SenderJID: sender,
+		CallID:    strings.TrimSpace(meta.CallID),
+		EventType: eventType,
+		Direction: directionFromCallCreator(meta.CallCreator, self, eventType),
+		Media:     cleanCallValue(media),
+		Outcome:   cleanCallValue(outcome),
+		Reason:    cleanCallValue(reason),
+		CallType:  cleanCallValue(callType),
+		Timestamp: meta.Timestamp,
+	}
+}
+
+func parseCallLogAppState(evt *events.AppState, self types.JID) (ParsedCallEvent, bool) {
+	if evt == nil || evt.SyncActionValue == nil || evt.GetCallLogAction() == nil || evt.GetCallLogAction().GetCallLogRecord() == nil {
+		return ParsedCallEvent{}, false
+	}
+	record := evt.GetCallLogAction().GetCallLogRecord()
+	chat, sender := callLogRecordChatAndSender(record, self)
+	if chat.IsEmpty() {
+		return ParsedCallEvent{}, false
+	}
+	ts := time.UnixMilli(record.GetStartTime()).UTC()
+	if record.GetStartTime() <= 0 && evt.GetTimestamp() > 0 {
+		ts = time.UnixMilli(evt.GetTimestamp()).UTC()
+	}
+	return ParsedCallEvent{
+		Chat:         chat,
+		SenderJID:    sender,
+		CallID:       strings.TrimSpace(record.GetCallID()),
+		EventType:    "call_log",
+		Direction:    directionFromIncoming(record.GetIsIncoming()),
+		Media:        audioVideo(record.GetIsVideo()),
+		Outcome:      callLogRecordResult(record.GetCallResult()),
+		Reason:       callLogRecordReason(record),
+		CallType:     callLogRecordType(record.GetCallType()),
+		DurationSecs: record.GetDuration(),
+		Timestamp:    ts,
+		Participants: callLogRecordParticipants(record.GetParticipants()),
+	}, true
+}
+
+func callLogRecordChatAndSender(record *waSyncAction.CallLogRecord, self types.JID) (types.JID, string) {
+	if group := strings.TrimSpace(record.GetGroupJID()); group != "" {
+		if jid, err := types.ParseJID(group); err == nil {
+			return jid, strings.TrimSpace(record.GetCallCreatorJID())
+		}
+	}
+	creator := strings.TrimSpace(record.GetCallCreatorJID())
+	if creator != "" {
+		if creatorJID, err := types.ParseJID(creator); err == nil && (self.IsEmpty() || creatorJID.ToNonAD() != self.ToNonAD()) {
+			return creatorJID, creator
+		}
+	}
+	for _, p := range record.GetParticipants() {
+		if p == nil || strings.TrimSpace(p.GetUserJID()) == "" {
+			continue
+		}
+		if jid, err := types.ParseJID(p.GetUserJID()); err == nil && (self.IsEmpty() || jid.ToNonAD() != self.ToNonAD()) {
+			return jid, creator
+		}
+	}
+	if creator != "" {
+		if jid, err := types.ParseJID(creator); err == nil {
+			return jid, creator
+		}
+	}
+	for _, p := range record.GetParticipants() {
+		if p == nil || strings.TrimSpace(p.GetUserJID()) == "" {
+			continue
+		}
+		if jid, err := types.ParseJID(p.GetUserJID()); err == nil {
+			return jid, p.GetUserJID()
+		}
+	}
+	return types.JID{}, ""
+}
+
+func directionFromCallCreator(creator, self types.JID, eventType string) string {
+	if !creator.IsEmpty() && !self.IsEmpty() {
+		if creator.ToNonAD() == self.ToNonAD() {
+			return "outbound"
+		}
+		return "inbound"
+	}
+	switch eventType {
+	case "offer", "offer_notice", "relay_latency":
+		return "inbound"
+	default:
+		return "unknown"
+	}
+}
+
+func directionFromFromMe(fromMe bool) string {
+	if fromMe {
+		return "outbound"
+	}
+	return "inbound"
+}
+
+func directionFromIncoming(incoming bool) string {
+	if incoming {
+		return "inbound"
+	}
+	return "outbound"
+}
+
+func audioVideo(isVideo bool) string {
+	if isVideo {
+		return "video"
+	}
+	return "audio"
+}
+
+func mediaFromCallNode(node *waBinary.Node) string {
+	if node == nil {
+		return ""
+	}
+	for _, key := range []string{"media", "type", "call-creator-media"} {
+		if value, ok := node.Attrs[key]; ok {
+			if s := cleanCallValue(fmt.Sprint(value)); s == "audio" || s == "video" {
+				return s
+			}
+		}
+	}
+	for _, child := range node.GetChildren() {
+		if s := cleanCallValue(child.Tag); s == "audio" || s == "video" {
+			return s
+		}
+		if media := mediaFromCallNode(&child); media != "" {
+			return media
+		}
+	}
+	return ""
+}
+
+func cleanCallValue(s string) string {
+	s = strings.TrimSpace(strings.ToLower(s))
+	s = strings.ReplaceAll(s, "-", "_")
+	s = strings.ReplaceAll(s, " ", "_")
+	return s
+}
+
+func callLogMessageOutcome(v waProto.CallLogMessage_CallOutcome) string {
+	return cleanCallValue(v.String())
+}
+
+func callLogMessageType(v waProto.CallLogMessage_CallType) string {
+	return cleanCallValue(v.String())
+}
+
+func callLogRecordResult(v waSyncAction.CallLogRecord_CallResult) string {
+	value := cleanCallValue(v.String())
+	if value == "acceptedelsewhere" {
+		return "accepted_elsewhere"
+	}
+	return value
+}
+
+func callLogRecordType(v waSyncAction.CallLogRecord_CallType) string {
+	return cleanCallValue(v.String())
+}
+
+func callLogRecordReason(record *waSyncAction.CallLogRecord) string {
+	if record == nil {
+		return ""
+	}
+	if reason := cleanCallValue(record.GetSilenceReason().String()); reason != "" && reason != "none" {
+		return reason
+	}
+	if record.GetIsDndMode() {
+		return "dnd"
+	}
+	return ""
+}
+
+func callLogMessageParticipants(participants []*waProto.CallLogMessage_CallParticipant) []ParsedCallParticipant {
+	out := make([]ParsedCallParticipant, 0, len(participants))
+	for _, p := range participants {
+		if p == nil || strings.TrimSpace(p.GetJID()) == "" {
+			continue
+		}
+		out = append(out, ParsedCallParticipant{
+			JID:     strings.TrimSpace(p.GetJID()),
+			Outcome: callLogMessageOutcome(p.GetCallOutcome()),
+		})
+	}
+	return out
+}
+
+func callLogRecordParticipants(participants []*waSyncAction.CallLogRecord_ParticipantInfo) []ParsedCallParticipant {
+	out := make([]ParsedCallParticipant, 0, len(participants))
+	for _, p := range participants {
+		if p == nil || strings.TrimSpace(p.GetUserJID()) == "" {
+			continue
+		}
+		out = append(out, ParsedCallParticipant{
+			JID:     strings.TrimSpace(p.GetUserJID()),
+			Outcome: callLogRecordResult(p.GetCallResult()),
+		})
+	}
+	return out
+}

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -80,6 +80,7 @@ type ParsedMessage struct {
 	StarredKnown    bool
 	Starred         bool
 	Revoked         bool
+	Call            *ParsedCallEvent
 }
 
 func ParseLiveMessage(evt *events.Message) ParsedMessage {
@@ -146,6 +147,7 @@ func extractWAProto(m *waProto.Message, pm *ParsedMessage) {
 	extractPoll(m, pm)
 	extractPollAddOption(m, pm)
 	extractPollUpdate(m, pm)
+	extractCallLog(m, pm)
 
 	if ctx := contextInfoForMessage(m); ctx != nil {
 		if id := strings.TrimSpace(ctx.GetStanzaID()); id != "" {

--- a/internal/wa/messages_test.go
+++ b/internal/wa/messages_test.go
@@ -33,6 +33,44 @@ func TestParseHistoryMessageTextAndSender(t *testing.T) {
 	}
 }
 
+func TestParseHistoryMessageCallLog(t *testing.T) {
+	outcome := waProto.CallLogMessage_CONNECTED
+	callType := waProto.CallLogMessage_REGULAR
+	h := &waProto.WebMessageInfo{
+		Key: &waProto.MessageKey{
+			ID:     proto.String("call-msg"),
+			FromMe: proto.Bool(true),
+		},
+		MessageTimestamp: proto.Uint64(uint64(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC).Unix())),
+		Message: &waProto.Message{
+			CallLogMesssage: &waProto.CallLogMessage{
+				IsVideo:      proto.Bool(true),
+				CallOutcome:  &outcome,
+				DurationSecs: proto.Int64(125),
+				CallType:     &callType,
+				Participants: []*waProto.CallLogMessage_CallParticipant{{
+					JID:         proto.String("456@s.whatsapp.net"),
+					CallOutcome: &outcome,
+				}},
+			},
+		},
+	}
+
+	pm := ParseHistoryMessage("456@s.whatsapp.net", h)
+	if pm.Call == nil {
+		t.Fatal("expected call log metadata")
+	}
+	if pm.Call.EventType != "call_log" || pm.Call.CallID != "call-msg" || pm.Call.MsgID != "call-msg" {
+		t.Fatalf("unexpected call identity: %+v", pm.Call)
+	}
+	if pm.Call.Direction != "outbound" || pm.Call.Media != "video" || pm.Call.Outcome != "connected" || pm.Call.DurationSecs != 125 {
+		t.Fatalf("unexpected call details: %+v", pm.Call)
+	}
+	if len(pm.Call.Participants) != 1 || pm.Call.Participants[0].JID != "456@s.whatsapp.net" {
+		t.Fatalf("unexpected participants: %+v", pm.Call.Participants)
+	}
+}
+
 func TestParseHistoryMessageTopLevelParticipant(t *testing.T) {
 	groupJID := "120363001234567890@g.us"
 	senderLID := "12345:67@lid"


### PR DESCRIPTION
Fixes #231

## Summary
- persist WhatsApp call metadata in a new `call_events` table instead of flattening call-log messages to generic `(message)` rows
- parse live whatsmeow call events and historical `CallLogMessage` payloads into structured call events
- add `wacli calls list` with table and `--json` output, plus docs and changelog coverage
- keep existing message listing behavior backwards-compatible while exposing calls through the dedicated command

## Details
- stores chat/sender names, call ID, message ID, event type, direction, media, outcome, reason, call type, duration, timestamp, and participants where available
- adds migration 15 for `call_events`; upstream polls remain migration 14 after the rebase
- handles app-state call logs and message-carried call logs, plus live call offer/accept/terminate/reject-style events
- adds tests for call-event upsert/listing, schema repair, message parsing, sync handling, and CLI output

## Validation
- `env GOCACHE=/tmp/go-build go test ./internal/store ./internal/wa`