### PR TITLE
feat: add status message sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Send: add `wacli send status` for WhatsApp status broadcasts, including text statuses with optional background/font and media statuses with captions.
+- Send: add `wacli send status` for WhatsApp status broadcasts, including text statuses with optional background/font and media statuses with captions. (#247 - thanks @dovocoder)
 - Store: persist synced and locally sent status broadcasts separately in `status_messages` instead of mixing them into normal chat messages.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.9.2 - Unreleased
 
+### Added
+
+- Send: add `wacli send status` for WhatsApp status broadcasts, including text statuses with optional background/font and media statuses with captions.
+- Store: persist synced and locally sent status broadcasts separately in `status_messages` instead of mixing them into normal chat messages.
+
 ### Fixed
 
 - History: unwrap edited WhatsApp messages during history sync and backfill so stored/searchable text shows the edited body instead of `(message)`. (#246 - thanks @hiasinho)

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Full documentation: **<https://wacli.sh>**
 ## Features
 
 - **Auth + sync** — QR pairing, one-shot or follow-mode sync, optional media downloads, optional signed webhook fan-out.
-- **Offline message store** — SQLite with FTS5 search (LIKE fallback), filterable by chat, sender, direction, time, and media type.
-- **Sending** — text with mentions/replies/link-previews, files (image/video/audio/document, ≤100 MiB), stickers, voice notes, reactions; rapid-send guardrails and retry-receipt grace.
+- **Offline message store** — SQLite with FTS5 search (LIKE fallback), filterable by chat, sender, direction, time, and media type, with status broadcasts stored separately.
+- **Sending** — text with mentions/replies/link-previews, files (image/video/audio/document, ≤100 MiB), stickers, voice notes, reactions, and status broadcasts; rapid-send guardrails and retry-receipt grace.
 - **History backfill** — best-effort per-chat requests to your primary device for older messages.
 - **Contacts / chats / groups / channels** — search, alias, tag, archive, pin, mute, mark-read, rename, prune, manage participants and invite links, send to channels.
 - **Diagnostics + safety** — `doctor`, read-only mode, store locks with owner reporting, panic recovery, bounded media queue, owner-only DB perms.
@@ -73,6 +73,7 @@ wacli messages search "meeting"
 # 4. Send
 wacli send text --to 1234567890 --message "hello"
 wacli send file --to mom --file ./pic.jpg --caption "hi"
+wacli send status --message "available today" --background-color '#1f7a8c'
 
 # 5. Diagnostics
 wacli doctor
@@ -80,7 +81,7 @@ wacli doctor
 
 Recipients accept a JID, phone number (E.164 or formatted), channel JID, or a synced contact/group/chat name. Ambiguous names prompt in a TTY; pass `--pick N` in scripts.
 
-More recipes — replies, mentions, stickers, voice, reactions, channels, history backfill, chat management — live in the [docs](https://wacli.sh).
+More recipes — replies, mentions, stickers, voice, reactions, statuses, channels, history backfill, chat management — live in the [docs](https://wacli.sh).
 
 ## Documentation
 

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -32,6 +32,7 @@ func newSendCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newSendVoiceCmd(flags))
 	cmd.AddCommand(newSendReactCmd(flags))
 	cmd.AddCommand(newSendPollCmd(flags))
+	cmd.AddCommand(newSendStatusCmd(flags))
 	return cmd
 }
 

--- a/cmd/wacli/send_file.go
+++ b/cmd/wacli/send_file.go
@@ -159,28 +159,47 @@ func sendFile(ctx context.Context, a interface {
 		return "", nil, err
 	}
 
-	chatName := a.WA().ResolveChatName(ctx, to, "")
-	kind := chatKindFromJID(to)
-	_ = a.DB().UpsertChat(to.String(), kind, chatName, now)
-	_ = a.DB().UpsertMessage(store.UpsertMessageParams{
-		ChatJID:       to.String(),
-		ChatName:      chatName,
-		MsgID:         id,
-		SenderJID:     "",
-		SenderName:    "me",
-		Timestamp:     now,
-		FromMe:        true,
-		Text:          opts.caption,
-		MediaType:     mediaType,
-		MediaCaption:  opts.caption,
-		Filename:      name,
-		MimeType:      mimeType,
-		DirectPath:    up.DirectPath,
-		MediaKey:      up.MediaKey,
-		FileSHA256:    up.FileSHA256,
-		FileEncSHA256: up.FileEncSHA256,
-		FileLength:    up.FileLength,
-	})
+	if to == types.StatusBroadcastJID {
+		_ = a.DB().UpsertStatusMessage(store.UpsertStatusMessageParams{
+			MsgID:         id,
+			Timestamp:     now,
+			FromMe:        true,
+			SenderName:    "me",
+			Text:          opts.caption,
+			MediaType:     mediaType,
+			MediaCaption:  opts.caption,
+			Filename:      name,
+			MimeType:      mimeType,
+			DirectPath:    up.DirectPath,
+			MediaKey:      up.MediaKey,
+			FileSHA256:    up.FileSHA256,
+			FileEncSHA256: up.FileEncSHA256,
+			FileLength:    up.FileLength,
+		})
+	} else {
+		chatName := a.WA().ResolveChatName(ctx, to, "")
+		kind := chatKindFromJID(to)
+		_ = a.DB().UpsertChat(to.String(), kind, chatName, now)
+		_ = a.DB().UpsertMessage(store.UpsertMessageParams{
+			ChatJID:       to.String(),
+			ChatName:      chatName,
+			MsgID:         id,
+			SenderJID:     "",
+			SenderName:    "me",
+			Timestamp:     now,
+			FromMe:        true,
+			Text:          opts.caption,
+			MediaType:     mediaType,
+			MediaCaption:  opts.caption,
+			Filename:      name,
+			MimeType:      mimeType,
+			DirectPath:    up.DirectPath,
+			MediaKey:      up.MediaKey,
+			FileSHA256:    up.FileSHA256,
+			FileEncSHA256: up.FileEncSHA256,
+			FileLength:    up.FileLength,
+		})
+	}
 
 	return id, map[string]string{
 		"name":      name,

--- a/cmd/wacli/send_status_cmd.go
+++ b/cmd/wacli/send_status_cmd.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openclaw/wacli/internal/out"
+	"github.com/openclaw/wacli/internal/store"
+	"github.com/spf13/cobra"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
+)
+
+type statusTextOptions struct {
+	BackgroundColor string
+	Font            *int32
+}
+
+type statusMessageSender interface {
+	SendProtoMessage(ctx context.Context, to types.JID, msg *waProto.Message) (types.MessageID, error)
+}
+
+func newSendStatusCmd(flags *rootFlags) *cobra.Command {
+	var message string
+	var backgroundColor string
+	var font int32
+	var fontSet bool
+	var filePath string
+	var mimeOverride string
+	var postSendWait = postSendRetryReceiptWait
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Send a status broadcast",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			filePath = strings.TrimSpace(filePath)
+			if strings.TrimSpace(message) == "" && filePath == "" {
+				return fmt.Errorf("--message or --file is required")
+			}
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+			if cmd.Flags().Changed("font") {
+				fontSet = true
+			}
+			var fontPtr *int32
+			if fontSet {
+				fontPtr = &font
+			}
+			var msg *waProto.Message
+			var err error
+			if filePath == "" {
+				msg, err = buildStatusTextMessage(message, statusTextOptions{BackgroundColor: backgroundColor, Font: fontPtr})
+				if err != nil {
+					return err
+				}
+			}
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+			if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
+				return err
+			}
+
+			if filePath != "" {
+				msgID, meta, err := sendFile(ctx, a, types.StatusBroadcastJID, filePath, sendFileOptions{
+					caption:      message,
+					mimeOverride: mimeOverride,
+				})
+				if err != nil {
+					return err
+				}
+				waitForPostSendRetryReceipts(ctx, postSendWait)
+				if flags.asJSON {
+					return out.WriteJSON(os.Stdout, map[string]any{
+						"sent":      true,
+						"to":        types.StatusBroadcastJID.String(),
+						"id":        msgID,
+						"media":     meta["media"],
+						"mime_type": meta["mime_type"],
+					})
+				}
+				fmt.Fprintf(os.Stdout, "Sent status (id %s)\n", msgID)
+				return nil
+			}
+
+			msgID, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (types.MessageID, error) {
+				return sendStatusTextMessage(ctx, a.WA(), msg)
+			})
+			if err != nil {
+				return err
+			}
+
+			now := time.Now().UTC()
+			chat := types.StatusBroadcastJID
+			var storedFont int32
+			if fontPtr != nil {
+				storedFont = *fontPtr
+			}
+			_ = a.DB().UpsertStatusMessage(store.UpsertStatusMessageParams{
+				MsgID:           string(msgID),
+				Timestamp:       now,
+				FromMe:          true,
+				Text:            message,
+				BackgroundColor: backgroundColor,
+				Font:            storedFont,
+			})
+
+			waitForPostSendRetryReceipts(ctx, postSendWait)
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"sent": true,
+					"to":   chat.String(),
+					"id":   msgID,
+				})
+			}
+			fmt.Fprintf(os.Stdout, "Sent status (id %s)\n", msgID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&message, "message", "", "status text or media caption")
+	cmd.Flags().StringVar(&filePath, "file", "", "media file to send as a status update")
+	cmd.Flags().StringVar(&mimeOverride, "mime", "", "override detected MIME type for --file")
+	cmd.Flags().StringVar(&backgroundColor, "background-color", "", "text status background color (#RRGGBB or #AARRGGBB)")
+	cmd.Flags().Int32Var(&font, "font", 0, "WhatsApp text status font number")
+	cmd.Flags().DurationVar(&postSendWait, "post-send-wait", postSendRetryReceiptWait, "keep the connection alive after send so retry receipts can be handled (0 disables)")
+	return cmd
+}
+
+func buildStatusTextMessage(text string, opts statusTextOptions) (*waProto.Message, error) {
+	ext := &waProto.ExtendedTextMessage{Text: proto.String(text)}
+	if strings.TrimSpace(opts.BackgroundColor) != "" {
+		color, err := parseStatusBackgroundColor(opts.BackgroundColor)
+		if err != nil {
+			return nil, err
+		}
+		ext.BackgroundArgb = proto.Uint32(color)
+	}
+	if opts.Font != nil {
+		ext.Font = waProto.ExtendedTextMessage_FontType(*opts.Font).Enum()
+	}
+	return &waProto.Message{ExtendedTextMessage: ext}, nil
+}
+
+func parseStatusBackgroundColor(s string) (uint32, error) {
+	s = strings.TrimSpace(strings.TrimPrefix(s, "#"))
+	if len(s) == 6 {
+		s = "ff" + s
+	}
+	if len(s) != 8 {
+		return 0, fmt.Errorf("--background-color must be #RRGGBB or #AARRGGBB")
+	}
+	v, err := strconv.ParseUint(s, 16, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --background-color: %w", err)
+	}
+	return uint32(v), nil
+}
+
+func sendStatusTextMessage(ctx context.Context, sender statusMessageSender, msg *waProto.Message) (types.MessageID, error) {
+	return sender.SendProtoMessage(ctx, types.StatusBroadcastJID, msg)
+}

--- a/cmd/wacli/send_status_test.go
+++ b/cmd/wacli/send_status_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestBuildStatusTextMessageUsesStatusStyling(t *testing.T) {
+	font := int32(2)
+	msg, err := buildStatusTextMessage("hello status", statusTextOptions{
+		BackgroundColor: "#ff00aa",
+		Font:            &font,
+	})
+	if err != nil {
+		t.Fatalf("buildStatusTextMessage: %v", err)
+	}
+
+	ext := msg.GetExtendedTextMessage()
+	if ext == nil {
+		t.Fatalf("missing ExtendedTextMessage")
+	}
+	if ext.GetText() != "hello status" {
+		t.Fatalf("text = %q", ext.GetText())
+	}
+	if ext.BackgroundArgb == nil || ext.GetBackgroundArgb() != 0xffff00aa {
+		t.Fatalf("backgroundArgb = %#x", ext.GetBackgroundArgb())
+	}
+	if ext.Font == nil || ext.GetFont() != waProto.ExtendedTextMessage_FontType(font) {
+		t.Fatalf("font = %v", ext.GetFont())
+	}
+}
+
+func TestSendStatusCommandExposesMediaFlags(t *testing.T) {
+	cmd := newSendStatusCmd(&rootFlags{})
+	for _, name := range []string{"file", "mime", "message", "post-send-wait"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Fatalf("missing --%s flag", name)
+		}
+	}
+}
+
+func TestStatusBroadcastJIDConstant(t *testing.T) {
+	if types.StatusBroadcastJID.String() != "status@broadcast" {
+		t.Fatalf("status broadcast JID = %q", types.StatusBroadcastJID.String())
+	}
+}

--- a/docs/help.md
+++ b/docs/help.md
@@ -17,6 +17,7 @@ wacli [command] --help
 ```bash
 wacli help send
 wacli send text --help
+wacli send status --help
 wacli docs
 wacli groups participants add --help
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ description: "wacli is a single Go CLI that pairs as a linked WhatsApp Web devic
 
 # wacli
 
-A script-friendly WhatsApp CLI built on [`whatsmeow`](https://github.com/tulir/whatsmeow). One binary pairs as a linked WhatsApp Web device, syncs messages into a local SQLite store, and exposes search, send, media, contact, and group commands with predictable output for terminals, shell pipelines, and coding agents.
+A script-friendly WhatsApp CLI built on [`whatsmeow`](https://github.com/tulir/whatsmeow). One binary pairs as a linked WhatsApp Web device, syncs messages and status broadcasts into a local SQLite store, and exposes search, send, media, contact, and group commands with predictable output for terminals, shell pipelines, and coding agents.
 
 ## Why wacli
 
@@ -25,7 +25,7 @@ A script-friendly WhatsApp CLI built on [`whatsmeow`](https://github.com/tulir/w
 - **Searching old chats.** Read [Sync](sync.md) for the sync model and [History](history.md) for coverage planning and on-demand backfill.
 - **Managing chat state.** Read [Chats](chats.md) for archive, pin, mute, and read/unread commands.
 - **Managing local storage.** Read [Store](store.md) for stats, dry-run cleanup, and local-only pruning.
-- **Sending from scripts.** Read [Send](send.md) for recipient resolution, channels, replies, mentions, files, and reactions.
+- **Sending from scripts.** Read [Send](send.md) for recipient resolution, channels, status broadcasts, replies, mentions, files, and reactions.
 - **Mirroring address-book names.** Read [Contacts import-system](contacts-import-system.md) to import macOS Contacts display names into local wacli metadata.
 - **Wiring up an agent.** Pair `--read-only`, `--json`, and `--events` from [Overview](overview.md); read [Doctor](doctor.md) for self-checks.
 - **Building companion tools.** Read [Companion integrations](integrations.md) for safe read-only SQLite and JSON integration patterns.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -25,7 +25,7 @@ Override with `--store DIR` or `WACLI_STORE_DIR`. Named accounts live in `config
 The store contains two SQLite databases:
 
 - `session.db`: owned by `whatsmeow`; contains linked-device identity and keys.
-- `wacli.db`: owned by `wacli`; contains chats, contacts, groups, messages, call events, media metadata, and local state.
+- `wacli.db`: owned by `wacli`; contains chats, contacts, groups, messages, status broadcasts, call events, media metadata, and local state.
 
 Companion tools should not read or write `session.db` unless they are explicitly working on WhatsApp session internals. Never write to `wacli.db` from a companion tool.
 
@@ -101,6 +101,15 @@ Recent WhatsApp call events:
 ```sql
 SELECT chat_jid, call_id, event_type, direction, media, outcome, duration_secs, ts
 FROM call_events
+ORDER BY ts DESC
+LIMIT 100;
+```
+
+Recent WhatsApp status broadcasts:
+
+```sql
+SELECT msg_id, sender_jid, sender_name, ts, text, media_type, media_caption
+FROM status_messages
 ORDER BY ts DESC
 LIMIT 100;
 ```

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -3,6 +3,7 @@
 Read when: listing, searching, exporting, showing, or inspecting local message context.
 
 Most `wacli messages` commands read from the local store. `messages edit` and `messages delete` are remote WhatsApp mutations and require an authenticated, writable store.
+WhatsApp status broadcasts are stored separately in `status_messages`; they are not returned by `messages list`, `messages search`, or `messages export`.
 
 ## Commands
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -26,7 +26,7 @@ Read when: you need the user-facing command map, global flags, store model, or l
 - [sync](sync.md) - sync messages, contacts, groups, channels, and optional media.
 - [messages](messages.md) - list, search, show, and contextualize stored messages.
 - [calls](calls.md) - list stored WhatsApp call events.
-- [send](send.md) - send text, files, stickers, replies, and reactions.
+- [send](send.md) - send text, files, stickers, statuses, replies, and reactions.
 - [media](media.md) - download media attached to stored messages.
 - [contacts](contacts.md) - search contacts and manage local aliases/tags.
 - [contacts import-system](contacts-import-system.md) - import macOS Contacts names into local contact metadata.
@@ -51,6 +51,7 @@ wacli auth
 wacli sync --follow
 wacli messages search "meeting"
 wacli send text --to mom --message "hello"
+wacli send status --message "available today"
 ```
 
 ## Recipient formats

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -85,9 +85,12 @@ wacli send voice --to 1234567890 --file ./voice.ogg
 
 # React (omit --reaction for the default thumbs-up; use --reaction "" to clear)
 wacli send react --to 1234567890 --id <message-id> --reaction "🎉"
+
+# Post a WhatsApp status broadcast
+wacli send status --message "available today" --background-color '#1f7a8c'
 ```
 
-Recipient resolution and disambiguation (`--pick N`, ambiguous-name prompts), link-preview behavior, and post-send waits are documented in [Send](send.md).
+Recipient resolution and disambiguation (`--pick N`, ambiguous-name prompts), link-preview behavior, status broadcasts, and post-send waits are documented in [Send](send.md).
 
 ## 6. Backfill older history (optional, best-effort)
 

--- a/docs/send.md
+++ b/docs/send.md
@@ -1,6 +1,6 @@
 # send
 
-Read when: sending text, files, stickers, polls, quoted replies, or reactions.
+Read when: sending text, files, stickers, polls, status broadcasts, quoted replies, or reactions.
 
 `wacli send` requires authentication, a live connection, and writable mode. Send attempts are bounded and retry once after reconnect for known stale-session/usync timeout failures. `Sent to ...` and JSON `sent: true` mean WhatsApp accepted the send request and returned a message ID; they do not confirm recipient delivery. After a successful send, wacli keeps the connection alive briefly so whatsmeow can handle retry receipts from devices that could not decrypt the first copy. Repeated send commands within 5 seconds print a stderr warning so tight loops make WhatsApp rate-limit/account-risk visible.
 
@@ -15,6 +15,7 @@ wacli send sticker --to RECIPIENT --file PATH [--pick N] [--reply-to MSG_ID] [--
 wacli send voice --to RECIPIENT --file PATH [--pick N] [--mime TYPE] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send react --to PHONE_OR_JID --id MSG_ID [--reaction TEXT] [--sender JID] [--post-send-wait 2s]
 wacli send poll --to RECIPIENT --question TEXT --option TEXT --option TEXT [--multi N] [--ephemeral] [--post-send-wait 2s]
+wacli send status [--message TEXT] [--file PATH] [--mime TYPE] [--background-color '#RRGGBB'] [--font N] [--post-send-wait 2s]
 wacli poll vote --to RECIPIENT --id MSG_ID --option TEXT [--option TEXT] [--sender JID] [--post-send-wait 2s]
 wacli poll show --to RECIPIENT --id MSG_ID [--json]
 wacli polls list [--chat RECIPIENT] [--limit N] [--json]
@@ -54,6 +55,16 @@ wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 - `poll show` prints current aggregates and per-voter selections from the local store.
 - `polls list` shows recently synced or sent polls, optionally filtered with `--chat`.
 
+## Status broadcasts
+
+- `send status` posts to WhatsApp's `status@broadcast` target.
+- `--message` or `--file` is required.
+- Text statuses use `--message`; media statuses use `--file` and can use `--message` as the caption.
+- Text statuses accept `--background-color` as `#RRGGBB` or `#AARRGGBB`.
+- Text statuses accept `--font N` to pass a WhatsApp text status font number.
+- Media statuses reuse the normal upload path, including MIME detection and `--mime` overrides.
+- Sent and synced statuses are stored in the local `status_messages` table, separate from normal chat `messages`.
+
 ## Files
 
 - File uploads are capped at 100 MiB.
@@ -84,6 +95,8 @@ wacli send sticker --to 1234567890 --file ./sticker-512.webp
 wacli send voice --to 1234567890 --file ./voice.ogg
 wacli send react --to 1234567890 --id ABC123 --reaction "❤️"
 wacli send poll --to "Family" --question "Dinner?" --option "Pizza" --option "Sushi" --multi 1
+wacli send status --message "available today" --background-color '#1f7a8c' --font 1
+wacli send status --file ./photo.jpg --message "new update"
 wacli poll vote --to "Family" --id ABC123 --option "Pizza"
 wacli poll show --to "Family" --id ABC123 --json
 wacli polls list --chat "Family" --limit 10

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -105,6 +105,9 @@ Immediately after QR pairing success, `wacli auth` runs a bootstrap sync:
 - `messages`
   - `rowid` (PK), `chat_jid`, `msg_id`, `sender_jid`, `ts`, `from_me`, `text`, `display_text`, `revoked`, `deleted_for_me`, `media_type`, `media_caption`, `filename`, `mime_type`, `direct_path`, hashes/keys, …
   - unique constraint: (`chat_jid`, `msg_id`)
+- `status_messages`
+  - `rowid` (PK), `msg_id` (unique), `ts`, `from_me`, `sender_jid`, `sender_name`, `text`, `media_type`, `media_caption`, `filename`, `mime_type`, `direct_path`, hashes/keys, `background_color`, `font`, …
+  - status broadcasts use WhatsApp's `status@broadcast` target and are kept out of normal chat `messages`.
 - `contact_aliases` (local management)
   - `jid` (PK/FK), `alias`, `notes`, `tags` (or join table)
 
@@ -208,12 +211,14 @@ WhatsApp Web history is best-effort. If you want to try fetching *older* message
 - `wacli send sticker --to RECIPIENT --file PATH [--pick N] [--reply-to MSG_ID] [--reply-to-sender JID]`
 - `wacli send voice --to RECIPIENT --file PATH [--mime TYPE] [--pick N] [--reply-to MSG_ID] [--reply-to-sender JID]`
 - `wacli send react --to PHONE_OR_JID --id MSG_ID [--reaction TEXT] [--sender JID]`
+- `wacli send status [--message TEXT] [--file PATH] [--mime TYPE] [--background-color '#RRGGBB'] [--font N]`
 
 `RECIPIENT` accepts a JID, phone number, channel JID (`...@newsletter`), or synced contact/group/chat name. If a name is ambiguous, interactive terminals prompt; scripts can pass `--pick N`.
 Sending to channels requires channel posting permission. File sends to channels use WhatsApp's unencrypted newsletter media upload and pass the returned media handle through `whatsmeow.SendRequestExtra`.
 Text sends automatically include a link preview for the first `http://` or `https://` URL unless `--no-preview` is passed.
 Voice notes require OGG/Opus audio and use optional `ffprobe`/`ffmpeg` metadata when available.
 Stickers require 512x512 WebP input and are stored locally as `sticker` media after sending. Static stickers are capped at 100 KiB; animated stickers are capped at 500 KiB and carry animation metadata in the outgoing proto.
+Status broadcasts are sent to `status@broadcast`; text statuses can carry background color and font metadata, and media statuses reuse the file upload path with optional captions.
 
 Send-file uploads and media downloads are capped at 100 MiB to avoid reading
 or writing unexpectedly large payloads in one command.

--- a/docs/store.md
+++ b/docs/store.md
@@ -20,7 +20,8 @@ wacli groups prune [--days N] [--left-only=false|--include-active] [--dry-run] [
 
 ## Notes
 
-- `store stats` reads local counts for chats, groups, left groups, and messages.
+- `store stats` reads local counts for chats, groups, left groups, and normal chat messages.
+- Status broadcasts are persisted separately in `status_messages`; they are not chat rows and are not included in normal chat/message cleanup paths.
 - `store cleanup` removes chats whose known local activity is older than `--days` and deletes their messages through the SQLite chat/message cascade.
 - `chats cleanup --jid JID` removes one local chat row and its local messages.
 - `groups prune` removes local group metadata plus the matching local chat/messages for pruned group JIDs.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -31,6 +31,7 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--max-mes
 - After connecting, sync fetches WhatsApp chat app-state deltas (`regular_high` and `regular_low`) so starred, delete-for-me, mute, archive, pin, and mark-read changes made while `wacli` was offline are caught up instead of relying only on live push notifications.
 - If whatsmeow reports an app-state LTHash mismatch, sync asks the primary device for the official recovery snapshot once for that app-state collection. If recovery also fails, the warning is printed and sync keeps handling normal message/history events.
 - Sync stores WhatsApp call signaling and call-log metadata in `call_events`; inspect it with `wacli calls list`.
+- Sync stores WhatsApp status broadcasts in `status_messages`, separate from normal chat `messages`.
 - In an interactive terminal, routine connected/history/progress updates share one updating stderr status line. Warnings and errors still print as separate lines so they remain visible.
 - `--events` emits one NDJSON lifecycle event per stderr line for machine consumers. Routine human progress/status lines, interrupt prompts, and command errors are emitted as events while events are enabled.
 

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -297,8 +297,10 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 	pm.Chat = a.canonicalStoreJID(ctx, pm.Chat)
 	chatJID := canonicalJIDString(pm.Chat)
 	chatName := a.wa.ResolveChatName(ctx, pm.Chat, pm.PushName)
-	if err := a.db.UpsertChat(chatJID, chatKind(pm.Chat), chatName, pm.Timestamp); err != nil {
-		return err
+	if pm.Chat != types.StatusBroadcastJID {
+		if err := a.db.UpsertChat(chatJID, chatKind(pm.Chat), chatName, pm.Timestamp); err != nil {
+			return err
+		}
 	}
 
 	// Best-effort: store contact info for DMs.
@@ -378,6 +380,26 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 		fileSha = pm.Media.FileSHA256
 		fileEncSha = pm.Media.FileEncSHA256
 		fileLen = pm.Media.FileLength
+	}
+
+	if pm.Chat == types.StatusBroadcastJID {
+		return a.db.UpsertStatusMessage(store.UpsertStatusMessageParams{
+			MsgID:         pm.ID,
+			Timestamp:     pm.Timestamp,
+			FromMe:        pm.FromMe,
+			SenderJID:     senderJID,
+			SenderName:    senderName,
+			Text:          pm.Text,
+			MediaType:     mediaType,
+			MediaCaption:  caption,
+			Filename:      filename,
+			MimeType:      mimeType,
+			DirectPath:    directPath,
+			MediaKey:      mediaKey,
+			FileSHA256:    fileSha,
+			FileEncSHA256: fileEncSha,
+			FileLength:    fileLen,
+		})
 	}
 
 	displayText := a.buildDisplayText(ctx, pm)

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -775,6 +775,33 @@ func TestSyncDownloadsHistoryNotificationBeforeProcessing(t *testing.T) {
 	}
 }
 
+func TestStoreParsedStatusMessageUsesSeparateStatusTable(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	err := a.storeParsedMessage(context.Background(), wa.ParsedMessage{
+		Chat:      types.StatusBroadcastJID,
+		ID:        "status-incoming",
+		SenderJID: "15551234567@s.whatsapp.net",
+		Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		Text:      "incoming status",
+	})
+	if err != nil {
+		t.Fatalf("storeParsedMessage: %v", err)
+	}
+	if _, err := a.db.GetMessage(types.StatusBroadcastJID.String(), "status-incoming"); err == nil {
+		t.Fatalf("status retrieval was stored as a regular message")
+	}
+	status, err := a.db.GetStatusMessage("status-incoming")
+	if err != nil {
+		t.Fatalf("GetStatusMessage: %v", err)
+	}
+	if status.MsgID != "status-incoming" || status.Text != "incoming status" || status.SenderJID != "15551234567@s.whatsapp.net" {
+		t.Fatalf("unexpected status retrieval: %+v", status)
+	}
+}
+
 func TestStoreParsedMessageNormalizesDefaultUserADJIDs(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -30,6 +30,7 @@ var schemaMigrations = []migration{
 	{version: 14, name: "polls and poll_votes", up: migratePolls},
 	{version: 15, name: "call events", up: migrateCallEvents},
 	{version: 16, name: "messages edited columns", up: migrateMessagesEditedColumns},
+	{version: 17, name: "status messages", up: migrateStatusMessages},
 }
 
 func (d *DB) ensureSchema() error {
@@ -93,6 +94,9 @@ func (d *DB) ensureCurrentSchema() error {
 	}
 	if err := migrateMessagesEditedColumns(d); err != nil {
 		return fmt.Errorf("ensure current messages edited columns: %w", err)
+	}
+	if err := migrateStatusMessages(d); err != nil {
+		return fmt.Errorf("ensure current status messages schema: %w", err)
 	}
 	return nil
 }
@@ -374,6 +378,35 @@ func migrateCallEvents(d *DB) error {
 		return fmt.Errorf("create call_events table: %w", err)
 	}
 	return nil
+}
+
+func migrateStatusMessages(d *DB) error {
+	if _, err := d.sql.Exec(`
+		CREATE TABLE IF NOT EXISTS status_messages (
+			rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+			msg_id TEXT NOT NULL UNIQUE,
+			ts INTEGER NOT NULL,
+			from_me INTEGER NOT NULL,
+			sender_jid TEXT,
+			sender_name TEXT,
+			text TEXT,
+			media_type TEXT,
+			media_caption TEXT,
+			filename TEXT,
+			mime_type TEXT,
+			direct_path TEXT,
+			media_key BLOB,
+			file_sha256 BLOB,
+			file_enc_sha256 BLOB,
+			file_length INTEGER,
+			background_color TEXT,
+			font INTEGER
+		);
+		CREATE INDEX IF NOT EXISTS idx_status_messages_ts ON status_messages(ts);
+	`); err != nil {
+		return fmt.Errorf("create status_messages table: %w", err)
+	}
+	return migrateStatusMessageMediaColumns(d)
 }
 
 func migrateContactsSystemNameColumn(d *DB) error {

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -157,7 +157,7 @@ func migrateCoreSchema(d *DB) error {
 	if _, err := d.sql.Exec(coreSchemaSQL); err != nil {
 		return fmt.Errorf("create tables: %w", err)
 	}
-	if err := migrateStatusMessageMediaColumns(d); err != nil {
+	if err := migrateStatusMessages(d); err != nil {
 		return err
 	}
 	return nil

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -96,6 +96,28 @@ const coreSchemaSQL = `
 	CREATE INDEX IF NOT EXISTS idx_messages_chat_ts ON messages(chat_jid, ts);
 	CREATE INDEX IF NOT EXISTS idx_messages_ts ON messages(ts);
 
+	CREATE TABLE IF NOT EXISTS status_messages (
+		rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+		msg_id TEXT NOT NULL UNIQUE,
+		ts INTEGER NOT NULL,
+		from_me INTEGER NOT NULL,
+		sender_jid TEXT,
+		sender_name TEXT,
+		text TEXT,
+		media_type TEXT,
+		media_caption TEXT,
+		filename TEXT,
+		mime_type TEXT,
+		direct_path TEXT,
+		media_key BLOB,
+		file_sha256 BLOB,
+		file_enc_sha256 BLOB,
+		file_length INTEGER,
+		background_color TEXT,
+		font INTEGER
+	);
+	CREATE INDEX IF NOT EXISTS idx_status_messages_ts ON status_messages(ts);
+
 	CREATE TABLE IF NOT EXISTS call_events (
 		rowid INTEGER PRIMARY KEY AUTOINCREMENT,
 		chat_jid TEXT NOT NULL,
@@ -134,6 +156,39 @@ const coreSchemaSQL = `
 func migrateCoreSchema(d *DB) error {
 	if _, err := d.sql.Exec(coreSchemaSQL); err != nil {
 		return fmt.Errorf("create tables: %w", err)
+	}
+	if err := migrateStatusMessageMediaColumns(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+func migrateStatusMessageMediaColumns(d *DB) error {
+	columns := []struct {
+		name string
+		sql  string
+	}{
+		{"sender_jid", `ALTER TABLE status_messages ADD COLUMN sender_jid TEXT`},
+		{"sender_name", `ALTER TABLE status_messages ADD COLUMN sender_name TEXT`},
+		{"filename", `ALTER TABLE status_messages ADD COLUMN filename TEXT`},
+		{"mime_type", `ALTER TABLE status_messages ADD COLUMN mime_type TEXT`},
+		{"direct_path", `ALTER TABLE status_messages ADD COLUMN direct_path TEXT`},
+		{"media_key", `ALTER TABLE status_messages ADD COLUMN media_key BLOB`},
+		{"file_sha256", `ALTER TABLE status_messages ADD COLUMN file_sha256 BLOB`},
+		{"file_enc_sha256", `ALTER TABLE status_messages ADD COLUMN file_enc_sha256 BLOB`},
+		{"file_length", `ALTER TABLE status_messages ADD COLUMN file_length INTEGER`},
+	}
+	for _, col := range columns {
+		has, err := d.tableHasColumn("status_messages", col.name)
+		if err != nil {
+			return fmt.Errorf("inspect status_messages.%s: %w", col.name, err)
+		}
+		if has {
+			continue
+		}
+		if _, err := d.sql.Exec(col.sql); err != nil {
+			return fmt.Errorf("add status_messages.%s: %w", col.name, err)
+		}
 	}
 	return nil
 }

--- a/internal/store/schema_test.go
+++ b/internal/store/schema_test.go
@@ -86,6 +86,19 @@ func TestOpenCreatesExpectedSchema(t *testing.T) {
 	if !contactCols["system_name"] {
 		t.Fatalf("expected contacts system_name column to exist")
 	}
+
+	statusCols, err := tableColumns(db.sql, "status_messages")
+	if err != nil {
+		t.Fatalf("status_messages tableColumns: %v", err)
+	}
+	for _, want := range []string{"msg_id", "ts", "from_me", "sender_jid", "media_key", "background_color", "font"} {
+		if !statusCols[want] {
+			t.Fatalf("expected status_messages column %q to exist", want)
+		}
+	}
+	if !indexExists(t, db.sql, "idx_status_messages_ts") {
+		t.Fatalf("expected status_messages timestamp index to exist")
+	}
 }
 
 func TestOpenRepairsRecordedCallEventsMigrationMissingTable(t *testing.T) {
@@ -291,6 +304,59 @@ func TestOpenMigratesContactsSystemNameColumn(t *testing.T) {
 	}
 	if !contactCols["system_name"] {
 		t.Fatalf("expected migrated contacts system_name column")
+	}
+}
+
+func TestOpenMigratesStatusMessagesTable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wacli.db")
+
+	raw, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	if _, err := raw.Exec(`
+		CREATE TABLE schema_migrations (
+			version INTEGER PRIMARY KEY,
+			name TEXT NOT NULL,
+			applied_at INTEGER NOT NULL
+		);
+	`); err != nil {
+		_ = raw.Close()
+		t.Fatalf("create old schema: %v", err)
+	}
+	for _, m := range schemaMigrations {
+		if m.version >= 17 {
+			continue
+		}
+		if _, err := raw.Exec(`INSERT INTO schema_migrations(version, name, applied_at) VALUES(?, ?, 1)`, m.version, m.name); err != nil {
+			_ = raw.Close()
+			t.Fatalf("mark migration %d: %v", m.version, err)
+		}
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw close: %v", err)
+	}
+
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open migrated DB: %v", err)
+	}
+	defer db.Close()
+
+	if ok, err := db.tableExists("status_messages"); err != nil || !ok {
+		t.Fatalf("status_messages exists=%v err=%v", ok, err)
+	}
+	if !indexExists(t, db.sql, "idx_status_messages_ts") {
+		t.Fatalf("expected status_messages timestamp index to exist")
+	}
+	if err := db.UpsertStatusMessage(UpsertStatusMessageParams{
+		MsgID:     "status-after-upgrade",
+		Timestamp: nowUTC(),
+		FromMe:    true,
+		Text:      "after upgrade",
+	}); err != nil {
+		t.Fatalf("UpsertStatusMessage after migration: %v", err)
 	}
 }
 

--- a/internal/store/status_messages.go
+++ b/internal/store/status_messages.go
@@ -1,0 +1,109 @@
+package store
+
+import (
+	"database/sql"
+	"strings"
+	"time"
+)
+
+type StatusMessage struct {
+	RowID           int64
+	MsgID           string
+	Timestamp       time.Time
+	FromMe          bool
+	SenderJID       string
+	SenderName      string
+	Text            string
+	MediaType       string
+	MediaCaption    string
+	Filename        string
+	MimeType        string
+	DirectPath      string
+	MediaKey        []byte
+	FileSHA256      []byte
+	FileEncSHA256   []byte
+	FileLength      uint64
+	BackgroundColor string
+	Font            int32
+}
+
+type UpsertStatusMessageParams struct {
+	MsgID           string
+	Timestamp       time.Time
+	FromMe          bool
+	SenderJID       string
+	SenderName      string
+	Text            string
+	MediaType       string
+	MediaCaption    string
+	Filename        string
+	MimeType        string
+	DirectPath      string
+	MediaKey        []byte
+	FileSHA256      []byte
+	FileEncSHA256   []byte
+	FileLength      uint64
+	BackgroundColor string
+	Font            int32
+}
+
+func (d *DB) UpsertStatusMessage(p UpsertStatusMessageParams) error {
+	_, err := d.sql.Exec(`
+		INSERT INTO status_messages(
+			msg_id, ts, from_me, sender_jid, sender_name, text,
+			media_type, media_caption, filename, mime_type, direct_path,
+			media_key, file_sha256, file_enc_sha256, file_length,
+			background_color, font
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(msg_id) DO UPDATE SET
+			ts=excluded.ts,
+			from_me=excluded.from_me,
+			sender_jid=excluded.sender_jid,
+			sender_name=excluded.sender_name,
+			text=excluded.text,
+			media_type=excluded.media_type,
+			media_caption=excluded.media_caption,
+			filename=excluded.filename,
+			mime_type=excluded.mime_type,
+			direct_path=excluded.direct_path,
+			media_key=excluded.media_key,
+			file_sha256=excluded.file_sha256,
+			file_enc_sha256=excluded.file_enc_sha256,
+			file_length=excluded.file_length,
+			background_color=excluded.background_color,
+			font=excluded.font
+	`, p.MsgID, unix(p.Timestamp), boolToInt(p.FromMe), nullIfEmpty(p.SenderJID), nullIfEmpty(p.SenderName), nullIfEmpty(p.Text),
+		nullIfEmpty(p.MediaType), nullIfEmpty(p.MediaCaption), nullIfEmpty(p.Filename), nullIfEmpty(p.MimeType), nullIfEmpty(p.DirectPath),
+		p.MediaKey, p.FileSHA256, p.FileEncSHA256, int64(p.FileLength), nullIfEmpty(p.BackgroundColor), int64(p.Font))
+	return err
+}
+
+func (d *DB) GetStatusMessage(msgID string) (StatusMessage, error) {
+	row := d.sql.QueryRow(`
+		SELECT rowid, msg_id, ts, from_me,
+			COALESCE(sender_jid,''), COALESCE(sender_name,''), COALESCE(text,''),
+			COALESCE(media_type,''), COALESCE(media_caption,''), COALESCE(filename,''),
+			COALESCE(mime_type,''), COALESCE(direct_path,''), media_key, file_sha256,
+			file_enc_sha256, COALESCE(file_length,0), COALESCE(background_color,''), COALESCE(font,0)
+		FROM status_messages
+		WHERE msg_id = ?
+	`, strings.TrimSpace(msgID))
+	var out StatusMessage
+	var ts int64
+	var fromMe int
+	var font int64
+	var fileLength int64
+	if err := row.Scan(&out.RowID, &out.MsgID, &ts, &fromMe, &out.SenderJID, &out.SenderName, &out.Text,
+		&out.MediaType, &out.MediaCaption, &out.Filename, &out.MimeType, &out.DirectPath,
+		&out.MediaKey, &out.FileSHA256, &out.FileEncSHA256, &fileLength, &out.BackgroundColor, &font); err != nil {
+		if err == sql.ErrNoRows {
+			return StatusMessage{}, sql.ErrNoRows
+		}
+		return StatusMessage{}, err
+	}
+	out.Timestamp = time.Unix(ts, 0).UTC()
+	out.FromMe = fromMe != 0
+	out.Font = int32(font)
+	out.FileLength = uint64(fileLength)
+	return out, nil
+}

--- a/internal/store/status_messages_test.go
+++ b/internal/store/status_messages_test.go
@@ -1,0 +1,73 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStatusMessagesStoredSeparatelyFromMessages(t *testing.T) {
+	db := openTestDB(t)
+	ts := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+
+	if err := db.UpsertStatusMessage(UpsertStatusMessageParams{
+		MsgID:           "status-1",
+		Timestamp:       ts,
+		FromMe:          true,
+		Text:            "test",
+		BackgroundColor: "#ff00aa",
+		Font:            2,
+	}); err != nil {
+		t.Fatalf("UpsertStatusMessage: %v", err)
+	}
+	if err := db.UpsertStatusMessage(UpsertStatusMessageParams{
+		MsgID:     "status-1",
+		Timestamp: ts.Add(time.Minute),
+		FromMe:    true,
+		Text:      "test edited locally",
+	}); err != nil {
+		t.Fatalf("UpsertStatusMessage duplicate: %v", err)
+	}
+
+	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM messages WHERE msg_id = ?", "status-1"); got != 0 {
+		t.Fatalf("expected no regular message rows, got %d", got)
+	}
+	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM status_messages WHERE msg_id = ?", "status-1"); got != 1 {
+		t.Fatalf("expected one status message row, got %d", got)
+	}
+	status, err := db.GetStatusMessage("status-1")
+	if err != nil {
+		t.Fatalf("GetStatusMessage: %v", err)
+	}
+	if status.MsgID != "status-1" || status.Text != "test edited locally" || !status.FromMe {
+		t.Fatalf("unexpected status message: %+v", status)
+	}
+}
+
+func TestStatusMessageStoresMediaMetadata(t *testing.T) {
+	db := openTestDB(t)
+	ts := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	if err := db.UpsertStatusMessage(UpsertStatusMessageParams{
+		MsgID:         "status-media",
+		Timestamp:     ts,
+		FromMe:        true,
+		Text:          "caption",
+		MediaType:     "image",
+		MediaCaption:  "caption",
+		Filename:      "photo.jpg",
+		MimeType:      "image/jpeg",
+		DirectPath:    "/media/path",
+		MediaKey:      []byte("key"),
+		FileSHA256:    []byte("sha"),
+		FileEncSHA256: []byte("enc"),
+		FileLength:    123,
+	}); err != nil {
+		t.Fatalf("UpsertStatusMessage: %v", err)
+	}
+	status, err := db.GetStatusMessage("status-media")
+	if err != nil {
+		t.Fatalf("GetStatusMessage: %v", err)
+	}
+	if status.MediaType != "image" || status.Filename != "photo.jpg" || status.MimeType != "image/jpeg" || status.DirectPath != "/media/path" || status.FileLength != 123 {
+		t.Fatalf("unexpected media status metadata: %+v", status)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `wacli send status` for WhatsApp status broadcasts via `status@broadcast`.
- Support text statuses with optional background color and font metadata.
- Support media statuses with `--file`, optional `--mime`, and `--message` as the media caption.
- Persist synced and locally sent statuses in a dedicated `status_messages` table, including sender fields, media metadata, and text-status styling fields.
- Keep statuses out of normal chat rows and `messages` list/search/export behavior.
- Update the changelog, README, send docs, quickstart, overview, spec, store/sync notes, and integration SQL examples for the new status behavior.

## Test Plan
- `go test ./cmd/wacli ./internal/store ./internal/app`
- `node scripts/build-docs-site.mjs`
- `git diff --check upstream/main..HEAD`

## Notes
- Status sends use WhatsApp status privacy. Targeted recipient selection is not exposed as a CLI flag in this PR.
- Full `pnpm test` was run earlier and still fails on `internal/fsutil TestEnsureWritableDirRejectsNonWritableDir` when executed as root, because root can write to the chmod-restricted test directory. The status-related cmd/store/app tests pass.