### PR TITLE
docs: update Homebrew tap references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::warning::Skipping Homebrew tap update because HOMEBREW_TAP_TOKEN is not configured with workflow access to steipete/homebrew-tap"
+            echo "::warning::Skipping Homebrew tap update because HOMEBREW_TAP_TOKEN is not configured with workflow access to openclaw/homebrew-tap"
             exit 0
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Fixed
 
+### Docs
+
+- Docs: update Homebrew install and release-token references to the OpenClaw Homebrew tap. (#254 - thanks @dovocoder)
+
 ## 0.10.0 - 2026-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Full documentation: **<https://wacli.sh>**
 ### Homebrew (recommended)
 
 ```bash
-brew install steipete/tap/wacli
+brew install openclaw/tap/wacli
 ```
 
-If a Linux install reports `Binary was compiled with 'CGO_ENABLED=0'`, run `brew update && brew reinstall steipete/tap/wacli`.
+If a Linux install reports `Binary was compiled with 'CGO_ENABLED=0'`, run `brew update && brew reinstall openclaw/tap/wacli`.
 
 ### Build from source
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,7 +10,7 @@ description: "Install wacli via Homebrew tap, prebuilt release archives, or a lo
 ## Homebrew (macOS, Linux)
 
 ```bash
-brew install steipete/tap/wacli
+brew install openclaw/tap/wacli
 wacli --version
 ```
 
@@ -18,7 +18,7 @@ If a Linux install from the tap reports `Binary was compiled with 'CGO_ENABLED=0
 
 ```bash
 brew update
-brew reinstall steipete/tap/wacli
+brew reinstall openclaw/tap/wacli
 ```
 
 ## GitHub releases (raw binaries)
@@ -68,7 +68,7 @@ wacli --help
 
 ## Updating
 
-- **Homebrew tap**: `brew upgrade wacli` (or `brew reinstall steipete/tap/wacli`).
+- **Homebrew tap**: `brew upgrade wacli` (or `brew reinstall openclaw/tap/wacli`).
 - **GitHub release archives**: download the new tarball / ZIP and replace the binary.
 - **Source builds**: `git pull && pnpm build` (or the manual `go build` above). Local builds use the version compiled into the source tree; release artifacts inject the tag during GoReleaser builds.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,7 +10,7 @@ Five minutes from a clean machine to authenticated sync, search, and send. For d
 ## 1. Install
 
 ```bash
-brew install steipete/tap/wacli
+brew install openclaw/tap/wacli
 wacli --version
 ```
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -36,7 +36,7 @@ The release workflow dispatches the `Update Formula` workflow in `openclaw/homeb
 
 Optional repository secret:
 
-- `HOMEBREW_TAP_TOKEN`: token with permission to run workflows in `steipete/homebrew-tap`
+- `HOMEBREW_TAP_TOKEN`: token with permission to run workflows in `openclaw/homebrew-tap`
 
 If `HOMEBREW_TAP_TOKEN` is missing, release artifacts are still published and the tap update is skipped with a workflow warning.
 

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -17,7 +17,7 @@ const productName = "wacli";
 const productTagline = "WhatsApp in your terminal";
 const productDescription =
   "A single Go CLI that pairs as a linked WhatsApp Web device, mirrors message history into local SQLite with FTS5 search, and exposes send, media, contact, and group workflows for terminals, scripts, and coding agents.";
-const brewInstall = "brew install steipete/tap/wacli";
+const brewInstall = "brew install openclaw/tap/wacli";
 
 const sections = [
   ["Start", ["index.md", "install.md", "quickstart.md", "overview.md"]],

--- a/scripts/docs-site-assets.mjs
+++ b/scripts/docs-site-assets.mjs
@@ -277,7 +277,7 @@ export function socialCardSvg() {
   </g>
   <text x="114" y="315" fill="#ffffff" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="104" font-weight="700">wacli</text>
   <text x="114" y="388" fill="#dcfce7" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="44" font-weight="600">WhatsApp in your terminal</text>
-  <text x="114" y="468" fill="#b7c8c0" font-family="JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, monospace" font-size="32">$ brew install steipete/tap/wacli</text>
+  <text x="114" y="468" fill="#b7c8c0" font-family="JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, monospace" font-size="32">$ brew install openclaw/tap/wacli</text>
   <g fill="#9af1b7" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="28" font-weight="600">
     <text x="742" y="150">sync</text>
     <text x="857" y="150">search</text>


### PR DESCRIPTION
Summary:
- Replace remaining Homebrew install/reinstall docs from steipete/tap to openclaw/tap.
- Update docs site source/social card tap text.
- Update Homebrew tap token wording and workflow warning to openclaw/homebrew-tap.

Test plan:
- pnpm -s docs:site
- pnpm -s format:check
- git diff --check