### PR TITLE
feat: allow read-only media downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Media: allow `media download --read-only` when `--output` is explicit, so synced media can be fetched without opening the WhatsApp session store or recording download state. (#250 - thanks @mbelinky)
+
 ### Security
 
 ### Fixed

--- a/cmd/wacli/media.go
+++ b/cmd/wacli/media.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/openclaw/wacli/internal/out"
+	"github.com/openclaw/wacli/internal/wa"
 	"github.com/spf13/cobra"
 )
 
@@ -31,21 +33,30 @@ func newMediaDownloadCmd(flags *rootFlags) *cobra.Command {
 			if chat == "" || id == "" {
 				return fmt.Errorf("--chat and --id are required")
 			}
-			if err := flags.requireWritable(); err != nil {
-				return err
+			readOnly := flags.isReadOnly()
+			if readOnly {
+				if strings.TrimSpace(outputPath) == "" {
+					return fmt.Errorf("--output is required in read-only mode")
+				}
+			} else {
+				if err := flags.requireWritable(); err != nil {
+					return err
+				}
 			}
 
 			ctx, cancel := withTimeout(context.Background(), flags)
 			defer cancel()
 
-			a, lk, err := newApp(ctx, flags, true, false)
+			a, lk, err := newApp(ctx, flags, !readOnly, false)
 			if err != nil {
 				return err
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
-				return err
+			if !readOnly {
+				if err := a.EnsureAuthed(); err != nil {
+					return err
+				}
 			}
 
 			info, err := a.DB().GetMediaDownloadInfo(chat, id)
@@ -59,6 +70,29 @@ func newMediaDownloadCmd(flags *rootFlags) *cobra.Command {
 			target, err := a.ResolveMediaOutputPath(info, outputPath)
 			if err != nil {
 				return err
+			}
+
+			if readOnly {
+				bytes, err := wa.DownloadMediaDirectToFile(ctx, info.DirectPath, info.FileEncSHA256, info.FileSHA256, info.MediaKey, info.FileLength, info.MediaType, target)
+				if err != nil {
+					return err
+				}
+				resp := map[string]any{
+					"chat":       info.ChatJID,
+					"id":         info.MsgID,
+					"path":       target,
+					"bytes":      bytes,
+					"media_type": info.MediaType,
+					"mime_type":  info.MimeType,
+					"downloaded": true,
+					"read_only":  true,
+					"recorded":   false,
+				}
+				if flags.asJSON {
+					return out.WriteJSON(os.Stdout, resp)
+				}
+				fmt.Fprintf(os.Stdout, "%s (%d bytes)\n", target, bytes)
+				return nil
 			}
 
 			if err := a.Connect(ctx, false, nil); err != nil {

--- a/cmd/wacli/media_test.go
+++ b/cmd/wacli/media_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMediaDownloadReadOnlyRequiresOutput(t *testing.T) {
+	err := execute([]string{"--read-only", "media", "download", "--chat", "chat@s.whatsapp.net", "--id", "mid"})
+	if err == nil || !strings.Contains(err.Error(), "--output is required in read-only mode") {
+		t.Fatalf("execute error = %v, want read-only output requirement", err)
+	}
+}

--- a/docs/media.md
+++ b/docs/media.md
@@ -16,6 +16,7 @@ wacli media download --chat JID --id MSG_ID [--output PATH]
 - Media downloads are capped at 100 MiB.
 - `--output` may be a file path or directory.
 - If `--output` is omitted, media is written under the store media directory.
+- `--read-only` is supported only with explicit `--output`; it writes the file without opening the WhatsApp session store or recording `local_path` / `downloaded_at`.
 
 ## Examples
 
@@ -23,4 +24,5 @@ wacli media download --chat JID --id MSG_ID [--output PATH]
 wacli media download --chat 1234567890@s.whatsapp.net --id ABC123
 wacli media download --chat 1234567890@s.whatsapp.net --id ABC123 --output ./downloads
 wacli media download --chat 1234567890@s.whatsapp.net --id ABC123 --output ./photo.jpg
+wacli --read-only media download --chat 1234567890@s.whatsapp.net --id ABC123 --output /tmp/photo.jpg
 ```

--- a/internal/wa/media.go
+++ b/internal/wa/media.go
@@ -1,15 +1,22 @@
 package wa
 
 import (
+	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/openclaw/wacli/internal/fsutil"
 	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/socket"
+	"go.mau.fi/whatsmeow/util/cbcutil"
+	"go.mau.fi/whatsmeow/util/hkdfutil"
 )
 
 const MaxMediaDownloadSize = 100 * 1024 * 1024
@@ -100,6 +107,155 @@ func (c *Client) DownloadMediaToFile(ctx context.Context, directPath string, enc
 	}
 	return info.Size(), nil
 }
+
+func DownloadMediaDirectToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType string, targetPath string) (int64, error) {
+	if strings.TrimSpace(directPath) == "" {
+		return 0, fmt.Errorf("direct path is required")
+	}
+	mediaURL, err := directMediaURL(directPath)
+	if err != nil {
+		return 0, err
+	}
+	mt, err := MediaTypeFromString(mediaType)
+	if err != nil {
+		return 0, err
+	}
+	if _, err := mediaDownloadLength(fileLength); err != nil {
+		return 0, err
+	}
+
+	plaintext, err := downloadAndDecryptDirect(ctx, mediaURL, encFileHash, fileHash, mediaKey, fileLength, mt)
+	if err != nil {
+		return 0, err
+	}
+	if len(plaintext) > MaxMediaDownloadSize {
+		return 0, fmt.Errorf("media too large; maximum download size is %d bytes", MaxMediaDownloadSize)
+	}
+	if err := fsutil.EnsureWritableDir(filepath.Dir(targetPath)); err != nil {
+		return 0, fmt.Errorf("create output dir: %w", err)
+	}
+
+	tmpFile, err := os.CreateTemp(filepath.Dir(targetPath), ".wacli-download-*")
+	if err != nil {
+		return 0, fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmpFile.Name()
+	success := false
+	defer func() {
+		_ = tmpFile.Close()
+		if !success {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmpFile.Write(plaintext); err != nil {
+		return 0, fmt.Errorf("write media file: %w", err)
+	}
+	if err := tmpFile.Sync(); err != nil {
+		return 0, fmt.Errorf("flush temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return 0, fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, targetPath); err != nil {
+		return 0, fmt.Errorf("move media file: %w", err)
+	}
+	success = true
+	return int64(len(plaintext)), nil
+}
+
+func directMediaURL(directPath string) (string, error) {
+	path := strings.TrimSpace(directPath)
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return path, nil
+	}
+	if !strings.HasPrefix(path, "/") {
+		return "", fmt.Errorf("media download path does not start with slash: %s", path)
+	}
+	return "https://mmg.whatsapp.net" + path, nil
+}
+
+func downloadAndDecryptDirect(ctx context.Context, mediaURL string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType whatsmeow.MediaType) ([]byte, error) {
+	encrypted, err := downloadDirectBytes(ctx, mediaURL)
+	if err != nil {
+		return nil, err
+	}
+	if len(encrypted) <= mediaHMACLength {
+		return nil, whatsmeow.ErrTooShortFile
+	}
+	if len(encrypted) > MaxMediaDownloadSize+maxEncryptedMediaDownloadOverhead {
+		return nil, fmt.Errorf("media too large; maximum download size is %d bytes", MaxMediaDownloadSize)
+	}
+	if len(encFileHash) == sha256.Size {
+		sum := sha256.Sum256(encrypted)
+		if !bytes.Equal(sum[:], encFileHash) {
+			return nil, whatsmeow.ErrInvalidMediaEncSHA256
+		}
+	}
+
+	iv, cipherKey, macKey := directMediaKeys(mediaKey, mediaType)
+	ciphertext := encrypted[:len(encrypted)-mediaHMACLength]
+	mac := encrypted[len(encrypted)-mediaHMACLength:]
+	if err := validateDirectMedia(iv, ciphertext, macKey, mac); err != nil {
+		return nil, err
+	}
+	plaintext, err := cbcutil.Decrypt(cipherKey, iv, append([]byte(nil), ciphertext...))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt file: %w", err)
+	}
+	if fileLength > 0 && uint64(len(plaintext)) != fileLength {
+		return nil, fmt.Errorf("%w: expected %d, got %d", whatsmeow.ErrFileLengthMismatch, fileLength, len(plaintext))
+	}
+	if len(fileHash) == sha256.Size {
+		sum := sha256.Sum256(plaintext)
+		if !bytes.Equal(sum[:], fileHash) {
+			return nil, whatsmeow.ErrInvalidMediaSHA256
+		}
+	}
+	return plaintext, nil
+}
+
+func downloadDirectBytes(ctx context.Context, mediaURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, mediaURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("prepare media request: %w", err)
+	}
+	req.Header.Set("Origin", socket.Origin)
+	req.Header.Set("Referer", socket.Origin+"/")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, whatsmeow.DownloadHTTPError{Response: resp}
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, MaxMediaDownloadSize+maxEncryptedMediaDownloadOverhead+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > MaxMediaDownloadSize+maxEncryptedMediaDownloadOverhead {
+		return nil, fmt.Errorf("media too large; maximum download size is %d bytes", MaxMediaDownloadSize)
+	}
+	return body, nil
+}
+
+func directMediaKeys(mediaKey []byte, appInfo whatsmeow.MediaType) (iv, cipherKey, macKey []byte) {
+	expanded := hkdfutil.SHA256(mediaKey, nil, []byte(appInfo), 112)
+	return expanded[:16], expanded[16:48], expanded[48:80]
+}
+
+func validateDirectMedia(iv, ciphertext, macKey, mac []byte) error {
+	h := hmac.New(sha256.New, macKey)
+	h.Write(iv)
+	h.Write(ciphertext)
+	if !hmac.Equal(h.Sum(nil)[:mediaHMACLength], mac) {
+		return whatsmeow.ErrInvalidMediaHMAC
+	}
+	return nil
+}
+
+const mediaHMACLength = 10
 
 type limitedDownloadFile struct {
 	*os.File

--- a/internal/wa/media.go
+++ b/internal/wa/media.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,6 +21,8 @@ import (
 )
 
 const MaxMediaDownloadSize = 100 * 1024 * 1024
+
+var directMediaBaseURL = "https://mmg.whatsapp.net"
 
 // WhatsApp writes encrypted media as padded ciphertext plus a 10-byte MAC before
 // truncating and decrypting it in place.
@@ -112,11 +115,11 @@ func DownloadMediaDirectToFile(ctx context.Context, directPath string, encFileHa
 	if strings.TrimSpace(directPath) == "" {
 		return 0, fmt.Errorf("direct path is required")
 	}
-	mediaURL, err := directMediaURL(directPath)
+	mt, err := MediaTypeFromString(mediaType)
 	if err != nil {
 		return 0, err
 	}
-	mt, err := MediaTypeFromString(mediaType)
+	mediaURL, err := directMediaURL(directPath, encFileHash, mt)
 	if err != nil {
 		return 0, err
 	}
@@ -164,15 +167,48 @@ func DownloadMediaDirectToFile(ctx context.Context, directPath string, encFileHa
 	return int64(len(plaintext)), nil
 }
 
-func directMediaURL(directPath string) (string, error) {
+func directMediaURL(directPath string, encFileHash []byte, mediaType whatsmeow.MediaType) (string, error) {
 	path := strings.TrimSpace(directPath)
-	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
-		return path, nil
+	if strings.Contains(path, "://") || strings.HasPrefix(path, "//") {
+		return "", fmt.Errorf("media download path must be a WhatsApp direct path, not a URL")
 	}
 	if !strings.HasPrefix(path, "/") {
 		return "", fmt.Errorf("media download path does not start with slash: %s", path)
 	}
-	return "https://mmg.whatsapp.net" + path, nil
+	mediaURL := strings.TrimRight(directMediaBaseURL, "/") + path
+	if len(encFileHash) > 0 {
+		mediaURL = appendDirectMediaQuery(mediaURL, "hash", base64.URLEncoding.EncodeToString(encFileHash))
+	}
+	if mmsType := directMediaMMSType(mediaType); mmsType != "" {
+		mediaURL = appendDirectMediaQuery(mediaURL, "mms-type", mmsType)
+	}
+	return appendDirectMediaQuery(mediaURL, "__wa-mms", ""), nil
+}
+
+func appendDirectMediaQuery(mediaURL, key, value string) string {
+	sep := "?"
+	if strings.Contains(mediaURL, "?") {
+		sep = "&"
+	}
+	if strings.HasSuffix(mediaURL, "?") || strings.HasSuffix(mediaURL, "&") {
+		sep = ""
+	}
+	return mediaURL + sep + key + "=" + value
+}
+
+func directMediaMMSType(mediaType whatsmeow.MediaType) string {
+	switch mediaType {
+	case whatsmeow.MediaImage:
+		return "image"
+	case whatsmeow.MediaAudio:
+		return "audio"
+	case whatsmeow.MediaVideo:
+		return "video"
+	case whatsmeow.MediaDocument:
+		return "document"
+	default:
+		return ""
+	}
 }
 
 func downloadAndDecryptDirect(ctx context.Context, mediaURL string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType whatsmeow.MediaType) ([]byte, error) {

--- a/internal/wa/media_test.go
+++ b/internal/wa/media_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/base64"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -63,12 +64,29 @@ func TestDownloadMediaDirectToFile(t *testing.T) {
 		if r.Header.Get("Origin") == "" || r.Header.Get("Referer") == "" {
 			t.Fatalf("missing WhatsApp media headers")
 		}
+		if r.URL.Path != "/voice.ogg" {
+			t.Fatalf("path = %q, want /voice.ogg", r.URL.Path)
+		}
+		if got, want := r.URL.Query().Get("hash"), base64.URLEncoding.EncodeToString(encHash[:]); got != want {
+			t.Fatalf("hash query = %q, want %q", got, want)
+		}
+		if got := r.URL.Query().Get("mms-type"); got != "audio" {
+			t.Fatalf("mms-type query = %q, want audio", got)
+		}
+		if !strings.Contains(r.URL.RawQuery, "__wa-mms=") {
+			t.Fatalf("raw query %q missing __wa-mms", r.URL.RawQuery)
+		}
 		_, _ = w.Write(encrypted)
 	}))
 	defer server.Close()
+	oldBaseURL := directMediaBaseURL
+	directMediaBaseURL = server.URL
+	defer func() {
+		directMediaBaseURL = oldBaseURL
+	}()
 
 	target := filepath.Join(t.TempDir(), "voice.ogg")
-	n, err := DownloadMediaDirectToFile(context.Background(), server.URL+"/voice.ogg", encHash[:], fileHash[:], mediaKey, uint64(len(plaintext)), "audio", target)
+	n, err := DownloadMediaDirectToFile(context.Background(), "/voice.ogg", encHash[:], fileHash[:], mediaKey, uint64(len(plaintext)), "audio", target)
 	if err != nil {
 		t.Fatalf("DownloadMediaDirectToFile: %v", err)
 	}
@@ -89,6 +107,17 @@ func TestDownloadMediaDirectToFileRejectsMalformedDirectPath(t *testing.T) {
 	_, err := DownloadMediaDirectToFile(context.Background(), "not-a-path", nil, nil, bytes.Repeat([]byte{7}, 32), 0, "audio", target)
 	if err == nil || !strings.Contains(err.Error(), "does not start with slash") {
 		t.Fatalf("DownloadMediaDirectToFile error = %v, want malformed direct path", err)
+	}
+	if _, statErr := os.Stat(target); !os.IsNotExist(statErr) {
+		t.Fatalf("target stat err = %v, want not exist", statErr)
+	}
+}
+
+func TestDownloadMediaDirectToFileRejectsAbsoluteURL(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "voice.ogg")
+	_, err := DownloadMediaDirectToFile(context.Background(), "https://example.com/voice.ogg", nil, nil, bytes.Repeat([]byte{7}, 32), 0, "audio", target)
+	if err == nil || !strings.Contains(err.Error(), "not a URL") {
+		t.Fatalf("DownloadMediaDirectToFile error = %v, want absolute URL rejection", err)
 	}
 	if _, statErr := os.Stat(target); !os.IsNotExist(statErr) {
 		t.Fatalf("target stat err = %v, want not exist", statErr)

--- a/internal/wa/media_test.go
+++ b/internal/wa/media_test.go
@@ -2,11 +2,19 @@ package wa
 
 import (
 	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/util/cbcutil"
 )
 
 func TestMediaTypeFromString(t *testing.T) {
@@ -33,6 +41,57 @@ func TestMediaDownloadLength(t *testing.T) {
 	}
 	if got, err := mediaDownloadLength(123); err != nil || got != 123 {
 		t.Fatalf("length(123) = %d, %v; want 123, nil", got, err)
+	}
+}
+
+func TestDownloadMediaDirectToFile(t *testing.T) {
+	plaintext := []byte("voice note bytes")
+	mediaKey := bytes.Repeat([]byte{7}, 32)
+	iv, cipherKey, macKey := directMediaKeys(mediaKey, whatsmeow.MediaAudio)
+	ciphertext, err := cbcutil.Encrypt(cipherKey, iv, append([]byte(nil), plaintext...))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	mac := hmac.New(sha256.New, macKey)
+	mac.Write(iv)
+	mac.Write(ciphertext)
+	encrypted := append(append([]byte(nil), ciphertext...), mac.Sum(nil)[:mediaHMACLength]...)
+	encHash := sha256.Sum256(encrypted)
+	fileHash := sha256.Sum256(plaintext)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Origin") == "" || r.Header.Get("Referer") == "" {
+			t.Fatalf("missing WhatsApp media headers")
+		}
+		_, _ = w.Write(encrypted)
+	}))
+	defer server.Close()
+
+	target := filepath.Join(t.TempDir(), "voice.ogg")
+	n, err := DownloadMediaDirectToFile(context.Background(), server.URL+"/voice.ogg", encHash[:], fileHash[:], mediaKey, uint64(len(plaintext)), "audio", target)
+	if err != nil {
+		t.Fatalf("DownloadMediaDirectToFile: %v", err)
+	}
+	if n != int64(len(plaintext)) {
+		t.Fatalf("downloaded bytes = %d, want %d", n, len(plaintext))
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("output = %q, want %q", got, plaintext)
+	}
+}
+
+func TestDownloadMediaDirectToFileRejectsMalformedDirectPath(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "voice.ogg")
+	_, err := DownloadMediaDirectToFile(context.Background(), "not-a-path", nil, nil, bytes.Repeat([]byte{7}, 32), 0, "audio", target)
+	if err == nil || !strings.Contains(err.Error(), "does not start with slash") {
+		t.Fatalf("DownloadMediaDirectToFile error = %v, want malformed direct path", err)
+	}
+	if _, statErr := os.Stat(target); !os.IsNotExist(statErr) {
+		t.Fatalf("target stat err = %v, want not exist", statErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- allow `wacli media download` to run in `--read-only` mode when an explicit `--output` path is provided
- download and decrypt media from synced metadata without opening the WhatsApp session store or taking the write lock
- leave the existing writable download path unchanged, including DB `local_path` / `downloaded_at` recording

## Why

Long-running `wacli sync --follow` processes can legitimately hold the store lock. In that state, already-synced media metadata is still useful for output-only media extraction, but the previous command path always required writable mode, opened the WhatsApp session store, and failed before it could download.

## Validation

- `go test ./internal/wa ./cmd/wacli`
- `pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`
- Manual live check: while a `sync --follow` process held the store lock, normal writable `media download` still failed with the lock, while `media download --read-only --output ...` downloaded audio and video files and left stored media metadata unchanged.
