### PR TITLE
ci: add aqua-friendly release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
   update-homebrew-tap:
     runs-on: ubuntu-latest
-    needs: goreleaser-darwin
+    needs: goreleaser-linux-windows
     steps:
       - name: Resolve release tag
         env:
@@ -85,7 +85,9 @@ jobs:
             -f formula=wacli \
             -f tag="$RELEASE_TAG" \
             -f repository=openclaw/wacli \
-            -f macos_artifact=wacli-macos-universal.tar.gz \
+            -f description="WhatsApp CLI built on whatsmeow" \
+            -f artifact_template=wacli-{target}.tar.gz \
+            -f target_aliases=darwin_amd64=darwin-amd64,darwin_arm64=darwin-arm64,linux_amd64=linux-amd64,linux_arm64=linux-arm64 \
             -f request_id="$request_id"
 
           run_id=""
@@ -161,12 +163,32 @@ jobs:
             echo "RELEASE_TAG=$REF_NAME" >> "$GITHUB_ENV"
           fi
 
-      - name: Upload linux/windows artifacts
+      - name: Create combined checksums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "$RELEASE_TAG" \
+            --pattern "wacli-darwin-*.tar.gz" \
+            --dir dist
+
+          cd dist
+          archives=(
+            wacli-darwin-amd64.tar.gz
+            wacli-darwin-arm64.tar.gz
+            wacli-darwin-universal.tar.gz
+            wacli-linux-amd64.tar.gz
+            wacli-linux-arm64.tar.gz
+            wacli-windows-amd64.zip
+          )
+          sha256sum "${archives[@]}" > checksums.txt
+
+      - name: Upload release artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "$RELEASE_TAG" \
-            dist/*.tar.gz \
-            dist/*.zip \
-            dist/checksums-linux-windows.txt \
+            dist/wacli-linux-amd64.tar.gz \
+            dist/wacli-linux-arm64.tar.gz \
+            dist/wacli-windows-amd64.zip \
+            dist/checksums.txt \
             --clobber

--- a/.goreleaser-linux-windows.yaml
+++ b/.goreleaser-linux-windows.yaml
@@ -71,7 +71,7 @@ archives:
       - README.md
 
 checksum:
-  name_template: checksums-linux-windows.txt
+  name_template: checksums.txt
 
 changelog:
   disable: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,14 +25,14 @@ universal_binaries:
     ids:
       - wacli
     name_template: wacli
-    replace: true
+    replace: false
 
 archives:
   - id: default
     formats:
       - tar.gz
     name_template: >-
-      {{ .ProjectName }}-{{ if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}-{{ if eq .Arch "all" }}universal{{ else }}{{ .Arch }}{{ end }}
+      {{ .ProjectName }}-{{ .Os }}-{{ if eq .Arch "all" }}universal{{ else }}{{ .Arch }}{{ end }}
     files:
       - LICENSE
       - README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Release: publish unified checksums and hand off target-specific assets to the Homebrew tap for aqua and Homebrew Linux support. (#249)
+
 ## 0.9.2 - 2026-05-17
 
 ### Added

--- a/docs/release.md
+++ b/docs/release.md
@@ -15,9 +15,11 @@ To cut a release:
 
 To re-release an existing tag, run the workflow manually and pass the tag (e.g. `v0.1.0`).
 
-Expected macOS artifact name (used by the tap updater):
+Expected macOS artifact names (used by the tap updater):
 
-- `wacli-macos-universal.tar.gz`
+- `wacli-darwin-amd64.tar.gz`
+- `wacli-darwin-arm64.tar.gz`
+- `wacli-darwin-universal.tar.gz` for backwards compatibility
 
 Other artifacts:
 
@@ -30,7 +32,7 @@ early if someone tries to compile it with `CGO_ENABLED=0`.
 
 ## Homebrew Tap
 
-The release workflow dispatches the `Update Formula` workflow in `steipete/homebrew-tap` after the macOS artifact is published when the tap token is configured. The tap workflow owns the formula-editing logic and updates both the macOS artifact SHA256 and the Linux source archive SHA256 in `Formula/wacli.rb`.
+The release workflow dispatches the `Update Formula` workflow in `steipete/homebrew-tap` after release artifacts are published when the tap token is configured. The tap workflow owns the formula-editing logic and updates the per-platform artifact URLs and SHA256 values in `Formula/wacli.rb`.
 
 Optional repository secret:
 


### PR DESCRIPTION
## Summary
- Publish aqua-friendly release archives for Darwin, Linux, and Windows while keeping the Darwin universal archive.
- Replace split platform checksum assets with one combined `checksums.txt` covering every release archive.
- Update the Homebrew tap handoff to use target-specific release binaries for macOS and Linux.

## Release assets
- `wacli-darwin-amd64.tar.gz`
- `wacli-darwin-arm64.tar.gz`
- `wacli-darwin-universal.tar.gz`
- `wacli-linux-amd64.tar.gz`
- `wacli-linux-arm64.tar.gz`
- `wacli-windows-amd64.zip`
- `checksums.txt`

## Validation
- `go run github.com/goreleaser/goreleaser/v2@v2.15.4 check --config .goreleaser.yaml`
- `go run github.com/goreleaser/goreleaser/v2@v2.15.4 check --config .goreleaser-linux-windows.yaml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml`
- Python YAML parse for release and GoReleaser YAML files
- Shell checksum-generation smoke test for the six expected archive names
- `git diff --check`
- Dry-run release workflow on fork: https://github.com/dovocoder/wacli/actions/runs/25992692978
  - verified all expected assets were published
  - verified `checksums.txt` contains six archive entries
  - cleaned up the temporary test release/tag afterward