### PR TITLE
fix: announce pushname via available presence after connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 - Release: publish target-specific macOS/Linux/Windows archives with one combined checksum file and update the OpenClaw Homebrew tap.
-- Connect: send an `available` presence after authenticated connect so the server records the linked-device pushname; without it, downstream recipients receive `notify=""` and Cloud API verified-business webhooks silently drop the message at the gateway.
+- Connect: send an `available` presence after authenticated connect so the server records the linked-device pushname; without it, downstream recipients receive `notify=""` and Cloud API verified-business webhooks silently drop the message at the gateway. (#252 - thanks @ceifa)
 
 ## 0.9.2 - 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Release: publish target-specific macOS/Linux/Windows archives with one combined checksum file and update the OpenClaw Homebrew tap.
+- Connect: send an `available` presence after authenticated connect so the server records the linked-device pushname; without it, downstream recipients receive `notify=""` and Cloud API verified-business webhooks silently drop the message at the gateway.
 
 ## 0.9.2 - 2026-05-17
 

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -116,19 +116,7 @@ func (c *Client) Connect(ctx context.Context, opts ConnectOptions) error {
 	}
 
 	if authed {
-		// Announce ourselves as `available` so the server records the
-		// linked-device pushname. Without this, downstream recipients see
-		// notify="" or "-" for our messages, and Cloud API verified-business
-		// webhook pipelines silently drop them at the gateway (the message
-		// still gets a <biz/> delivery ack so the failure is invisible from
-		// the sender side). Whatsmeow's own SendPresence docs flag this:
-		// "call this at least once after connecting so that the server has
-		// your pushname".
-		if cli.Store != nil && len(cli.Store.PushName) > 0 {
-			if err := cli.SendPresence(ctx, types.PresenceAvailable); err != nil {
-				fmt.Fprintf(os.Stderr, "warn: failed to send initial available presence: %v\n", err)
-			}
-		}
+		sendInitialAvailablePresence(ctx, cli)
 		return nil
 	}
 
@@ -784,6 +772,16 @@ func (c *Client) SendChatPresence(ctx context.Context, jid types.JID, state type
 		return fmt.Errorf("not connected")
 	}
 	return cli.SendChatPresence(ctx, jid, state, media)
+}
+
+func sendInitialAvailablePresence(ctx context.Context, cli *whatsmeow.Client) {
+	// Whatsmeow recommends this once after connect so the server records the linked-device pushname.
+	if cli == nil || cli.Store == nil || strings.TrimSpace(cli.Store.PushName) == "" {
+		return
+	}
+	if err := cli.SendPresence(ctx, types.PresenceAvailable); err != nil {
+		fmt.Fprintf(os.Stderr, "warn: failed to send initial available presence: %v\n", err)
+	}
 }
 
 func (c *Client) Logout(ctx context.Context) error {

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -116,6 +116,19 @@ func (c *Client) Connect(ctx context.Context, opts ConnectOptions) error {
 	}
 
 	if authed {
+		// Announce ourselves as `available` so the server records the
+		// linked-device pushname. Without this, downstream recipients see
+		// notify="" or "-" for our messages, and Cloud API verified-business
+		// webhook pipelines silently drop them at the gateway (the message
+		// still gets a <biz/> delivery ack so the failure is invisible from
+		// the sender side). Whatsmeow's own SendPresence docs flag this:
+		// "call this at least once after connecting so that the server has
+		// your pushname".
+		if cli.Store != nil && len(cli.Store.PushName) > 0 {
+			if err := cli.SendPresence(ctx, types.PresenceAvailable); err != nil {
+				fmt.Fprintf(os.Stderr, "warn: failed to send initial available presence: %v\n", err)
+			}
+		}
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

- Send `Presence: available` after every successful authenticated connect so the server records the linked-device pushname.
- Without it, downstream recipients receive `notify=""` / `"-"`, and Cloud API verified-business webhook pipelines silently drop those messages at the gateway — the send still receives a `<biz/>` delivery ack so the failure is invisible from the sender side.

## Why

whatsmeow's own `SendPresence` docs already warn:

> You should call this at least once after connecting so that the server has your pushname. Otherwise, other users will see "-" as the name.

WhatsApp Business app contacts tolerate the missing pushname, which is why this has not surfaced before. Meta Cloud API (`verified_level="high"`) bots do not: their webhook never fires for senders without a valid pushname, even though the server gateway acknowledges delivery.

## Notes

- Best-effort: any error from `SendPresence` is logged to stderr and ignored so it never blocks the connect.
- Guarded by `len(cli.Store.PushName) > 0` because `SendPresence` returns `ErrNoPushName` otherwise (and pre-auth flows reach this branch with an empty store).
- No new tests: the call lives on a real websocket-connected client and the existing `internal/wa` suite doesn't have a fake whatsmeow client to assert against. Verified manually against a Cloud API business chat that was silently dropping wacli sends — the bot started replying within seconds once this was in place.

## Human note

Same as #240, I don't know golang, I asked my claw to try fix it and it did, then I asked to open a PR and it probably has slop. Feel free to close but you can use it as a reference to actually fix the problem.