### PR TITLE
fix: align poll compatibility handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - History: unwrap edited WhatsApp messages during history sync and backfill so stored/searchable text shows the edited body instead of `(message)`. (#246 - thanks @hiasinho)
+- Polls: use WhatsApp's single-select poll creation field for outbound single-select polls and preserve unmatched poll vote hashes in `poll show --json`.
 - Sync: canonicalize `@lid` chat JIDs before enqueuing media downloads so `sync --follow --download-media` finds the correct DB row for live one-to-one messages. (#244 - thanks @Daniel1of1)
 
 ## 0.9.1 - 2026-05-15

--- a/cmd/wacli/poll_cmd.go
+++ b/cmd/wacli/poll_cmd.go
@@ -494,10 +494,11 @@ func aggregatePollVotes(options []string, votes []store.PollVote) map[string]int
 }
 
 type pollVoterPayload struct {
-	JID      string   `json:"jid"`
-	Name     string   `json:"name,omitempty"`
-	Selected []string `json:"selected"`
-	VotedAt  string   `json:"voted_at"`
+	JID           string   `json:"jid"`
+	Name          string   `json:"name,omitempty"`
+	Selected      []string `json:"selected"`
+	UnknownHashes []string `json:"unknown_hashes,omitempty"`
+	VotedAt       string   `json:"voted_at"`
 }
 
 type pollShowJSON struct {
@@ -527,10 +528,11 @@ func pollShowPayload(a *app.App, ctx context.Context, poll store.Poll, votes []s
 	for _, v := range votes {
 		name := resolveVoterName(a, ctx, v.VoterJID)
 		out.Voters = append(out.Voters, pollVoterPayload{
-			JID:      v.VoterJID,
-			Name:     name,
-			Selected: v.Selected,
-			VotedAt:  v.VotedAt.Format(time.RFC3339),
+			JID:           v.VoterJID,
+			Name:          name,
+			Selected:      v.Selected,
+			UnknownHashes: v.UnknownHashes,
+			VotedAt:       v.VotedAt.Format(time.RFC3339),
 		})
 	}
 	return out

--- a/cmd/wacli/send_poll_test.go
+++ b/cmd/wacli/send_poll_test.go
@@ -308,3 +308,34 @@ func TestGetPollForShowFindsNonADChat(t *testing.T) {
 		t.Fatalf("votes = %+v", votes)
 	}
 }
+
+func TestPollShowPayloadIncludesUnknownVoteHashes(t *testing.T) {
+	poll := store.Poll{
+		ChatJID:         "chat@s.whatsapp.net",
+		MsgID:           "poll-id",
+		Question:        "Dinner?",
+		Options:         []string{"Yes", "No"},
+		SelectableCount: 1,
+		CreatedAt:       time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC),
+	}
+	votes := []store.PollVote{{
+		ChatJID:       poll.ChatJID,
+		PollMsgID:     poll.MsgID,
+		VoterJID:      "15557654321@s.whatsapp.net",
+		VoteMsgID:     "vote-id",
+		Selected:      []string{"Yes"},
+		UnknownHashes: []string{"001122"},
+		VotedAt:       time.Date(2026, 5, 9, 12, 1, 0, 0, time.UTC),
+	}}
+
+	payload := pollShowPayload(nil, context.Background(), poll, votes, aggregatePollVotes(poll.Options, votes))
+	if len(payload.Voters) != 1 {
+		t.Fatalf("voter count = %d", len(payload.Voters))
+	}
+	if !reflect.DeepEqual(payload.Voters[0].UnknownHashes, []string{"001122"}) {
+		t.Fatalf("unknown hashes = %#v", payload.Voters[0].UnknownHashes)
+	}
+	if payload.Aggregates["Yes"] != 1 || payload.Aggregates["No"] != 0 {
+		t.Fatalf("aggregates = %#v", payload.Aggregates)
+	}
+}

--- a/docs/send.md
+++ b/docs/send.md
@@ -49,10 +49,11 @@ wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 
 - `send poll` accepts 2-12 repeatable `--option` values.
 - `--multi N` sets how many options a voter may select. The default is `1`.
+- Outbound single-select polls use WhatsApp's V3 poll creation field. Multi-select polls use the base poll creation field. Community announcement groups use V2 when live group metadata identifies the target as both announce-only and a community parent.
 - Incoming polls and poll votes are stored during sync in the local poll tables.
 - `poll vote` validates selected options when the original poll is present in the local store.
 - For unsynced group polls, pass `--sender` with the poll author's JID.
-- `poll show` prints current aggregates and per-voter selections from the local store.
+- `poll show` prints current aggregates and per-voter selections from the local store. JSON output includes `unknown_hashes` for vote hashes that could not be matched to a stored option.
 - `polls list` shows recently synced or sent polls, optionally filtered with `--chat`.
 
 ## Status broadcasts

--- a/internal/app/sync_polls.go
+++ b/internal/app/sync_polls.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -327,12 +328,13 @@ func (a *App) handlePollVote(ctx context.Context, pm wa.ParsedMessage, evt *even
 	}
 
 	if err := a.db.UpsertPollVote(store.PollVote{
-		ChatJID:   chatJID,
-		PollMsgID: pollMsgID,
-		VoterJID:  voterJID,
-		VoteMsgID: pm.ID,
-		Selected:  selected,
-		VotedAt:   votedAt,
+		ChatJID:       chatJID,
+		PollMsgID:     pollMsgID,
+		VoterJID:      voterJID,
+		VoteMsgID:     pm.ID,
+		Selected:      selected.Selected,
+		UnknownHashes: selected.UnknownHashes,
+		VotedAt:       votedAt,
 	}); err != nil {
 		a.emitWarning(
 			"poll_vote_store_failed",
@@ -417,21 +419,30 @@ func resolvePollAddKey(pm wa.ParsedMessage, add *wa.PollAddOptionRef) (string, s
 	return chatJID, pollMsgID, nil
 }
 
+type pollOptionMatches struct {
+	Selected      []string
+	UnknownHashes []string
+}
+
 // matchPollOptions maps SHA-256 vote hashes back to option names by hashing
 // the stored option list (whatsmeow.HashPollOptions) and matching by bytes.
-// Unknown hashes are dropped silently.
-func matchPollOptions(stored []string, hashes [][]byte) []string {
+func matchPollOptions(stored []string, hashes [][]byte) pollOptionMatches {
 	if len(hashes) == 0 {
-		return []string{}
+		return pollOptionMatches{Selected: []string{}}
 	}
 	storedHashes := whatsmeow.HashPollOptions(stored)
-	out := make([]string, 0, len(hashes))
+	out := pollOptionMatches{Selected: make([]string, 0, len(hashes))}
 	for _, h := range hashes {
+		matched := false
 		for i, sh := range storedHashes {
 			if bytes.Equal(h, sh) {
-				out = append(out, stored[i])
+				out.Selected = append(out.Selected, stored[i])
+				matched = true
 				break
 			}
+		}
+		if !matched {
+			out.UnknownHashes = append(out.UnknownHashes, hex.EncodeToString(h))
 		}
 	}
 	return out

--- a/internal/app/sync_polls_test.go
+++ b/internal/app/sync_polls_test.go
@@ -486,6 +486,19 @@ func TestLiveSyncDecryptsAndStoresPollVote(t *testing.T) {
 	_ = options
 }
 
+func TestMatchPollOptionsPreservesUnknownHashes(t *testing.T) {
+	knownHash := whatsmeow.HashPollOptions([]string{"Yes"})[0]
+	unknownHash := []byte{0, 1, 2, 3}
+
+	matched := matchPollOptions([]string{"Yes", "No"}, [][]byte{knownHash, unknownHash})
+	if !sameStringSet(matched.Selected, []string{"Yes"}) {
+		t.Fatalf("selected = %v", matched.Selected)
+	}
+	if !sameStringSet(matched.UnknownHashes, []string{"00010203"}) {
+		t.Fatalf("unknown hashes = %v", matched.UnknownHashes)
+	}
+}
+
 func TestLiveSyncKeepsNewerSameSecondPollVote(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/store/polls.go
+++ b/internal/store/polls.go
@@ -24,12 +24,13 @@ type Poll struct {
 
 // PollVote represents one voter's latest vote on a poll.
 type PollVote struct {
-	ChatJID   string
-	PollMsgID string
-	VoterJID  string
-	VoteMsgID string
-	Selected  []string
-	VotedAt   time.Time
+	ChatJID       string
+	PollMsgID     string
+	VoterJID      string
+	VoteMsgID     string
+	Selected      []string
+	UnknownHashes []string
+	VotedAt       time.Time
 }
 
 // PollListFilter narrows down polls returned by ListPolls.
@@ -222,7 +223,7 @@ func (d *DB) UpsertPollVote(v PollVote) error {
 	if v.Selected == nil {
 		v.Selected = []string{}
 	}
-	selJSON, err := json.Marshal(v.Selected)
+	selJSON, err := marshalPollVoteSelection(v)
 	if err != nil {
 		return fmt.Errorf("marshal selected: %w", err)
 	}
@@ -393,11 +394,46 @@ func pollVotesFromRows(rows []storedb.PollVote) ([]PollVote, error) {
 			VotedAt:   time.UnixMilli(row.Ts).UTC(),
 		}
 		if row.SelectedOptionsJson != "" {
-			if err := json.Unmarshal([]byte(row.SelectedOptionsJson), &v.Selected); err != nil {
+			if err := unmarshalPollVoteSelection(row.SelectedOptionsJson, &v); err != nil {
 				return nil, fmt.Errorf("unmarshal selected: %w", err)
 			}
 		}
 		out = append(out, v)
 	}
 	return out, nil
+}
+
+type pollVoteSelectionJSON struct {
+	Selected      []string `json:"selected"`
+	UnknownHashes []string `json:"unknown_hashes,omitempty"`
+}
+
+func marshalPollVoteSelection(v PollVote) (string, error) {
+	if len(v.UnknownHashes) == 0 {
+		raw, err := json.Marshal(v.Selected)
+		return string(raw), err
+	}
+	raw, err := json.Marshal(pollVoteSelectionJSON{
+		Selected:      v.Selected,
+		UnknownHashes: v.UnknownHashes,
+	})
+	return string(raw), err
+}
+
+func unmarshalPollVoteSelection(raw string, v *PollVote) error {
+	var selected []string
+	if err := json.Unmarshal([]byte(raw), &selected); err == nil {
+		v.Selected = selected
+		return nil
+	}
+	var wrapped pollVoteSelectionJSON
+	if err := json.Unmarshal([]byte(raw), &wrapped); err != nil {
+		return err
+	}
+	v.Selected = wrapped.Selected
+	v.UnknownHashes = wrapped.UnknownHashes
+	if v.Selected == nil {
+		v.Selected = []string{}
+	}
+	return nil
 }

--- a/internal/store/polls_test.go
+++ b/internal/store/polls_test.go
@@ -147,6 +147,33 @@ func TestUpsertPollVoteReplacesPriorVote(t *testing.T) {
 	}
 }
 
+func TestUpsertPollVoteRoundTripsUnknownHashes(t *testing.T) {
+	db := openTestDB(t)
+
+	in := PollVote{
+		ChatJID:       "chat@s.whatsapp.net",
+		PollMsgID:     "P1",
+		VoterJID:      "voter@s.whatsapp.net",
+		VoteMsgID:     "V1",
+		Selected:      []string{"known"},
+		UnknownHashes: []string{"001122"},
+		VotedAt:       time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	if err := db.UpsertPollVote(in); err != nil {
+		t.Fatal(err)
+	}
+	votes, err := db.ListPollVotes(in.ChatJID, in.PollMsgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(votes) != 1 {
+		t.Fatalf("vote count = %d", len(votes))
+	}
+	if !reflect.DeepEqual(votes[0].Selected, in.Selected) || !reflect.DeepEqual(votes[0].UnknownHashes, in.UnknownHashes) {
+		t.Fatalf("vote = %+v", votes[0])
+	}
+}
+
 func TestUpsertPollVoteKeepsNewerVote(t *testing.T) {
 	db := openTestDB(t)
 

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -2,6 +2,7 @@ package wa
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"os"
 	"strings"
@@ -248,7 +249,11 @@ func (c *Client) SendPoll(ctx context.Context, to types.JID, name string, option
 	if cli == nil || !cli.IsConnected() {
 		return "", fmt.Errorf("not connected")
 	}
-	msg := cli.BuildPollCreation(name, options, selectable)
+	var groupInfo *types.GroupInfo
+	if to.Server == types.GroupServer {
+		groupInfo, _ = cli.GetGroupInfo(ctx, to)
+	}
+	msg := buildPollCreationMessage(name, options, selectable, isCommunityAnnouncementGroup(groupInfo))
 	if ephemeral {
 		msg = wrapEphemeralPollMessage(msg)
 	}
@@ -257,6 +262,54 @@ func (c *Client) SendPoll(ctx context.Context, to types.JID, name string, option
 		return "", err
 	}
 	return resp.ID, nil
+}
+
+func buildPollCreationMessage(name string, optionNames []string, selectableOptionCount int, toAnnouncementGroup bool) *waE2E.Message {
+	msgSecret := make([]byte, 32)
+	_, _ = rand.Read(msgSecret)
+	if selectableOptionCount < 0 || selectableOptionCount > len(optionNames) {
+		selectableOptionCount = 0
+	}
+	options := make([]*waE2E.PollCreationMessage_Option, len(optionNames))
+	for i, option := range optionNames {
+		options[i] = &waE2E.PollCreationMessage_Option{OptionName: proto.String(option)}
+	}
+	creation := &waE2E.PollCreationMessage{
+		Name:                   proto.String(name),
+		Options:                options,
+		SelectableOptionsCount: proto.Uint32(uint32(selectableOptionCount)),
+	}
+	msg := &waE2E.Message{
+		MessageContextInfo: &waE2E.MessageContextInfo{
+			MessageSecret: msgSecret,
+		},
+	}
+	switch {
+	case toAnnouncementGroup:
+		msg.PollCreationMessageV2 = creation
+	case selectableOptionCount == 1:
+		msg.PollCreationMessageV3 = creation
+	default:
+		msg.PollCreationMessage = creation
+	}
+	return msg
+}
+
+func isCommunityAnnouncementGroup(info *types.GroupInfo) bool {
+	return info != nil && info.IsAnnounce && info.IsParent
+}
+
+func pickOutboundPollCreation(msg *waE2E.Message) *waE2E.PollCreationMessage {
+	if msg == nil {
+		return nil
+	}
+	if msg.GetPollCreationMessage() != nil {
+		return msg.GetPollCreationMessage()
+	}
+	if msg.GetPollCreationMessageV2() != nil {
+		return msg.GetPollCreationMessageV2()
+	}
+	return msg.GetPollCreationMessageV3()
 }
 
 func wrapEphemeralPollMessage(msg *waE2E.Message) *waE2E.Message {

--- a/internal/wa/client_test.go
+++ b/internal/wa/client_test.go
@@ -86,6 +86,67 @@ func TestWrapEphemeralPollMessagePreservesSecretOnOuterMessage(t *testing.T) {
 	}
 }
 
+func TestBuildPollCreationMessageSelectsVersion(t *testing.T) {
+	tests := []struct {
+		name           string
+		selectable     int
+		announcement   bool
+		wantBase       bool
+		wantV2         bool
+		wantV3         bool
+		wantSelectable uint32
+	}{
+		{name: "multi base", selectable: 2, wantBase: true, wantSelectable: 2},
+		{name: "single v3", selectable: 1, wantV3: true, wantSelectable: 1},
+		{name: "announcement v2", selectable: 1, announcement: true, wantV2: true, wantSelectable: 1},
+		{name: "zero stays base", selectable: 0, wantBase: true, wantSelectable: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := buildPollCreationMessage("Lunch?", []string{"A", "B"}, tt.selectable, tt.announcement)
+			if got := msg.GetPollCreationMessage() != nil; got != tt.wantBase {
+				t.Fatalf("base = %t, want %t", got, tt.wantBase)
+			}
+			if got := msg.GetPollCreationMessageV2() != nil; got != tt.wantV2 {
+				t.Fatalf("v2 = %t, want %t", got, tt.wantV2)
+			}
+			if got := msg.GetPollCreationMessageV3() != nil; got != tt.wantV3 {
+				t.Fatalf("v3 = %t, want %t", got, tt.wantV3)
+			}
+			creation := pickOutboundPollCreation(msg)
+			if creation.GetName() != "Lunch?" {
+				t.Fatalf("name = %q", creation.GetName())
+			}
+			if got := creation.GetSelectableOptionsCount(); got != tt.wantSelectable {
+				t.Fatalf("selectable = %d, want %d", got, tt.wantSelectable)
+			}
+			if len(msg.GetMessageContextInfo().GetMessageSecret()) != 32 {
+				t.Fatalf("message secret length = %d, want 32", len(msg.GetMessageContextInfo().GetMessageSecret()))
+			}
+		})
+	}
+}
+
+func TestIsCommunityAnnouncementGroup(t *testing.T) {
+	tests := []struct {
+		name string
+		info *types.GroupInfo
+		want bool
+	}{
+		{name: "nil"},
+		{name: "regular announce", info: &types.GroupInfo{GroupAnnounce: types.GroupAnnounce{IsAnnounce: true}}},
+		{name: "community parent not announce", info: &types.GroupInfo{GroupParent: types.GroupParent{IsParent: true}}},
+		{name: "community announcement", info: &types.GroupInfo{GroupAnnounce: types.GroupAnnounce{IsAnnounce: true}, GroupParent: types.GroupParent{IsParent: true}}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCommunityAnnouncementGroup(tt.info); got != tt.want {
+				t.Fatalf("isCommunityAnnouncementGroup = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRewritePollVoteInfoForLIDRewritesDM(t *testing.T) {
 	chat := types.NewJID("15551234567", types.DefaultUserServer)
 	sender := types.NewJID("15557654321", types.DefaultUserServer)


### PR DESCRIPTION
## Summary
- make outbound poll encoding follow the newer WhatsApp poll message variants for better future compatibility with current WhatsApp clients
- send single-select polls with the V3 poll creation field while keeping multi-select polls on the base field
- use V2 for community announcement groups when live group metadata identifies the target as both announce-only and a community parent
- preserve unmatched poll vote hashes and expose them in `poll show --json` so newer/unknown poll options do not disappear silently
- update poll send docs and changelog

## Why
WhatsApp has multiple poll creation fields in the wire format. The existing whatsmeow convenience helper only emits the original/base field, while other clients already select newer fields depending on poll type. This PR keeps wacli aligned with those message variants so outbound polls remain compatible as WhatsApp clients continue to evolve.

This also makes poll result inspection more forward-compatible: if a synced vote references an option hash that wacli cannot currently map to a stored option, the hash is preserved and surfaced in JSON instead of being dropped.

## Notes
- whatsmeow's high-level `BuildPollCreation` helper only builds the base poll field, but the generated proto exposes V2/V3 fields, so wacli now builds the minimal poll creation message locally and still sends through `SendMessage`.
- No broad poll metadata migration was added; unknown hashes are stored in the existing poll vote JSON payload only when needed.
- V2 selection is intentionally conservative and depends on available live group metadata, avoiding speculative behavior for regular groups.

## Test Plan
- [x] `git diff --check upstream/main...HEAD`
- [x] `go test ./...`
- [x] `pnpm test` 