### PR TITLE
fix: canonicalize sync media enqueue JIDs

### DIFF
--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -207,7 +207,7 @@ func (a *App) handleLiveSyncMessage(ctx context.Context, opts SyncOptions, v *ev
 		a.handlePollSideEffects(sideEffectCtx, pm, v)
 	}
 	if opts.DownloadMedia && pm.Media != nil && pm.ID != "" {
-		enqueueMedia(pm.Chat.String(), pm.ID)
+		enqueueMedia(canonicalJIDString(a.canonicalStoreJID(ctx, pm.Chat)), pm.ID)
 	}
 }
 
@@ -283,7 +283,7 @@ func (a *App) handleHistorySync(ctx context.Context, opts SyncOptions, v *events
 				return
 			}
 			if opts.DownloadMedia && pm.Media != nil && pm.ID != "" {
-				enqueueMedia(pm.Chat.String(), pm.ID)
+				enqueueMedia(canonicalJIDString(a.canonicalStoreJID(ctx, pm.Chat)), pm.ID)
 			}
 		}
 		flushCtx := ctx

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -847,6 +847,60 @@ func TestSyncStoresDisplayText(t *testing.T) {
 	}
 }
 
+func TestSyncDownloadMediaCanonicalizesLIDChatBeforeEnqueue(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	lid := types.JID{User: "152527844733129", Server: types.HiddenUserServer}
+	pn := types.JID{User: "447356168511", Server: types.DefaultUserServer}
+	f.lids[lid] = pn
+	f.contacts[pn] = types.ContactInfo{Found: true, FullName: "Dave", PushName: "Dave"}
+
+	msgID := "media-lid"
+	f.connectEvents = append(f.connectEvents, &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     lid,
+				Sender:   lid,
+				IsFromMe: false,
+			},
+			ID:        msgID,
+			Timestamp: time.Date(2026, 5, 15, 17, 30, 0, 0, time.UTC),
+			PushName:  "Dave",
+		},
+		Message: &waProto.Message{
+			ImageMessage: &waProto.ImageMessage{
+				Mimetype:      proto.String("image/jpeg"),
+				DirectPath:    proto.String("/direct"),
+				MediaKey:      []byte{1, 2, 3},
+				FileSHA256:    []byte{4, 5, 6},
+				FileEncSHA256: []byte{7, 8, 9},
+				FileLength:    proto.Uint64(4),
+			},
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := a.Sync(ctx, SyncOptions{
+		Mode:          SyncModeOnce,
+		AllowQR:       false,
+		DownloadMedia: true,
+		IdleExit:      100 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	msg, err := a.db.GetMessage(pn.String(), msgID)
+	if err != nil {
+		t.Fatalf("GetMessage canonical PN row: %v", err)
+	}
+	if msg.LocalPath == "" {
+		t.Fatalf("expected media downloaded via canonical PN row, got empty local_path")
+	}
+}
+
 func TestSyncMediaEnqueueUsesBoundedBackpressure(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()


### PR DESCRIPTION
# fix: canonicalize sync media enqueue JIDs

## Summary

Fixes background media downloads during `sync --follow --download-media` when live one-to-one messages arrive with an `@lid` chat JID.

Message storage canonicalizes incoming chat JIDs via `canonicalStoreJID`, so the DB row may be stored under the resolved phone-number JID (`@s.whatsapp.net`). The media download enqueue path previously used the raw live `pm.Chat.String()`, which could still be an `@lid`. The media worker then looked up the wrong `(chat_jid, msg_id)` and skipped the download because the row was not found.

This change queues media downloads using the same canonical chat JID used by message storage.

## Test

Added regression coverage for a live `@lid` media message that resolves to a PN chat row. Pre-fix, the row is stored under the PN JID but the worker looks up the LID JID, leaving `local_path` empty. Post-fix, the media is downloaded and `local_path` is set.

```bash
go test ./internal/app -run TestSyncDownloadMediaCanonicalizesLIDChatBeforeEnqueue -count=1
```

Optional pre-fix failure check:

```bash
git checkout HEAD~1 -- internal/app/sync_events.go && go test ./internal/app -run TestSyncDownloadMediaCanonicalizesLIDChatBeforeEnqueue -count=1; git checkout HEAD -- internal/app/sync_events.go
```

## Notes

Observed with `sync --follow --download-media`: live image messages were stored with media metadata, but `local_path` stayed empty. Manual `media download --chat <pn-jid> --id <msg-id>` worked immediately, confirming the metadata/download path was valid and the issue was the live enqueue lookup JID.
