### PR TITLE
Add support for interacting with buttons and lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Chats: store unread marker state and numeric `unread_count` separately; migrate existing stores away from sentinel unread values while preserving public chat JSON fields. (#255 - thanks @drelum and @dovocoder)
+- Send: add `send select` to choose stored inbound WhatsApp quick-reply buttons and list rows from scripts.
 
 ### Security
 

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -33,6 +33,7 @@ func newSendCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newSendReactCmd(flags))
 	cmd.AddCommand(newSendPollCmd(flags))
 	cmd.AddCommand(newSendStatusCmd(flags))
+	cmd.AddCommand(newSendSelectCmd(flags))
 	return cmd
 }
 
@@ -134,19 +135,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 
 			now := time.Now().UTC()
 			chat := toJID
-			chatName := a.WA().ResolveChatName(ctx, chat, "")
-			kind := chatKindFromJID(chat)
-			_ = a.DB().UpsertChat(chat.String(), kind, chatName, now)
-			_ = a.DB().UpsertMessage(store.UpsertMessageParams{
-				ChatJID:    chat.String(),
-				ChatName:   chatName,
-				MsgID:      string(msgID),
-				SenderJID:  "",
-				SenderName: "me",
-				Timestamp:  now,
-				FromMe:     true,
-				Text:       message,
-			})
+			persistOutboundText(ctx, a, chat, string(msgID), message, now)
 
 			waitForPostSendRetryReceipts(ctx, postSendWait)
 
@@ -174,6 +163,33 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().BoolVar(&messageEscapes, "message-escapes", false, `interpret backslash escapes in --message (\n, \r, \t, \\, \")`)
 	cmd.Flags().DurationVar(&postSendWait, "post-send-wait", postSendRetryReceiptWait, "keep the connection alive after send so retry receipts can be handled (0 disables)")
 	return cmd
+}
+
+func persistOutboundText(ctx context.Context, a *app.App, chat types.JID, msgID, text string, now time.Time) {
+	chatName := a.WA().ResolveChatName(ctx, chat, "")
+	if err := a.DB().UpsertChat(chat.String(), chatKindFromJID(chat), chatName, now); err != nil {
+		warnOutboundPersist("chat", msgID, err)
+		return
+	}
+	if err := a.DB().UpsertMessage(store.UpsertMessageParams{
+		ChatJID:    chat.String(),
+		ChatName:   chatName,
+		MsgID:      msgID,
+		SenderJID:  "",
+		SenderName: "me",
+		Timestamp:  now,
+		FromMe:     true,
+		Text:       text,
+	}); err != nil {
+		warnOutboundPersist("message", msgID, err)
+	}
+}
+
+func warnOutboundPersist(kind, msgID string, err error) {
+	if err == nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "warning: sent message %s was accepted by WhatsApp, but local outbound %s persistence failed: %v\n", msgID, kind, err)
 }
 
 type sendTextApp interface {

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openclaw/wacli/internal/app"
 	"github.com/openclaw/wacli/internal/lock"
 	"github.com/openclaw/wacli/internal/out"
-	"github.com/openclaw/wacli/internal/store"
 	"go.mau.fi/whatsmeow/types"
 )
 
@@ -46,6 +45,10 @@ type sendDelegateRequest struct {
 	ID                   string   `json:"id,omitempty"`
 	Reaction             string   `json:"reaction,omitempty"`
 	Sender               string   `json:"sender,omitempty"`
+	Label                string   `json:"label,omitempty"`
+	ButtonID             string   `json:"button_id,omitempty"`
+	SelectIndex          int      `json:"select_index,omitempty"`
+	Type                 string   `json:"type,omitempty"`
 	Question             string   `json:"question,omitempty"`
 	Options              []string `json:"options,omitempty"`
 	Selectable           int      `json:"selectable,omitempty"`
@@ -54,17 +57,18 @@ type sendDelegateRequest struct {
 }
 
 type sendDelegateResponse struct {
-	OK       bool              `json:"ok"`
-	Error    string            `json:"error,omitempty"`
-	Sent     bool              `json:"sent,omitempty"`
-	To       string            `json:"to,omitempty"`
-	ID       string            `json:"id,omitempty"`
-	Target   string            `json:"target,omitempty"`
-	Reaction string            `json:"reaction,omitempty"`
-	Question string            `json:"question,omitempty"`
-	Options  []string          `json:"options,omitempty"`
-	Selected []string          `json:"selected,omitempty"`
-	File     map[string]string `json:"file,omitempty"`
+	OK             bool              `json:"ok"`
+	Error          string            `json:"error,omitempty"`
+	Sent           bool              `json:"sent,omitempty"`
+	To             string            `json:"to,omitempty"`
+	ID             string            `json:"id,omitempty"`
+	Target         string            `json:"target,omitempty"`
+	Reaction       string            `json:"reaction,omitempty"`
+	Question       string            `json:"question,omitempty"`
+	Options        []string          `json:"options,omitempty"`
+	Selected       []string          `json:"selected,omitempty"`
+	SelectedOption *selectOption     `json:"selected_option,omitempty"`
+	File           map[string]string `json:"file,omitempty"`
 }
 
 func sendDelegateSocketPath(storeDir string) string {
@@ -204,6 +208,8 @@ func executeDelegatedSend(parent context.Context, a *app.App, req sendDelegateRe
 		return executeDelegatedPoll(ctx, a, req)
 	case "poll_vote":
 		return executeDelegatedPollVote(ctx, a, req)
+	case "button_list_select":
+		return executeDelegatedButtonListSelect(ctx, a, req)
 	default:
 		return sendDelegateResponse{}, fmt.Errorf("unsupported send kind %q", req.Kind)
 	}
@@ -238,17 +244,7 @@ func executeDelegatedText(ctx context.Context, a *app.App, req sendDelegateReque
 		return sendDelegateResponse{}, err
 	}
 	now := time.Now().UTC()
-	chatName := a.WA().ResolveChatName(ctx, toJID, "")
-	_ = a.DB().UpsertChat(toJID.String(), chatKindFromJID(toJID), chatName, now)
-	_ = a.DB().UpsertMessage(store.UpsertMessageParams{
-		ChatJID:    toJID.String(),
-		ChatName:   chatName,
-		MsgID:      string(msgID),
-		SenderName: "me",
-		Timestamp:  now,
-		FromMe:     true,
-		Text:       req.Message,
-	})
+	persistOutboundText(ctx, a, toJID, string(msgID), req.Message, now)
 	waitForPostSendRetryReceipts(ctx, millisDuration(req.PostSendWaitMS, 0))
 	return sendDelegateResponse{OK: true, Sent: true, To: toJID.String(), ID: string(msgID)}, nil
 }
@@ -349,6 +345,10 @@ func writeDelegatedSendOutput(flags *rootFlags, kind string, resp sendDelegateRe
 			body["target"] = resp.Target
 			body["selected"] = resp.Selected
 		}
+		if kind == "button_list_select" {
+			body["target"] = resp.Target
+			body["selected"] = resp.SelectedOption
+		}
 		return out.WriteJSON(os.Stdout, body)
 	}
 	switch kind {
@@ -368,6 +368,12 @@ func writeDelegatedSendOutput(flags *rootFlags, kind string, resp sendDelegateRe
 		fmt.Fprintf(os.Stdout, "Sent poll to %s (id %s)\n", resp.To, resp.ID)
 	case "poll_vote":
 		fmt.Fprintf(os.Stdout, "Voted on %s in %s (id %s)\n", resp.Target, resp.To, resp.ID)
+	case "button_list_select":
+		label := ""
+		if resp.SelectedOption != nil {
+			label = resp.SelectedOption.DisplayText
+		}
+		fmt.Fprintf(os.Stdout, "Selected %q on %s in %s (id %s)\n", label, resp.Target, resp.To, resp.ID)
 	default:
 		fmt.Fprintf(os.Stdout, "Sent to %s (id %s)\n", resp.To, resp.ID)
 	}

--- a/cmd/wacli/send_select_cmd.go
+++ b/cmd/wacli/send_select_cmd.go
@@ -376,17 +376,29 @@ func buildSelectResponseMessage(chat types.JID, opt selectOption, target store.M
 	}
 	switch opt.ResponseType {
 	case selectResponseList:
+		listType := waProto.ListResponseMessage_SINGLE_SELECT
+		resp := &waProto.ListResponseMessage{
+			Title:             proto.String(opt.DisplayText),
+			ListType:          &listType,
+			SingleSelectReply: &waProto.ListResponseMessage_SingleSelectReply{SelectedRowID: proto.String(opt.ID)},
+			ContextInfo:       ctx,
+		}
+		if opt.Description != "" {
+			resp.Description = proto.String(opt.Description)
+		}
 		return &waProto.Message{
-			ExtendedTextMessage: &waProto.ExtendedTextMessage{
-				Text:        proto.String(opt.DisplayText),
-				ContextInfo: ctx,
-			},
+			ListResponseMessage: resp,
 		}, nil
 	case selectResponseButtons:
+		respType := waProto.ButtonsResponseMessage_DISPLAY_TEXT
 		return &waProto.Message{
-			ExtendedTextMessage: &waProto.ExtendedTextMessage{
-				Text:        proto.String(opt.DisplayText),
+			ButtonsResponseMessage: &waProto.ButtonsResponseMessage{
+				SelectedButtonID: proto.String(opt.ID),
+				Response: &waProto.ButtonsResponseMessage_SelectedDisplayText{
+					SelectedDisplayText: opt.DisplayText,
+				},
 				ContextInfo: ctx,
+				Type:        &respType,
 			},
 		}, nil
 	case selectResponseTemplate:

--- a/cmd/wacli/send_select_cmd.go
+++ b/cmd/wacli/send_select_cmd.go
@@ -387,7 +387,7 @@ func buildSelectResponseMessage(opt selectOption, target store.Message, senderOv
 		if opt.Index < 1 {
 			return nil, fmt.Errorf("template quick reply %q has no stored index; sync this message again with a newer wacli", opt.DisplayText)
 		}
-		selectedIndex := uint32(opt.Index)
+		selectedIndex := uint32(opt.Index - 1)
 		return &waProto.Message{
 			TemplateButtonReplyMessage: &waProto.TemplateButtonReplyMessage{
 				SelectedID:          proto.String(opt.ID),

--- a/cmd/wacli/send_select_cmd.go
+++ b/cmd/wacli/send_select_cmd.go
@@ -1,0 +1,469 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/openclaw/wacli/internal/app"
+	"github.com/openclaw/wacli/internal/out"
+	"github.com/openclaw/wacli/internal/store"
+	"github.com/openclaw/wacli/internal/wa"
+	"github.com/spf13/cobra"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	selectResponseList        = "list_response"
+	selectResponseButtons     = "buttons_response"
+	selectResponseTemplate    = "template_button_reply"
+	selectResponseInteractive = "interactive_response"
+)
+
+type selectSender interface {
+	SendProtoMessage(ctx context.Context, to types.JID, msg *waProto.Message) (types.MessageID, error)
+}
+
+type selectRequest struct {
+	Label        string
+	ButtonID     string
+	Index        int
+	IndexSet     bool
+	Type         string
+	Sender       string
+	PostSendWait time.Duration
+}
+
+type selectOption struct {
+	Type         string `json:"type"`
+	DisplayText  string `json:"display_text"`
+	ID           string `json:"id,omitempty"`
+	ResponseType string `json:"-"`
+	Index        int    `json:"-"`
+	Description  string `json:"-"`
+}
+
+type selectResult struct {
+	Sent     bool         `json:"sent"`
+	To       string       `json:"to"`
+	ID       string       `json:"id"`
+	Target   string       `json:"target"`
+	Selected selectOption `json:"selected"`
+}
+
+func newSendSelectCmd(flags *rootFlags) *cobra.Command {
+	var to string
+	var pick int
+	var msgID string
+	var label string
+	var buttonID string
+	var index int
+	var typ string
+	var senderOverride string
+	postSendWait := postSendRetryReceiptWait
+
+	cmd := &cobra.Command{
+		Use:   "select",
+		Short: "Select a stored WhatsApp button or list row",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(to) == "" || strings.TrimSpace(msgID) == "" {
+				return fmt.Errorf("--to and --id are required")
+			}
+			req := selectRequest{
+				Label:        label,
+				ButtonID:     buttonID,
+				Index:        index,
+				IndexSet:     cmd.Flags().Changed("index"),
+				Type:         typ,
+				Sender:       senderOverride,
+				PostSendWait: postSendWait,
+			}
+			if err := validateSelectRequest(req); err != nil {
+				return err
+			}
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				resp, delegated, delegateErr := tryDelegateSend(ctx, flags, err, sendDelegateRequest{
+					Kind:           "button_list_select",
+					To:             to,
+					Pick:           pick,
+					ID:             msgID,
+					Label:          label,
+					ButtonID:       buttonID,
+					SelectIndex:    index,
+					Type:           typ,
+					Sender:         senderOverride,
+					PostSendWaitMS: durationMillis(postSendWait),
+				})
+				if delegated {
+					if delegateErr != nil {
+						return delegateErr
+					}
+					return writeDelegatedSendOutput(flags, "button_list_select", resp)
+				}
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			toJID, err := resolveRecipient(a, to, recipientOptions{pick: pick, asJSON: flags.asJSON})
+			if err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+			toJID = warmupRecipient(ctx, a.WA(), toJID, os.Stderr)
+
+			res, err := sendButtonListSelection(ctx, a, toJID, msgID, req)
+			if err != nil {
+				return err
+			}
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, res)
+			}
+			fmt.Fprintf(os.Stdout, "Selected %q on %s in %s (id %s)\n", res.Selected.DisplayText, res.Target, res.To, res.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&to, "to", "", "chat JID, phone number, or contact/group/chat name where the message lives")
+	cmd.Flags().IntVar(&pick, "pick", 0, "when --to is ambiguous, pick the Nth match (1-indexed)")
+	cmd.Flags().StringVar(&msgID, "id", "", "button or list message ID")
+	cmd.Flags().StringVar(&label, "label", "", "select the option whose display text exactly matches this value after trimming")
+	cmd.Flags().StringVar(&buttonID, "button-id", "", "select the option whose stored button ID exactly matches this value after trimming")
+	cmd.Flags().IntVar(&index, "index", 0, "select the Nth selectable option (1-indexed)")
+	cmd.Flags().StringVar(&typ, "type", "", "filter selectable options by type: list_row or quick_reply")
+	cmd.Flags().StringVar(&senderOverride, "sender", "", "JID of the original message sender when the local store has no sender")
+	cmd.Flags().DurationVar(&postSendWait, "post-send-wait", postSendRetryReceiptWait, "keep the connection alive after send so retry receipts can be handled (0 disables)")
+	return cmd
+}
+
+func validateSelectRequest(req selectRequest) error {
+	choices := 0
+	if strings.TrimSpace(req.Label) != "" {
+		choices++
+	}
+	if strings.TrimSpace(req.ButtonID) != "" {
+		choices++
+	}
+	if req.IndexSet {
+		choices++
+		if req.Index < 1 {
+			return fmt.Errorf("--index must be 1 or greater")
+		}
+	}
+	if choices != 1 {
+		return fmt.Errorf("exactly one of --label, --button-id, or --index is required")
+	}
+	switch strings.TrimSpace(req.Type) {
+	case "", "list_row", "quick_reply":
+		return nil
+	default:
+		return fmt.Errorf("--type must be list_row or quick_reply")
+	}
+}
+
+func sendButtonListSelection(ctx context.Context, a *app.App, chat types.JID, targetID string, req selectRequest) (selectResult, error) {
+	target, chatJID, err := loadSelectTargetMessage(ctx, a, chat, targetID)
+	if err != nil {
+		return selectResult{}, err
+	}
+	selected, err := resolveSelectOption(target.Buttons, req)
+	if err != nil {
+		return selectResult{}, err
+	}
+	msg, err := buildSelectResponseMessage(selected, target, req.Sender)
+	if err != nil {
+		return selectResult{}, err
+	}
+	if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
+		return selectResult{}, err
+	}
+	sentID, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (types.MessageID, error) {
+		return sendSelectProto(ctx, a.WA(), chat, msg)
+	})
+	if err != nil {
+		return selectResult{}, err
+	}
+	now := time.Now().UTC()
+	persistOutboundSelection(ctx, a, chat, chatJID, string(sentID), selected, now)
+	waitForPostSendRetryReceipts(ctx, req.PostSendWait)
+	return selectResult{
+		Sent:     true,
+		To:       chat.String(),
+		ID:       string(sentID),
+		Target:   targetID,
+		Selected: selected,
+	}, nil
+}
+
+func sendSelectProto(ctx context.Context, sender selectSender, to types.JID, msg *waProto.Message) (types.MessageID, error) {
+	return sender.SendProtoMessage(ctx, to, msg)
+}
+
+func loadSelectTargetMessage(ctx context.Context, a *app.App, chat types.JID, msgID string) (store.Message, string, error) {
+	var lastErr error = sql.ErrNoRows
+	for _, chatJID := range pollChatJIDCandidates(ctx, a, chat) {
+		msg, err := a.DB().GetMessage(chatJID, msgID)
+		if err == nil {
+			if msg.FromMe {
+				return store.Message{}, "", fmt.Errorf("message %s in %s is from this account; select requires a stored inbound button or list message", msgID, chatJID)
+			}
+			return msg, chatJID, nil
+		}
+		lastErr = err
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		}
+		return store.Message{}, "", fmt.Errorf("lookup message: %w", err)
+	}
+	if errors.Is(lastErr, sql.ErrNoRows) {
+		return store.Message{}, "", fmt.Errorf("message %s not found in local store for chat %s; run `wacli sync` first", msgID, chat.String())
+	}
+	return store.Message{}, "", fmt.Errorf("lookup message: %w", lastErr)
+}
+
+func resolveSelectOption(buttons []store.Button, req selectRequest) (selectOption, error) {
+	filterType := strings.TrimSpace(req.Type)
+	var candidates []store.Button
+	for _, b := range buttons {
+		if filterType != "" && strings.TrimSpace(b.Type) != filterType {
+			continue
+		}
+		candidates = append(candidates, b)
+	}
+	if len(candidates) == 0 {
+		if filterType != "" {
+			return selectOption{}, fmt.Errorf("message has no %s options", filterType)
+		}
+		return selectOption{}, fmt.Errorf("message has no stored button or list options")
+	}
+
+	var matches []store.Button
+	switch {
+	case strings.TrimSpace(req.Label) != "":
+		label := strings.TrimSpace(req.Label)
+		for _, b := range candidates {
+			if strings.TrimSpace(b.DisplayText) == label {
+				matches = append(matches, b)
+			}
+		}
+	case strings.TrimSpace(req.ButtonID) != "":
+		id := strings.TrimSpace(req.ButtonID)
+		for _, b := range candidates {
+			if strings.TrimSpace(b.ID) == id {
+				matches = append(matches, b)
+			}
+		}
+	case req.IndexSet:
+		selectable := selectableButtons(candidates)
+		if req.Index > len(selectable) {
+			return selectOption{}, fmt.Errorf("--index %d is out of range; message has %d selectable option(s)", req.Index, len(selectable))
+		}
+		matches = append(matches, selectable[req.Index-1])
+	}
+
+	if len(matches) == 0 {
+		return selectOption{}, fmt.Errorf("no matching option found")
+	}
+	if len(matches) > 1 {
+		return selectOption{}, fmt.Errorf("multiple options match; candidates: %s", describeSelectCandidates(matches))
+	}
+	return normalizeSelectOption(matches[0])
+}
+
+func selectableButtons(buttons []store.Button) []store.Button {
+	out := make([]store.Button, 0, len(buttons))
+	for _, b := range buttons {
+		if isSelectableButtonType(b.Type) {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+func normalizeSelectOption(b store.Button) (selectOption, error) {
+	typ := strings.TrimSpace(b.Type)
+	if !isSelectableButtonType(typ) {
+		return selectOption{}, fmt.Errorf("option %q has unsupported control type %q", strings.TrimSpace(b.DisplayText), typ)
+	}
+	opt := selectOption{
+		Type:         typ,
+		DisplayText:  strings.TrimSpace(b.DisplayText),
+		ID:           strings.TrimSpace(b.ID),
+		ResponseType: strings.TrimSpace(b.ResponseType),
+		Index:        b.Index,
+		Description:  strings.TrimSpace(b.Description),
+	}
+	if opt.ResponseType == "" {
+		switch opt.Type {
+		case "list_row":
+			opt.ResponseType = selectResponseList
+		case "quick_reply":
+			return selectOption{}, fmt.Errorf("quick reply %q has no stored response_type; sync this message again with a newer wacli", opt.DisplayText)
+		}
+	}
+	return opt, nil
+}
+
+func isSelectableButtonType(typ string) bool {
+	switch strings.TrimSpace(typ) {
+	case "list_row", "quick_reply":
+		return true
+	default:
+		return false
+	}
+}
+
+func describeSelectCandidates(buttons []store.Button) string {
+	parts := make([]string, 0, len(buttons))
+	for _, b := range buttons {
+		label := strings.TrimSpace(b.DisplayText)
+		id := strings.TrimSpace(b.ID)
+		if id != "" {
+			parts = append(parts, fmt.Sprintf("%q (%s, id %q)", label, strings.TrimSpace(b.Type), id))
+		} else {
+			parts = append(parts, fmt.Sprintf("%q (%s)", label, strings.TrimSpace(b.Type)))
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+func buildSelectResponseMessage(opt selectOption, target store.Message, senderOverride string) (*waProto.Message, error) {
+	if opt.DisplayText == "" {
+		return nil, fmt.Errorf("selected option has no display text")
+	}
+	if opt.ID == "" {
+		return nil, fmt.Errorf("selected option %q has no stored ID; sync this message again with a newer wacli", opt.DisplayText)
+	}
+	ctx, err := buildSelectContextInfo(target, senderOverride)
+	if err != nil {
+		return nil, err
+	}
+	switch opt.ResponseType {
+	case selectResponseList:
+		return &waProto.Message{
+			ExtendedTextMessage: &waProto.ExtendedTextMessage{
+				Text:        proto.String(opt.DisplayText),
+				ContextInfo: ctx,
+			},
+		}, nil
+	case selectResponseButtons:
+		return &waProto.Message{
+			ExtendedTextMessage: &waProto.ExtendedTextMessage{
+				Text:        proto.String(opt.DisplayText),
+				ContextInfo: ctx,
+			},
+		}, nil
+	case selectResponseTemplate:
+		if opt.Index < 1 {
+			return nil, fmt.Errorf("template quick reply %q has no stored index; sync this message again with a newer wacli", opt.DisplayText)
+		}
+		selectedIndex := uint32(opt.Index)
+		return &waProto.Message{
+			TemplateButtonReplyMessage: &waProto.TemplateButtonReplyMessage{
+				SelectedID:          proto.String(opt.ID),
+				SelectedDisplayText: proto.String(opt.DisplayText),
+				SelectedIndex:       proto.Uint32(selectedIndex),
+				ContextInfo:         ctx,
+			},
+		}, nil
+	case selectResponseInteractive:
+		return nil, fmt.Errorf("native-flow quick replies are not supported yet; sync captured phone-tap fixtures before implementing interactive_response")
+	default:
+		return nil, fmt.Errorf("unsupported response_type %q; sync this message again with a newer wacli", opt.ResponseType)
+	}
+}
+
+func buildSelectContextInfo(target store.Message, senderOverride string) (*waProto.ContextInfo, error) {
+	stanzaID := strings.TrimSpace(target.MsgID)
+	if stanzaID == "" {
+		return nil, fmt.Errorf("target message ID is required")
+	}
+	info := &waProto.ContextInfo{StanzaID: proto.String(stanzaID)}
+	sender := strings.TrimSpace(senderOverride)
+	if sender == "" {
+		sender = strings.TrimSpace(target.SenderJID)
+	}
+	if sender != "" {
+		jid, err := wa.ParseUserOrJID(sender)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --sender: %w", err)
+		}
+		info.Participant = proto.String(jid.String())
+	}
+	return info, nil
+}
+
+func persistOutboundSelection(ctx context.Context, a *app.App, chat types.JID, chatJID, msgID string, selected selectOption, now time.Time) {
+	if strings.TrimSpace(chatJID) == "" {
+		chatJID = primaryPollChatJID(ctx, a, chat)
+	}
+	chatName := a.WA().ResolveChatName(ctx, chat, "")
+	if err := a.DB().UpsertChat(chatJID, chatKindFromJID(chat), chatName, now); err != nil {
+		warnOutboundPersist("chat", msgID, err)
+		return
+	}
+	if err := a.DB().UpsertMessage(store.UpsertMessageParams{
+		ChatJID:    chatJID,
+		ChatName:   chatName,
+		MsgID:      msgID,
+		SenderName: "me",
+		Timestamp:  now,
+		FromMe:     true,
+		Text:       "Selected: " + selected.DisplayText,
+	}); err != nil {
+		warnOutboundPersist("message", msgID, err)
+	}
+}
+
+func executeDelegatedButtonListSelect(ctx context.Context, a *app.App, req sendDelegateRequest) (sendDelegateResponse, error) {
+	if strings.TrimSpace(req.To) == "" || strings.TrimSpace(req.ID) == "" {
+		return sendDelegateResponse{}, fmt.Errorf("send select requires --to and --id")
+	}
+	selectReq := selectRequest{
+		Label:        req.Label,
+		ButtonID:     req.ButtonID,
+		Index:        req.SelectIndex,
+		IndexSet:     req.SelectIndex > 0,
+		Type:         req.Type,
+		Sender:       req.Sender,
+		PostSendWait: millisDuration(req.PostSendWaitMS, 0),
+	}
+	if err := validateSelectRequest(selectReq); err != nil {
+		return sendDelegateResponse{}, err
+	}
+	toJID, err := resolveRecipient(a, req.To, recipientOptions{pick: req.Pick, asJSON: true})
+	if err != nil {
+		return sendDelegateResponse{}, err
+	}
+	toJID = warmupDelegatedRecipient(ctx, a, toJID)
+	res, err := sendButtonListSelection(ctx, a, toJID, req.ID, selectReq)
+	if err != nil {
+		return sendDelegateResponse{}, err
+	}
+	return sendDelegateResponse{
+		OK:             true,
+		Sent:           true,
+		To:             res.To,
+		ID:             res.ID,
+		Target:         res.Target,
+		SelectedOption: &res.Selected,
+	}, nil
+}

--- a/cmd/wacli/send_select_cmd.go
+++ b/cmd/wacli/send_select_cmd.go
@@ -358,29 +358,17 @@ func buildSelectResponseMessage(chat types.JID, opt selectOption, target store.M
 	}
 	switch opt.ResponseType {
 	case selectResponseList:
-		listType := waProto.ListResponseMessage_SINGLE_SELECT
-		resp := &waProto.ListResponseMessage{
-			Title:             proto.String(opt.DisplayText),
-			ListType:          &listType,
-			SingleSelectReply: &waProto.ListResponseMessage_SingleSelectReply{SelectedRowID: proto.String(opt.ID)},
-			ContextInfo:       ctx,
-		}
-		if opt.Description != "" {
-			resp.Description = proto.String(opt.Description)
-		}
 		return &waProto.Message{
-			ListResponseMessage: resp,
+			ExtendedTextMessage: &waProto.ExtendedTextMessage{
+				Text:        proto.String(opt.DisplayText),
+				ContextInfo: ctx,
+			},
 		}, nil
 	case selectResponseButtons:
-		respType := waProto.ButtonsResponseMessage_DISPLAY_TEXT
 		return &waProto.Message{
-			ButtonsResponseMessage: &waProto.ButtonsResponseMessage{
-				SelectedButtonID: proto.String(opt.ID),
-				Response: &waProto.ButtonsResponseMessage_SelectedDisplayText{
-					SelectedDisplayText: opt.DisplayText,
-				},
+			ExtendedTextMessage: &waProto.ExtendedTextMessage{
+				Text:        proto.String(opt.DisplayText),
 				ContextInfo: ctx,
-				Type:        &respType,
 			},
 		}, nil
 	case selectResponseTemplate:

--- a/cmd/wacli/send_select_cmd.go
+++ b/cmd/wacli/send_select_cmd.go
@@ -255,6 +255,10 @@ func resolveSelectOption(buttons []store.Button, req selectRequest) (selectOptio
 		}
 		return selectOption{}, fmt.Errorf("message has no stored button or list options")
 	}
+	candidates = selectableButtons(candidates)
+	if len(candidates) == 0 {
+		return selectOption{}, fmt.Errorf("message has no selectable button or list options")
+	}
 
 	var matches []store.Button
 	switch {

--- a/cmd/wacli/send_select_cmd.go
+++ b/cmd/wacli/send_select_cmd.go
@@ -188,7 +188,7 @@ func sendButtonListSelection(ctx context.Context, a *app.App, chat types.JID, ta
 	if err != nil {
 		return selectResult{}, err
 	}
-	msg, err := buildSelectResponseMessage(selected, target, req.Sender)
+	msg, err := buildSelectResponseMessage(chat, selected, target, req.Sender)
 	if err != nil {
 		return selectResult{}, err
 	}
@@ -345,14 +345,14 @@ func describeSelectCandidates(buttons []store.Button) string {
 	return strings.Join(parts, "; ")
 }
 
-func buildSelectResponseMessage(opt selectOption, target store.Message, senderOverride string) (*waProto.Message, error) {
+func buildSelectResponseMessage(chat types.JID, opt selectOption, target store.Message, senderOverride string) (*waProto.Message, error) {
 	if opt.DisplayText == "" {
 		return nil, fmt.Errorf("selected option has no display text")
 	}
 	if opt.ID == "" {
 		return nil, fmt.Errorf("selected option %q has no stored ID; sync this message again with a newer wacli", opt.DisplayText)
 	}
-	ctx, err := buildSelectContextInfo(target, senderOverride)
+	ctx, err := buildSelectContextInfo(chat, target, senderOverride)
 	if err != nil {
 		return nil, err
 	}
@@ -403,24 +403,41 @@ func buildSelectResponseMessage(opt selectOption, target store.Message, senderOv
 	}
 }
 
-func buildSelectContextInfo(target store.Message, senderOverride string) (*waProto.ContextInfo, error) {
+func buildSelectContextInfo(chat types.JID, target store.Message, senderOverride string) (*waProto.ContextInfo, error) {
 	stanzaID := strings.TrimSpace(target.MsgID)
 	if stanzaID == "" {
 		return nil, fmt.Errorf("target message ID is required")
 	}
 	info := &waProto.ContextInfo{StanzaID: proto.String(stanzaID)}
-	sender := strings.TrimSpace(senderOverride)
-	if sender == "" {
-		sender = strings.TrimSpace(target.SenderJID)
+	jid, err := resolveSelectSender(chat, target, senderOverride)
+	if err != nil {
+		return nil, err
 	}
-	if sender != "" {
-		jid, err := wa.ParseUserOrJID(sender)
-		if err != nil {
-			return nil, fmt.Errorf("invalid --sender: %w", err)
-		}
+	if !jid.IsEmpty() {
 		info.Participant = proto.String(jid.String())
 	}
 	return info, nil
+}
+
+func resolveSelectSender(chat types.JID, target store.Message, override string) (types.JID, error) {
+	if strings.TrimSpace(override) != "" {
+		jid, err := wa.ParseUserOrJID(override)
+		if err != nil {
+			return types.JID{}, fmt.Errorf("invalid --sender: %w", err)
+		}
+		return jid, nil
+	}
+	if strings.TrimSpace(target.SenderJID) != "" {
+		jid, err := types.ParseJID(target.SenderJID)
+		if err != nil {
+			return types.JID{}, fmt.Errorf("stored target sender is invalid: %w", err)
+		}
+		return jid, nil
+	}
+	if chat.Server == types.GroupServer {
+		return types.JID{}, fmt.Errorf("--sender is required for unsynced group selections")
+	}
+	return types.JID{}, nil
 }
 
 func persistOutboundSelection(ctx context.Context, a *app.App, chat types.JID, chatJID, msgID string, selected selectOption, now time.Time) {

--- a/cmd/wacli/send_select_cmd.go
+++ b/cmd/wacli/send_select_cmd.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -272,7 +273,7 @@ func resolveSelectOption(buttons []store.Button, req selectRequest) (selectOptio
 			}
 		}
 	case req.IndexSet:
-		selectable := selectableButtons(candidates)
+		selectable := selectableButtonsByIndex(candidates)
 		if req.Index > len(selectable) {
 			return selectOption{}, fmt.Errorf("--index %d is out of range; message has %d selectable option(s)", req.Index, len(selectable))
 		}
@@ -295,6 +296,19 @@ func selectableButtons(buttons []store.Button) []store.Button {
 			out = append(out, b)
 		}
 	}
+	return out
+}
+
+func selectableButtonsByIndex(buttons []store.Button) []store.Button {
+	out := selectableButtons(buttons)
+	for _, b := range out {
+		if b.Index < 1 {
+			return out
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Index < out[j].Index
+	})
 	return out
 }
 

--- a/cmd/wacli/send_select_cmd.go
+++ b/cmd/wacli/send_select_cmd.go
@@ -358,17 +358,29 @@ func buildSelectResponseMessage(opt selectOption, target store.Message, senderOv
 	}
 	switch opt.ResponseType {
 	case selectResponseList:
+		listType := waProto.ListResponseMessage_SINGLE_SELECT
+		resp := &waProto.ListResponseMessage{
+			Title:             proto.String(opt.DisplayText),
+			ListType:          &listType,
+			SingleSelectReply: &waProto.ListResponseMessage_SingleSelectReply{SelectedRowID: proto.String(opt.ID)},
+			ContextInfo:       ctx,
+		}
+		if opt.Description != "" {
+			resp.Description = proto.String(opt.Description)
+		}
 		return &waProto.Message{
-			ExtendedTextMessage: &waProto.ExtendedTextMessage{
-				Text:        proto.String(opt.DisplayText),
-				ContextInfo: ctx,
-			},
+			ListResponseMessage: resp,
 		}, nil
 	case selectResponseButtons:
+		respType := waProto.ButtonsResponseMessage_DISPLAY_TEXT
 		return &waProto.Message{
-			ExtendedTextMessage: &waProto.ExtendedTextMessage{
-				Text:        proto.String(opt.DisplayText),
+			ButtonsResponseMessage: &waProto.ButtonsResponseMessage{
+				SelectedButtonID: proto.String(opt.ID),
+				Response: &waProto.ButtonsResponseMessage_SelectedDisplayText{
+					SelectedDisplayText: opt.DisplayText,
+				},
 				ContextInfo: ctx,
+				Type:        &respType,
 			},
 		}, nil
 	case selectResponseTemplate:

--- a/cmd/wacli/send_select_cmd.go
+++ b/cmd/wacli/send_select_cmd.go
@@ -376,29 +376,17 @@ func buildSelectResponseMessage(chat types.JID, opt selectOption, target store.M
 	}
 	switch opt.ResponseType {
 	case selectResponseList:
-		listType := waProto.ListResponseMessage_SINGLE_SELECT
-		resp := &waProto.ListResponseMessage{
-			Title:             proto.String(opt.DisplayText),
-			ListType:          &listType,
-			SingleSelectReply: &waProto.ListResponseMessage_SingleSelectReply{SelectedRowID: proto.String(opt.ID)},
-			ContextInfo:       ctx,
-		}
-		if opt.Description != "" {
-			resp.Description = proto.String(opt.Description)
-		}
 		return &waProto.Message{
-			ListResponseMessage: resp,
+			ExtendedTextMessage: &waProto.ExtendedTextMessage{
+				Text:        proto.String(opt.DisplayText),
+				ContextInfo: ctx,
+			},
 		}, nil
 	case selectResponseButtons:
-		respType := waProto.ButtonsResponseMessage_DISPLAY_TEXT
 		return &waProto.Message{
-			ButtonsResponseMessage: &waProto.ButtonsResponseMessage{
-				SelectedButtonID: proto.String(opt.ID),
-				Response: &waProto.ButtonsResponseMessage_SelectedDisplayText{
-					SelectedDisplayText: opt.DisplayText,
-				},
+			ExtendedTextMessage: &waProto.ExtendedTextMessage{
+				Text:        proto.String(opt.DisplayText),
 				ContextInfo: ctx,
-				Type:        &respType,
 			},
 		}, nil
 	case selectResponseTemplate:

--- a/cmd/wacli/send_select_cmd_test.go
+++ b/cmd/wacli/send_select_cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/openclaw/wacli/internal/store"
+	"go.mau.fi/whatsmeow/types"
 )
 
 func TestSendSelectCommandRegistered(t *testing.T) {
@@ -104,7 +105,7 @@ func TestResolveSelectOptionRejectsAmbiguousAndUnsupported(t *testing.T) {
 }
 
 func TestBuildSelectResponseMessageListRow(t *testing.T) {
-	msg, err := buildSelectResponseMessage(selectOption{
+	msg, err := buildSelectResponseMessage(types.JID{User: "15557654321", Server: types.DefaultUserServer}, selectOption{
 		Type:         "list_row",
 		DisplayText:  "Alpha",
 		ID:           "alpha",
@@ -127,7 +128,7 @@ func TestBuildSelectResponseMessageListRow(t *testing.T) {
 }
 
 func TestBuildSelectResponseMessageClassicButton(t *testing.T) {
-	msg, err := buildSelectResponseMessage(selectOption{
+	msg, err := buildSelectResponseMessage(types.JID{User: "15557654321", Server: types.DefaultUserServer}, selectOption{
 		Type:         "quick_reply",
 		DisplayText:  "Yes",
 		ID:           "yes",
@@ -149,7 +150,7 @@ func TestBuildSelectResponseMessageClassicButton(t *testing.T) {
 }
 
 func TestBuildSelectResponseMessageTemplateAndNativeFlow(t *testing.T) {
-	msg, err := buildSelectResponseMessage(selectOption{
+	msg, err := buildSelectResponseMessage(types.JID{User: "15557654321", Server: types.DefaultUserServer}, selectOption{
 		Type:         "quick_reply",
 		DisplayText:  "Book",
 		ID:           "book",
@@ -167,7 +168,7 @@ func TestBuildSelectResponseMessageTemplateAndNativeFlow(t *testing.T) {
 		t.Fatalf("template response = %+v", tbr)
 	}
 
-	_, err = buildSelectResponseMessage(selectOption{
+	_, err = buildSelectResponseMessage(types.JID{User: "15557654321", Server: types.DefaultUserServer}, selectOption{
 		Type:         "quick_reply",
 		DisplayText:  "Cancel",
 		ID:           "cancel",
@@ -175,5 +176,31 @@ func TestBuildSelectResponseMessageTemplateAndNativeFlow(t *testing.T) {
 	}, store.Message{MsgID: "inbound4"}, "")
 	if err == nil || !strings.Contains(err.Error(), "native-flow quick replies are not supported") {
 		t.Fatalf("native flow error = %v", err)
+	}
+}
+
+func TestBuildSelectResponseMessageRequiresSenderForUnsyncedGroup(t *testing.T) {
+	group := types.JID{User: "12345", Server: types.GroupServer}
+	_, err := buildSelectResponseMessage(group, selectOption{
+		Type:         "quick_reply",
+		DisplayText:  "Yes",
+		ID:           "yes",
+		ResponseType: selectResponseButtons,
+	}, store.Message{MsgID: "inbound5"}, "")
+	if err == nil || !strings.Contains(err.Error(), "--sender is required") {
+		t.Fatalf("missing sender error = %v", err)
+	}
+
+	msg, err := buildSelectResponseMessage(group, selectOption{
+		Type:         "quick_reply",
+		DisplayText:  "Yes",
+		ID:           "yes",
+		ResponseType: selectResponseButtons,
+	}, store.Message{MsgID: "inbound5"}, "15551234567@s.whatsapp.net")
+	if err != nil {
+		t.Fatalf("group sender override: %v", err)
+	}
+	if got := msg.GetButtonsResponseMessage().GetContextInfo().GetParticipant(); got != "15551234567@s.whatsapp.net" {
+		t.Fatalf("participant = %q", got)
 	}
 }

--- a/cmd/wacli/send_select_cmd_test.go
+++ b/cmd/wacli/send_select_cmd_test.go
@@ -114,15 +114,15 @@ func TestBuildSelectResponseMessageListRow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build list response: %v", err)
 	}
-	ext := msg.GetExtendedTextMessage()
-	if ext == nil {
-		t.Fatalf("missing ExtendedTextMessage")
+	resp := msg.GetListResponseMessage()
+	if resp == nil {
+		t.Fatalf("missing ListResponseMessage")
 	}
-	if ext.GetText() != "Alpha" {
-		t.Fatalf("extended text = %q", ext.GetText())
+	if resp.GetTitle() != "Alpha" || resp.GetSingleSelectReply().GetSelectedRowID() != "alpha" || resp.GetDescription() != "First item" {
+		t.Fatalf("list response = %+v", resp)
 	}
-	if ext.GetContextInfo().GetStanzaID() != "inbound1" || ext.GetContextInfo().GetParticipant() != "15551234567@s.whatsapp.net" {
-		t.Fatalf("context = %+v", ext.GetContextInfo())
+	if resp.GetContextInfo().GetStanzaID() != "inbound1" || resp.GetContextInfo().GetParticipant() != "15551234567@s.whatsapp.net" {
+		t.Fatalf("context = %+v", resp.GetContextInfo())
 	}
 }
 
@@ -136,15 +136,15 @@ func TestBuildSelectResponseMessageClassicButton(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build button response: %v", err)
 	}
-	ext := msg.GetExtendedTextMessage()
-	if ext == nil {
-		t.Fatalf("missing ExtendedTextMessage")
+	resp := msg.GetButtonsResponseMessage()
+	if resp == nil {
+		t.Fatalf("missing ButtonsResponseMessage")
 	}
-	if ext.GetText() != "Yes" {
-		t.Fatalf("extended text = %q", ext.GetText())
+	if resp.GetSelectedButtonID() != "yes" || resp.GetSelectedDisplayText() != "Yes" {
+		t.Fatalf("button response = %+v", resp)
 	}
-	if ext.GetContextInfo().GetStanzaID() != "inbound2" {
-		t.Fatalf("stanza = %q", ext.GetContextInfo().GetStanzaID())
+	if resp.GetContextInfo().GetStanzaID() != "inbound2" {
+		t.Fatalf("stanza = %q", resp.GetContextInfo().GetStanzaID())
 	}
 }
 

--- a/cmd/wacli/send_select_cmd_test.go
+++ b/cmd/wacli/send_select_cmd_test.go
@@ -134,7 +134,7 @@ func TestResolveSelectOptionRejectsAmbiguousAndUnsupported(t *testing.T) {
 	}
 }
 
-func TestBuildSelectResponseMessageListRow(t *testing.T) {
+func TestBuildSelectResponseMessageListRowSendsQuotedText(t *testing.T) {
 	msg, err := buildSelectResponseMessage(types.JID{User: "15557654321", Server: types.DefaultUserServer}, selectOption{
 		Type:         "list_row",
 		DisplayText:  "Alpha",
@@ -145,11 +145,11 @@ func TestBuildSelectResponseMessageListRow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build list response: %v", err)
 	}
-	resp := msg.GetListResponseMessage()
+	resp := msg.GetExtendedTextMessage()
 	if resp == nil {
-		t.Fatalf("missing ListResponseMessage")
+		t.Fatalf("missing ExtendedTextMessage")
 	}
-	if resp.GetTitle() != "Alpha" || resp.GetSingleSelectReply().GetSelectedRowID() != "alpha" || resp.GetDescription() != "First item" {
+	if resp.GetText() != "Alpha" {
 		t.Fatalf("list response = %+v", resp)
 	}
 	if resp.GetContextInfo().GetStanzaID() != "inbound1" || resp.GetContextInfo().GetParticipant() != "15551234567@s.whatsapp.net" {
@@ -157,7 +157,7 @@ func TestBuildSelectResponseMessageListRow(t *testing.T) {
 	}
 }
 
-func TestBuildSelectResponseMessageClassicButton(t *testing.T) {
+func TestBuildSelectResponseMessageClassicButtonSendsQuotedText(t *testing.T) {
 	msg, err := buildSelectResponseMessage(types.JID{User: "15557654321", Server: types.DefaultUserServer}, selectOption{
 		Type:         "quick_reply",
 		DisplayText:  "Yes",
@@ -167,11 +167,11 @@ func TestBuildSelectResponseMessageClassicButton(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build button response: %v", err)
 	}
-	resp := msg.GetButtonsResponseMessage()
+	resp := msg.GetExtendedTextMessage()
 	if resp == nil {
-		t.Fatalf("missing ButtonsResponseMessage")
+		t.Fatalf("missing ExtendedTextMessage")
 	}
-	if resp.GetSelectedButtonID() != "yes" || resp.GetSelectedDisplayText() != "Yes" {
+	if resp.GetText() != "Yes" {
 		t.Fatalf("button response = %+v", resp)
 	}
 	if resp.GetContextInfo().GetStanzaID() != "inbound2" {
@@ -230,7 +230,7 @@ func TestBuildSelectResponseMessageRequiresSenderForUnsyncedGroup(t *testing.T) 
 	if err != nil {
 		t.Fatalf("group sender override: %v", err)
 	}
-	if got := msg.GetButtonsResponseMessage().GetContextInfo().GetParticipant(); got != "15551234567@s.whatsapp.net" {
+	if got := msg.GetExtendedTextMessage().GetContextInfo().GetParticipant(); got != "15551234567@s.whatsapp.net" {
 		t.Fatalf("participant = %q", got)
 	}
 }

--- a/cmd/wacli/send_select_cmd_test.go
+++ b/cmd/wacli/send_select_cmd_test.go
@@ -79,6 +79,21 @@ func TestResolveSelectOption(t *testing.T) {
 	}
 }
 
+func TestResolveSelectOptionUsesStoredIndexOrder(t *testing.T) {
+	buttons := []store.Button{
+		{Type: "quick_reply", DisplayText: "Second", ID: "second", ResponseType: selectResponseTemplate, Index: 2},
+		{Type: "quick_reply", DisplayText: "First", ID: "first", ResponseType: selectResponseTemplate, Index: 1},
+	}
+
+	byIndex, err := resolveSelectOption(buttons, selectRequest{Index: 1, IndexSet: true})
+	if err != nil {
+		t.Fatalf("index select: %v", err)
+	}
+	if byIndex.ID != "first" || byIndex.Index != 1 {
+		t.Fatalf("index select = %+v, want first stored index", byIndex)
+	}
+}
+
 func TestResolveSelectOptionRejectsAmbiguousAndUnsupported(t *testing.T) {
 	_, err := resolveSelectOption([]store.Button{
 		{Type: "quick_reply", DisplayText: "Same", ID: "a"},

--- a/cmd/wacli/send_select_cmd_test.go
+++ b/cmd/wacli/send_select_cmd_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openclaw/wacli/internal/store"
+)
+
+func TestSendSelectCommandRegistered(t *testing.T) {
+	cmd := newSendCmd(&rootFlags{})
+	found := false
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "select" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("send select command was not registered")
+	}
+}
+
+func TestValidateSelectRequestRequiresExactlyOneSelector(t *testing.T) {
+	tests := []struct {
+		name string
+		req  selectRequest
+		want string
+	}{
+		{name: "none", req: selectRequest{}, want: "exactly one"},
+		{name: "two", req: selectRequest{Label: "Yes", ButtonID: "yes"}, want: "exactly one"},
+		{name: "bad index", req: selectRequest{IndexSet: true}, want: "--index must be 1"},
+		{name: "bad type", req: selectRequest{Label: "Yes", Type: "url"}, want: "--type must be"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSelectRequest(tt.req)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+
+	if err := validateSelectRequest(selectRequest{Label: "Yes", Type: "quick_reply"}); err != nil {
+		t.Fatalf("valid request: %v", err)
+	}
+}
+
+func TestResolveSelectOption(t *testing.T) {
+	buttons := []store.Button{
+		{Type: "list", DisplayText: "Menu"},
+		{Type: "url", DisplayText: "Open", URL: "https://example.com"},
+		{Type: "list_row", DisplayText: "Alpha", ID: "alpha"},
+		{Type: "quick_reply", DisplayText: "Beta", ID: "beta", ResponseType: selectResponseButtons},
+	}
+
+	byLabel, err := resolveSelectOption(buttons, selectRequest{Label: " Alpha "})
+	if err != nil {
+		t.Fatalf("label select: %v", err)
+	}
+	if byLabel.Type != "list_row" || byLabel.ID != "alpha" || byLabel.ResponseType != selectResponseList {
+		t.Fatalf("label select = %+v", byLabel)
+	}
+
+	byID, err := resolveSelectOption(buttons, selectRequest{ButtonID: " beta "})
+	if err != nil {
+		t.Fatalf("button-id select: %v", err)
+	}
+	if byID.Type != "quick_reply" || byID.ID != "beta" || byID.ResponseType != selectResponseButtons {
+		t.Fatalf("button-id select = %+v", byID)
+	}
+
+	byIndex, err := resolveSelectOption(buttons, selectRequest{Index: 2, IndexSet: true})
+	if err != nil {
+		t.Fatalf("index select: %v", err)
+	}
+	if byIndex.ID != "beta" {
+		t.Fatalf("index select ID = %q, want beta", byIndex.ID)
+	}
+}
+
+func TestResolveSelectOptionRejectsAmbiguousAndUnsupported(t *testing.T) {
+	_, err := resolveSelectOption([]store.Button{
+		{Type: "quick_reply", DisplayText: "Same", ID: "a"},
+		{Type: "quick_reply", DisplayText: "Same", ID: "b"},
+	}, selectRequest{Label: "Same"})
+	if err == nil || !strings.Contains(err.Error(), "multiple options match") {
+		t.Fatalf("ambiguous error = %v", err)
+	}
+
+	_, err = resolveSelectOption([]store.Button{
+		{Type: "url", DisplayText: "Open", URL: "https://example.com"},
+	}, selectRequest{Label: "Open"})
+	if err == nil || !strings.Contains(err.Error(), "unsupported control type") {
+		t.Fatalf("unsupported error = %v", err)
+	}
+
+	_, err = resolveSelectOption([]store.Button{
+		{Type: "quick_reply", DisplayText: "Old", ID: "old"},
+	}, selectRequest{Label: "Old"})
+	if err == nil || !strings.Contains(err.Error(), "sync this message again with a newer wacli") {
+		t.Fatalf("old quick reply error = %v", err)
+	}
+}
+
+func TestBuildSelectResponseMessageListRow(t *testing.T) {
+	msg, err := buildSelectResponseMessage(selectOption{
+		Type:         "list_row",
+		DisplayText:  "Alpha",
+		ID:           "alpha",
+		Description:  "First item",
+		ResponseType: selectResponseList,
+	}, store.Message{MsgID: "inbound1", SenderJID: "15551234567@s.whatsapp.net"}, "")
+	if err != nil {
+		t.Fatalf("build list response: %v", err)
+	}
+	ext := msg.GetExtendedTextMessage()
+	if ext == nil {
+		t.Fatalf("missing ExtendedTextMessage")
+	}
+	if ext.GetText() != "Alpha" {
+		t.Fatalf("extended text = %q", ext.GetText())
+	}
+	if ext.GetContextInfo().GetStanzaID() != "inbound1" || ext.GetContextInfo().GetParticipant() != "15551234567@s.whatsapp.net" {
+		t.Fatalf("context = %+v", ext.GetContextInfo())
+	}
+}
+
+func TestBuildSelectResponseMessageClassicButton(t *testing.T) {
+	msg, err := buildSelectResponseMessage(selectOption{
+		Type:         "quick_reply",
+		DisplayText:  "Yes",
+		ID:           "yes",
+		ResponseType: selectResponseButtons,
+	}, store.Message{MsgID: "inbound2"}, "")
+	if err != nil {
+		t.Fatalf("build button response: %v", err)
+	}
+	ext := msg.GetExtendedTextMessage()
+	if ext == nil {
+		t.Fatalf("missing ExtendedTextMessage")
+	}
+	if ext.GetText() != "Yes" {
+		t.Fatalf("extended text = %q", ext.GetText())
+	}
+	if ext.GetContextInfo().GetStanzaID() != "inbound2" {
+		t.Fatalf("stanza = %q", ext.GetContextInfo().GetStanzaID())
+	}
+}
+
+func TestBuildSelectResponseMessageTemplateAndNativeFlow(t *testing.T) {
+	msg, err := buildSelectResponseMessage(selectOption{
+		Type:         "quick_reply",
+		DisplayText:  "Book",
+		ID:           "book",
+		ResponseType: selectResponseTemplate,
+		Index:        2,
+	}, store.Message{MsgID: "inbound3"}, "")
+	if err != nil {
+		t.Fatalf("build template response: %v", err)
+	}
+	tbr := msg.GetTemplateButtonReplyMessage()
+	if tbr == nil {
+		t.Fatalf("missing TemplateButtonReplyMessage")
+	}
+	if tbr.GetSelectedID() != "book" || tbr.GetSelectedDisplayText() != "Book" || tbr.GetSelectedIndex() != 2 {
+		t.Fatalf("template response = %+v", tbr)
+	}
+
+	_, err = buildSelectResponseMessage(selectOption{
+		Type:         "quick_reply",
+		DisplayText:  "Cancel",
+		ID:           "cancel",
+		ResponseType: selectResponseInteractive,
+	}, store.Message{MsgID: "inbound4"}, "")
+	if err == nil || !strings.Contains(err.Error(), "native-flow quick replies are not supported") {
+		t.Fatalf("native flow error = %v", err)
+	}
+}

--- a/cmd/wacli/send_select_cmd_test.go
+++ b/cmd/wacli/send_select_cmd_test.go
@@ -134,7 +134,7 @@ func TestResolveSelectOptionRejectsAmbiguousAndUnsupported(t *testing.T) {
 	}
 }
 
-func TestBuildSelectResponseMessageListRowSendsQuotedText(t *testing.T) {
+func TestBuildSelectResponseMessageListRow(t *testing.T) {
 	msg, err := buildSelectResponseMessage(types.JID{User: "15557654321", Server: types.DefaultUserServer}, selectOption{
 		Type:         "list_row",
 		DisplayText:  "Alpha",
@@ -145,11 +145,11 @@ func TestBuildSelectResponseMessageListRowSendsQuotedText(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build list response: %v", err)
 	}
-	resp := msg.GetExtendedTextMessage()
+	resp := msg.GetListResponseMessage()
 	if resp == nil {
-		t.Fatalf("missing ExtendedTextMessage")
+		t.Fatalf("missing ListResponseMessage")
 	}
-	if resp.GetText() != "Alpha" {
+	if resp.GetTitle() != "Alpha" || resp.GetSingleSelectReply().GetSelectedRowID() != "alpha" || resp.GetDescription() != "First item" {
 		t.Fatalf("list response = %+v", resp)
 	}
 	if resp.GetContextInfo().GetStanzaID() != "inbound1" || resp.GetContextInfo().GetParticipant() != "15551234567@s.whatsapp.net" {
@@ -157,7 +157,7 @@ func TestBuildSelectResponseMessageListRowSendsQuotedText(t *testing.T) {
 	}
 }
 
-func TestBuildSelectResponseMessageClassicButtonSendsQuotedText(t *testing.T) {
+func TestBuildSelectResponseMessageClassicButton(t *testing.T) {
 	msg, err := buildSelectResponseMessage(types.JID{User: "15557654321", Server: types.DefaultUserServer}, selectOption{
 		Type:         "quick_reply",
 		DisplayText:  "Yes",
@@ -167,11 +167,11 @@ func TestBuildSelectResponseMessageClassicButtonSendsQuotedText(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build button response: %v", err)
 	}
-	resp := msg.GetExtendedTextMessage()
+	resp := msg.GetButtonsResponseMessage()
 	if resp == nil {
-		t.Fatalf("missing ExtendedTextMessage")
+		t.Fatalf("missing ButtonsResponseMessage")
 	}
-	if resp.GetText() != "Yes" {
+	if resp.GetSelectedButtonID() != "yes" || resp.GetSelectedDisplayText() != "Yes" {
 		t.Fatalf("button response = %+v", resp)
 	}
 	if resp.GetContextInfo().GetStanzaID() != "inbound2" {
@@ -230,7 +230,7 @@ func TestBuildSelectResponseMessageRequiresSenderForUnsyncedGroup(t *testing.T) 
 	if err != nil {
 		t.Fatalf("group sender override: %v", err)
 	}
-	if got := msg.GetExtendedTextMessage().GetContextInfo().GetParticipant(); got != "15551234567@s.whatsapp.net" {
+	if got := msg.GetButtonsResponseMessage().GetContextInfo().GetParticipant(); got != "15551234567@s.whatsapp.net" {
 		t.Fatalf("participant = %q", got)
 	}
 }

--- a/cmd/wacli/send_select_cmd_test.go
+++ b/cmd/wacli/send_select_cmd_test.go
@@ -104,7 +104,7 @@ func TestResolveSelectOptionRejectsAmbiguousAndUnsupported(t *testing.T) {
 	}
 }
 
-func TestBuildSelectResponseMessageListRow(t *testing.T) {
+func TestBuildSelectResponseMessageListRowSendsQuotedText(t *testing.T) {
 	msg, err := buildSelectResponseMessage(types.JID{User: "15557654321", Server: types.DefaultUserServer}, selectOption{
 		Type:         "list_row",
 		DisplayText:  "Alpha",
@@ -115,11 +115,11 @@ func TestBuildSelectResponseMessageListRow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build list response: %v", err)
 	}
-	resp := msg.GetListResponseMessage()
+	resp := msg.GetExtendedTextMessage()
 	if resp == nil {
-		t.Fatalf("missing ListResponseMessage")
+		t.Fatalf("missing ExtendedTextMessage")
 	}
-	if resp.GetTitle() != "Alpha" || resp.GetSingleSelectReply().GetSelectedRowID() != "alpha" || resp.GetDescription() != "First item" {
+	if resp.GetText() != "Alpha" {
 		t.Fatalf("list response = %+v", resp)
 	}
 	if resp.GetContextInfo().GetStanzaID() != "inbound1" || resp.GetContextInfo().GetParticipant() != "15551234567@s.whatsapp.net" {
@@ -127,7 +127,7 @@ func TestBuildSelectResponseMessageListRow(t *testing.T) {
 	}
 }
 
-func TestBuildSelectResponseMessageClassicButton(t *testing.T) {
+func TestBuildSelectResponseMessageClassicButtonSendsQuotedText(t *testing.T) {
 	msg, err := buildSelectResponseMessage(types.JID{User: "15557654321", Server: types.DefaultUserServer}, selectOption{
 		Type:         "quick_reply",
 		DisplayText:  "Yes",
@@ -137,11 +137,11 @@ func TestBuildSelectResponseMessageClassicButton(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build button response: %v", err)
 	}
-	resp := msg.GetButtonsResponseMessage()
+	resp := msg.GetExtendedTextMessage()
 	if resp == nil {
-		t.Fatalf("missing ButtonsResponseMessage")
+		t.Fatalf("missing ExtendedTextMessage")
 	}
-	if resp.GetSelectedButtonID() != "yes" || resp.GetSelectedDisplayText() != "Yes" {
+	if resp.GetText() != "Yes" {
 		t.Fatalf("button response = %+v", resp)
 	}
 	if resp.GetContextInfo().GetStanzaID() != "inbound2" {
@@ -200,7 +200,7 @@ func TestBuildSelectResponseMessageRequiresSenderForUnsyncedGroup(t *testing.T) 
 	if err != nil {
 		t.Fatalf("group sender override: %v", err)
 	}
-	if got := msg.GetButtonsResponseMessage().GetContextInfo().GetParticipant(); got != "15551234567@s.whatsapp.net" {
+	if got := msg.GetExtendedTextMessage().GetContextInfo().GetParticipant(); got != "15551234567@s.whatsapp.net" {
 		t.Fatalf("participant = %q", got)
 	}
 }

--- a/cmd/wacli/send_select_cmd_test.go
+++ b/cmd/wacli/send_select_cmd_test.go
@@ -94,6 +94,21 @@ func TestResolveSelectOptionUsesStoredIndexOrder(t *testing.T) {
 	}
 }
 
+func TestResolveSelectOptionIgnoresNonSelectableMatches(t *testing.T) {
+	buttons := []store.Button{
+		{Type: "url", DisplayText: "Same", URL: "https://example.com"},
+		{Type: "quick_reply", DisplayText: "Same", ID: "same", ResponseType: selectResponseButtons},
+	}
+
+	byLabel, err := resolveSelectOption(buttons, selectRequest{Label: "Same"})
+	if err != nil {
+		t.Fatalf("label select: %v", err)
+	}
+	if byLabel.ID != "same" {
+		t.Fatalf("label select = %+v, want quick reply", byLabel)
+	}
+}
+
 func TestResolveSelectOptionRejectsAmbiguousAndUnsupported(t *testing.T) {
 	_, err := resolveSelectOption([]store.Button{
 		{Type: "quick_reply", DisplayText: "Same", ID: "a"},
@@ -106,7 +121,7 @@ func TestResolveSelectOptionRejectsAmbiguousAndUnsupported(t *testing.T) {
 	_, err = resolveSelectOption([]store.Button{
 		{Type: "url", DisplayText: "Open", URL: "https://example.com"},
 	}, selectRequest{Label: "Open"})
-	if err == nil || !strings.Contains(err.Error(), "unsupported control type") {
+	if err == nil || !strings.Contains(err.Error(), "no selectable button or list options") {
 		t.Fatalf("unsupported error = %v", err)
 	}
 

--- a/cmd/wacli/send_select_cmd_test.go
+++ b/cmd/wacli/send_select_cmd_test.go
@@ -163,7 +163,7 @@ func TestBuildSelectResponseMessageTemplateAndNativeFlow(t *testing.T) {
 	if tbr == nil {
 		t.Fatalf("missing TemplateButtonReplyMessage")
 	}
-	if tbr.GetSelectedID() != "book" || tbr.GetSelectedDisplayText() != "Book" || tbr.GetSelectedIndex() != 2 {
+	if tbr.GetSelectedID() != "book" || tbr.GetSelectedDisplayText() != "Book" || tbr.GetSelectedIndex() != 1 {
 		t.Fatalf("template response = %+v", tbr)
 	}
 

--- a/docs/send.md
+++ b/docs/send.md
@@ -67,7 +67,8 @@ wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 - `--index` is 1-indexed and counts selectable controls only. URL buttons, call buttons, and list container buttons are excluded.
 - Use `--type list_row` or `--type quick_reply` to narrow the candidate set.
 - List rows from older stores are safely inferred as list responses, but older quick replies without `response_type` fail with a sync-again error.
-- Synced list rows and plain quick replies send WhatsApp list/button response messages with the stored option ID.
+- Synced list rows and plain quick replies send the selected display text as a quoted reply to the original message.
+- This intentionally treats selection as a quoted text reply, not as a synthetic phone-tap event.
 - Native-flow quick replies are detected but not sent yet; wacli returns an explicit unsupported error instead of guessing the wire format.
 - Sent selections are stored locally as `Selected: <display text>` and support JSON output for scripts.
 

--- a/docs/send.md
+++ b/docs/send.md
@@ -67,7 +67,7 @@ wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 - `--index` is 1-indexed and counts selectable controls only. URL buttons, call buttons, and list container buttons are excluded.
 - Use `--type list_row` or `--type quick_reply` to narrow the candidate set.
 - List rows from older stores are safely inferred as list responses, but older quick replies without `response_type` fail with a sync-again error.
-- Synced list rows and plain quick replies send structured `list_response` / `buttons_response` payloads with the stored option ID and quote the original message.
+- Synced list rows and plain quick replies send the selected display text as a quoted reply to the original message.
 - Native-flow quick replies are detected but not sent yet; wacli returns an explicit unsupported error instead of guessing the wire format.
 - Sent selections are stored locally as `Selected: <display text>` and support JSON output for scripts.
 

--- a/docs/send.md
+++ b/docs/send.md
@@ -67,7 +67,7 @@ wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 - `--index` is 1-indexed and counts selectable controls only. URL buttons, call buttons, and list container buttons are excluded.
 - Use `--type list_row` or `--type quick_reply` to narrow the candidate set.
 - List rows from older stores are safely inferred as list responses, but older quick replies without `response_type` fail with a sync-again error.
-- Synced list rows and plain quick replies are sent as quoted text replies to the original message. Structured `list_response` and `buttons_response` sends are not used for these controls.
+- Synced list rows and plain quick replies send structured `list_response` / `buttons_response` payloads with the stored option ID and quote the original message.
 - Native-flow quick replies are detected but not sent yet; wacli returns an explicit unsupported error instead of guessing the wire format.
 - Sent selections are stored locally as `Selected: <display text>` and support JSON output for scripts.
 

--- a/docs/send.md
+++ b/docs/send.md
@@ -16,6 +16,7 @@ wacli send voice --to RECIPIENT --file PATH [--pick N] [--mime TYPE] [--reply-to
 wacli send react --to PHONE_OR_JID --id MSG_ID [--reaction TEXT] [--sender JID] [--post-send-wait 2s]
 wacli send poll --to RECIPIENT --question TEXT --option TEXT --option TEXT [--multi N] [--ephemeral] [--post-send-wait 2s]
 wacli send status [--message TEXT] [--file PATH] [--mime TYPE] [--background-color '#RRGGBB'] [--font N] [--post-send-wait 2s]
+wacli send select --to RECIPIENT --id MSG_ID (--label TEXT | --button-id ID | --index N) [--type list_row|quick_reply] [--pick N] [--sender JID] [--post-send-wait 2s]
 wacli poll vote --to RECIPIENT --id MSG_ID --option TEXT [--option TEXT] [--sender JID] [--post-send-wait 2s]
 wacli poll show --to RECIPIENT --id MSG_ID [--json]
 wacli polls list [--chat RECIPIENT] [--limit N] [--json]
@@ -55,6 +56,20 @@ wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 - For unsynced group polls, pass `--sender` with the poll author's JID.
 - `poll show` prints current aggregates and per-voter selections from the local store. JSON output includes `unknown_hashes` for vote hashes that could not be matched to a stored option.
 - `polls list` shows recently synced or sent polls, optionally filtered with `--chat`.
+
+## Buttons and lists
+
+- `send select` selects a stored inbound WhatsApp quick-reply button or list row.
+- Sync the target chat first, then pass the inbound button or list message ID with `--id`.
+- Select exactly one option with `--label`, `--button-id`, or `--index`.
+- `--label` matches stored display text exactly after trimming whitespace. Ambiguous labels fail before sending.
+- `--button-id` matches the stored WhatsApp option ID exactly after trimming whitespace.
+- `--index` is 1-indexed and counts selectable controls only. URL buttons, call buttons, and list container buttons are excluded.
+- Use `--type list_row` or `--type quick_reply` to narrow the candidate set.
+- List rows from older stores are safely inferred as list responses, but older quick replies without `response_type` fail with a sync-again error.
+- Synced list rows and plain quick replies are sent as quoted text replies to the original message. Structured `list_response` and `buttons_response` sends are not used for these controls.
+- Native-flow quick replies are detected but not sent yet; wacli returns an explicit unsupported error instead of guessing the wire format.
+- Sent selections are stored locally as `Selected: <display text>` and support JSON output for scripts.
 
 ## Status broadcasts
 
@@ -98,6 +113,8 @@ wacli send react --to 1234567890 --id ABC123 --reaction "❤️"
 wacli send poll --to "Family" --question "Dinner?" --option "Pizza" --option "Sushi" --multi 1
 wacli send status --message "available today" --background-color '#1f7a8c' --font 1
 wacli send status --file ./photo.jpg --message "new update"
+wacli send select --to "Example Bot" --id ABC123 --label "View available lessons" --json
+wacli send select --to "Example Bot" --id ABC123 --index 2 --type list_row
 wacli poll vote --to "Family" --id ABC123 --option "Pizza"
 wacli poll show --to "Family" --id ABC123 --json
 wacli polls list --chat "Family" --limit 10

--- a/docs/send.md
+++ b/docs/send.md
@@ -67,7 +67,7 @@ wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 - `--index` is 1-indexed and counts selectable controls only. URL buttons, call buttons, and list container buttons are excluded.
 - Use `--type list_row` or `--type quick_reply` to narrow the candidate set.
 - List rows from older stores are safely inferred as list responses, but older quick replies without `response_type` fail with a sync-again error.
-- Synced list rows and plain quick replies send the selected display text as a quoted reply to the original message.
+- Synced list rows and plain quick replies send WhatsApp list/button response messages with the stored option ID.
 - Native-flow quick replies are detected but not sent yet; wacli returns an explicit unsupported error instead of guessing the wire format.
 - Sent selections are stored locally as `Selected: <display text>` and support JSON output for scripts.
 

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -562,12 +562,14 @@ func waButtonsToStore(buttons []wa.Button) []store.Button {
 	out := make([]store.Button, len(buttons))
 	for i, b := range buttons {
 		out[i] = store.Button{
-			Type:        b.Type,
-			DisplayText: b.DisplayText,
-			ID:          b.ID,
-			URL:         b.URL,
-			PhoneNumber: b.PhoneNumber,
-			Description: b.Description,
+			Type:         b.Type,
+			DisplayText:  b.DisplayText,
+			ID:           b.ID,
+			URL:          b.URL,
+			PhoneNumber:  b.PhoneNumber,
+			Description:  b.Description,
+			ResponseType: b.ResponseType,
+			Index:        b.Index,
 		}
 	}
 	return out

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -877,8 +877,8 @@ func TestMessageButtonsListRowRoundTrip(t *testing.T) {
 
 	buttons := []Button{
 		{Type: "list", DisplayText: "Options"},
-		{Type: "list_row", DisplayText: "Alice", ID: "alice", Description: "Send to Alice"},
-		{Type: "list_row", DisplayText: "Bob", ID: "bob"},
+		{Type: "list_row", DisplayText: "Alice", ID: "alice", Description: "Send to Alice", ResponseType: "list_response", Index: 1},
+		{Type: "list_row", DisplayText: "Bob", ID: "bob", ResponseType: "list_response", Index: 2},
 	}
 	if err := db.UpsertMessage(UpsertMessageParams{
 		ChatJID:   chat,
@@ -901,10 +901,10 @@ func TestMessageButtonsListRowRoundTrip(t *testing.T) {
 	if msg.Buttons[0].Type != "list" || msg.Buttons[0].DisplayText != "Options" {
 		t.Fatalf("unexpected list button: %+v", msg.Buttons[0])
 	}
-	if msg.Buttons[1].ID != "alice" || msg.Buttons[1].Description != "Send to Alice" {
+	if msg.Buttons[1].ID != "alice" || msg.Buttons[1].Description != "Send to Alice" || msg.Buttons[1].ResponseType != "list_response" || msg.Buttons[1].Index != 1 {
 		t.Fatalf("unexpected row[0]: %+v", msg.Buttons[1])
 	}
-	if msg.Buttons[2].ID != "bob" || msg.Buttons[2].Description != "" {
+	if msg.Buttons[2].ID != "bob" || msg.Buttons[2].Description != "" || msg.Buttons[2].ResponseType != "list_response" || msg.Buttons[2].Index != 2 {
 		t.Fatalf("unexpected row[1]: %+v", msg.Buttons[2])
 	}
 }

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -60,12 +60,14 @@ type MediaDownloadInfo struct {
 }
 
 type Button struct {
-	Type        string `json:"type"`
-	DisplayText string `json:"display_text"`
-	ID          string `json:"id,omitempty"`
-	URL         string `json:"url,omitempty"`
-	PhoneNumber string `json:"phone_number,omitempty"`
-	Description string `json:"description,omitempty"`
+	Type         string `json:"type"`
+	DisplayText  string `json:"display_text"`
+	ID           string `json:"id,omitempty"`
+	URL          string `json:"url,omitempty"`
+	PhoneNumber  string `json:"phone_number,omitempty"`
+	Description  string `json:"description,omitempty"`
+	ResponseType string `json:"response_type,omitempty"`
+	Index        int    `json:"index,omitempty"`
 }
 
 type Message struct {

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -23,12 +23,14 @@ type Media struct {
 }
 
 type Button struct {
-	Type        string `json:"type"`
-	DisplayText string `json:"display_text"`
-	ID          string `json:"id,omitempty"`
-	URL         string `json:"url,omitempty"`
-	PhoneNumber string `json:"phone_number,omitempty"`
-	Description string `json:"description,omitempty"`
+	Type         string `json:"type"`
+	DisplayText  string `json:"display_text"`
+	ID           string `json:"id,omitempty"`
+	URL          string `json:"url,omitempty"`
+	PhoneNumber  string `json:"phone_number,omitempty"`
+	Description  string `json:"description,omitempty"`
+	ResponseType string `json:"response_type,omitempty"`
+	Index        int    `json:"index,omitempty"`
 }
 
 // Poll captures the question + option list extracted from an incoming

--- a/internal/wa/messages_business.go
+++ b/internal/wa/messages_business.go
@@ -23,24 +23,28 @@ func extractBusinessText(m *waProto.Message, pm *ParsedMessage) {
 				}
 				pm.Text = strings.Join(parts, "\n")
 			}
-			for _, hb := range hydrated.GetHydratedButtons() {
+			for i, hb := range hydrated.GetHydratedButtons() {
 				if btn := hb.GetUrlButton(); btn != nil {
 					pm.Buttons = append(pm.Buttons, Button{
 						Type:        "url",
 						DisplayText: strings.TrimSpace(btn.GetDisplayText()),
 						URL:         strings.TrimSpace(btn.GetURL()),
+						Index:       i + 1,
 					})
 				} else if btn := hb.GetQuickReplyButton(); btn != nil {
 					pm.Buttons = append(pm.Buttons, Button{
-						Type:        "quick_reply",
-						DisplayText: strings.TrimSpace(btn.GetDisplayText()),
-						ID:          strings.TrimSpace(btn.GetID()),
+						Type:         "quick_reply",
+						DisplayText:  strings.TrimSpace(btn.GetDisplayText()),
+						ID:           strings.TrimSpace(btn.GetID()),
+						ResponseType: "template_button_reply",
+						Index:        i + 1,
 					})
 				} else if btn := hb.GetCallButton(); btn != nil {
 					pm.Buttons = append(pm.Buttons, Button{
 						Type:        "call",
 						DisplayText: strings.TrimSpace(btn.GetDisplayText()),
 						PhoneNumber: strings.TrimSpace(btn.GetPhoneNumber()),
+						Index:       i + 1,
 					})
 				}
 			}
@@ -66,14 +70,16 @@ func extractBusinessText(m *waProto.Message, pm *ParsedMessage) {
 			}
 			pm.Text = strings.Join(parts, "\n")
 		}
-		for _, b := range btn.GetButtons() {
+		for i, b := range btn.GetButtons() {
 			if bt := b.GetButtonText(); bt != nil {
 				dt := strings.TrimSpace(bt.GetDisplayText())
 				if dt != "" {
 					pm.Buttons = append(pm.Buttons, Button{
-						Type:        "quick_reply",
-						DisplayText: dt,
-						ID:          strings.TrimSpace(b.GetButtonID()),
+						Type:         "quick_reply",
+						DisplayText:  dt,
+						ID:           strings.TrimSpace(b.GetButtonID()),
+						ResponseType: "buttons_response",
+						Index:        i + 1,
 					})
 				}
 			}
@@ -111,17 +117,21 @@ func extractBusinessText(m *waProto.Message, pm *ParsedMessage) {
 		if bt := strings.TrimSpace(list.GetButtonText()); bt != "" {
 			pm.Buttons = append(pm.Buttons, Button{Type: "list", DisplayText: bt})
 		}
+		rowIndex := 0
 		for _, sec := range list.GetSections() {
 			for _, row := range sec.GetRows() {
 				dt := strings.TrimSpace(row.GetTitle())
 				if dt == "" {
 					continue
 				}
+				rowIndex++
 				pm.Buttons = append(pm.Buttons, Button{
-					Type:        "list_row",
-					DisplayText: dt,
-					ID:          strings.TrimSpace(row.GetRowID()),
-					Description: strings.TrimSpace(row.GetDescription()),
+					Type:         "list_row",
+					DisplayText:  dt,
+					ID:           strings.TrimSpace(row.GetRowID()),
+					Description:  strings.TrimSpace(row.GetDescription()),
+					ResponseType: "list_response",
+					Index:        rowIndex,
 				})
 			}
 		}
@@ -150,13 +160,13 @@ func hydratedTemplate(tmpl *waProto.TemplateMessage) *waProto.TemplateMessage_Hy
 
 func appendNativeFlowButtons(pm *ParsedMessage, im *waProto.InteractiveMessage) {
 	if nf := im.GetNativeFlowMessage(); nf != nil {
-		for _, btn := range nf.GetButtons() {
-			pm.Buttons = append(pm.Buttons, nativeFlowButton(btn)...)
+		for i, btn := range nf.GetButtons() {
+			pm.Buttons = append(pm.Buttons, nativeFlowButton(btn, i+1)...)
 		}
 	}
 }
 
-func nativeFlowButton(btn *waProto.InteractiveMessage_NativeFlowMessage_NativeFlowButton) []Button {
+func nativeFlowButton(btn *waProto.InteractiveMessage_NativeFlowMessage_NativeFlowButton, index int) []Button {
 	name := strings.TrimSpace(btn.GetName())
 	raw := strings.TrimSpace(btn.GetButtonParamsJSON())
 	if raw == "" {
@@ -169,7 +179,7 @@ func nativeFlowButton(btn *waProto.InteractiveMessage_NativeFlowMessage_NativeFl
 			URL         string `json:"url"`
 		}
 		if json.Unmarshal([]byte(raw), &p) == nil && (p.DisplayText != "" || p.URL != "") {
-			return []Button{{Type: "url", DisplayText: strings.TrimSpace(p.DisplayText), URL: strings.TrimSpace(p.URL)}}
+			return []Button{{Type: "url", DisplayText: strings.TrimSpace(p.DisplayText), URL: strings.TrimSpace(p.URL), Index: index}}
 		}
 	case "quick_reply":
 		var p struct {
@@ -177,7 +187,7 @@ func nativeFlowButton(btn *waProto.InteractiveMessage_NativeFlowMessage_NativeFl
 			ID          string `json:"id"`
 		}
 		if json.Unmarshal([]byte(raw), &p) == nil && p.DisplayText != "" {
-			return []Button{{Type: "quick_reply", DisplayText: strings.TrimSpace(p.DisplayText), ID: strings.TrimSpace(p.ID)}}
+			return []Button{{Type: "quick_reply", DisplayText: strings.TrimSpace(p.DisplayText), ID: strings.TrimSpace(p.ID), ResponseType: "interactive_response", Index: index}}
 		}
 	case "cta_call":
 		var p struct {
@@ -185,7 +195,7 @@ func nativeFlowButton(btn *waProto.InteractiveMessage_NativeFlowMessage_NativeFl
 			PhoneNumber string `json:"phone_number"`
 		}
 		if json.Unmarshal([]byte(raw), &p) == nil && p.DisplayText != "" {
-			return []Button{{Type: "call", DisplayText: strings.TrimSpace(p.DisplayText), PhoneNumber: strings.TrimSpace(p.PhoneNumber)}}
+			return []Button{{Type: "call", DisplayText: strings.TrimSpace(p.DisplayText), PhoneNumber: strings.TrimSpace(p.PhoneNumber), Index: index}}
 		}
 	}
 	return nil

--- a/internal/wa/messages_business.go
+++ b/internal/wa/messages_business.go
@@ -24,12 +24,13 @@ func extractBusinessText(m *waProto.Message, pm *ParsedMessage) {
 				pm.Text = strings.Join(parts, "\n")
 			}
 			for i, hb := range hydrated.GetHydratedButtons() {
+				index := hydratedButtonIndex(hb, i)
 				if btn := hb.GetUrlButton(); btn != nil {
 					pm.Buttons = append(pm.Buttons, Button{
 						Type:        "url",
 						DisplayText: strings.TrimSpace(btn.GetDisplayText()),
 						URL:         strings.TrimSpace(btn.GetURL()),
-						Index:       i + 1,
+						Index:       index,
 					})
 				} else if btn := hb.GetQuickReplyButton(); btn != nil {
 					pm.Buttons = append(pm.Buttons, Button{
@@ -37,14 +38,14 @@ func extractBusinessText(m *waProto.Message, pm *ParsedMessage) {
 						DisplayText:  strings.TrimSpace(btn.GetDisplayText()),
 						ID:           strings.TrimSpace(btn.GetID()),
 						ResponseType: "template_button_reply",
-						Index:        i + 1,
+						Index:        index,
 					})
 				} else if btn := hb.GetCallButton(); btn != nil {
 					pm.Buttons = append(pm.Buttons, Button{
 						Type:        "call",
 						DisplayText: strings.TrimSpace(btn.GetDisplayText()),
 						PhoneNumber: strings.TrimSpace(btn.GetPhoneNumber()),
-						Index:       i + 1,
+						Index:       index,
 					})
 				}
 			}
@@ -156,6 +157,13 @@ func hydratedTemplate(tmpl *waProto.TemplateMessage) *waProto.TemplateMessage_Hy
 		return h
 	}
 	return tmpl.GetHydratedTemplate()
+}
+
+func hydratedButtonIndex(btn *waProto.HydratedTemplateButton, fallback int) int {
+	if btn != nil && btn.Index != nil {
+		return int(btn.GetIndex()) + 1
+	}
+	return fallback + 1
 }
 
 func appendNativeFlowButtons(pm *ParsedMessage, im *waProto.InteractiveMessage) {

--- a/internal/wa/messages_test.go
+++ b/internal/wa/messages_test.go
@@ -593,7 +593,7 @@ func TestParseTemplateMessageWithMixedButtons(t *testing.T) {
 	if len(pm.Buttons) != 2 {
 		t.Fatalf("expected 2 buttons, got %d", len(pm.Buttons))
 	}
-	if pm.Buttons[0].Type != "quick_reply" || pm.Buttons[0].DisplayText != "Yes" || pm.Buttons[0].ID != "yes_id" {
+	if pm.Buttons[0].Type != "quick_reply" || pm.Buttons[0].DisplayText != "Yes" || pm.Buttons[0].ID != "yes_id" || pm.Buttons[0].ResponseType != "template_button_reply" || pm.Buttons[0].Index != 1 {
 		t.Fatalf("unexpected quick_reply button: %+v", pm.Buttons[0])
 	}
 	if pm.Buttons[1].Type != "call" || pm.Buttons[1].DisplayText != "Call us" || pm.Buttons[1].PhoneNumber != "+1234567890" {
@@ -642,10 +642,10 @@ func TestParseButtonsMessage(t *testing.T) {
 	if len(pm.Buttons) != 2 {
 		t.Fatalf("expected 2 buttons, got %d", len(pm.Buttons))
 	}
-	if pm.Buttons[0].Type != "quick_reply" || pm.Buttons[0].DisplayText != "Option A" || pm.Buttons[0].ID != "btn_a" {
+	if pm.Buttons[0].Type != "quick_reply" || pm.Buttons[0].DisplayText != "Option A" || pm.Buttons[0].ID != "btn_a" || pm.Buttons[0].ResponseType != "buttons_response" || pm.Buttons[0].Index != 1 {
 		t.Fatalf("unexpected button[0]: %+v", pm.Buttons[0])
 	}
-	if pm.Buttons[1].Type != "quick_reply" || pm.Buttons[1].DisplayText != "Option B" || pm.Buttons[1].ID != "btn_b" {
+	if pm.Buttons[1].Type != "quick_reply" || pm.Buttons[1].DisplayText != "Option B" || pm.Buttons[1].ID != "btn_b" || pm.Buttons[1].ResponseType != "buttons_response" || pm.Buttons[1].Index != 2 {
 		t.Fatalf("unexpected button[1]: %+v", pm.Buttons[1])
 	}
 }
@@ -764,7 +764,7 @@ func TestParseInteractiveMessageWithNativeFlowButtons(t *testing.T) {
 	if pm.Buttons[0].Type != "url" || pm.Buttons[0].DisplayText != "Pay now" || pm.Buttons[0].URL != "https://pay.example.com" {
 		t.Fatalf("unexpected button[0]: %+v", pm.Buttons[0])
 	}
-	if pm.Buttons[1].Type != "quick_reply" || pm.Buttons[1].DisplayText != "Cancel" || pm.Buttons[1].ID != "cancel" {
+	if pm.Buttons[1].Type != "quick_reply" || pm.Buttons[1].DisplayText != "Cancel" || pm.Buttons[1].ID != "cancel" || pm.Buttons[1].ResponseType != "interactive_response" || pm.Buttons[1].Index != 2 {
 		t.Fatalf("unexpected button[1]: %+v", pm.Buttons[1])
 	}
 	if pm.Buttons[2].Type != "call" || pm.Buttons[2].DisplayText != "Call" || pm.Buttons[2].PhoneNumber != "+15551234567" {
@@ -821,7 +821,7 @@ func TestParseInteractiveTemplateWithNativeFlowButtons(t *testing.T) {
 	if pm.Buttons[0].Type != "url" || pm.Buttons[0].DisplayText != "Open" || pm.Buttons[0].URL != "https://example.com" {
 		t.Fatalf("unexpected button[0]: %+v", pm.Buttons[0])
 	}
-	if pm.Buttons[1].Type != "quick_reply" || pm.Buttons[1].DisplayText != "Reply" || pm.Buttons[1].ID != "reply" {
+	if pm.Buttons[1].Type != "quick_reply" || pm.Buttons[1].DisplayText != "Reply" || pm.Buttons[1].ID != "reply" || pm.Buttons[1].ResponseType != "interactive_response" || pm.Buttons[1].Index != 2 {
 		t.Fatalf("unexpected button[1]: %+v", pm.Buttons[1])
 	}
 }
@@ -866,10 +866,10 @@ func TestParseListMessage(t *testing.T) {
 	if pm.Buttons[0].Type != "list" || pm.Buttons[0].DisplayText != "Options" {
 		t.Fatalf("unexpected list button: %+v", pm.Buttons[0])
 	}
-	if pm.Buttons[1].Type != "list_row" || pm.Buttons[1].DisplayText != "Alice" || pm.Buttons[1].ID != "alice" || pm.Buttons[1].Description != "Send to Alice" {
+	if pm.Buttons[1].Type != "list_row" || pm.Buttons[1].DisplayText != "Alice" || pm.Buttons[1].ID != "alice" || pm.Buttons[1].Description != "Send to Alice" || pm.Buttons[1].ResponseType != "list_response" || pm.Buttons[1].Index != 1 {
 		t.Fatalf("unexpected row[0]: %+v", pm.Buttons[1])
 	}
-	if pm.Buttons[2].Type != "list_row" || pm.Buttons[2].DisplayText != "Bob" || pm.Buttons[2].ID != "bob" {
+	if pm.Buttons[2].Type != "list_row" || pm.Buttons[2].DisplayText != "Bob" || pm.Buttons[2].ID != "bob" || pm.Buttons[2].ResponseType != "list_response" || pm.Buttons[2].Index != 2 {
 		t.Fatalf("unexpected row[1]: %+v", pm.Buttons[2])
 	}
 }

--- a/internal/wa/messages_test.go
+++ b/internal/wa/messages_test.go
@@ -662,6 +662,56 @@ func TestParseTemplateMessageWithMixedButtons(t *testing.T) {
 	}
 }
 
+func TestParseTemplateMessageUsesHydratedButtonIndex(t *testing.T) {
+	chat, _ := types.ParseJID("123@s.whatsapp.net")
+	sender, _ := types.ParseJID("biz@s.whatsapp.net")
+
+	ev := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat: chat, Sender: sender, IsFromMe: false,
+			},
+			ID:        "tmpl-index",
+			Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{
+			TemplateMessage: &waProto.TemplateMessage{
+				HydratedTemplate: &waProto.TemplateMessage_HydratedFourRowTemplate{
+					HydratedContentText: proto.String("Choose"),
+					HydratedButtons: []*waProto.HydratedTemplateButton{
+						{
+							Index: proto.Uint32(1),
+							HydratedButton: &waProto.HydratedTemplateButton_UrlButton{
+								UrlButton: &waProto.HydratedTemplateButton_HydratedURLButton{
+									DisplayText: proto.String("Open"),
+									URL:         proto.String("https://example.com"),
+								},
+							},
+						},
+						{
+							Index: proto.Uint32(0),
+							HydratedButton: &waProto.HydratedTemplateButton_QuickReplyButton{
+								QuickReplyButton: &waProto.HydratedTemplateButton_HydratedQuickReplyButton{
+									DisplayText: proto.String("Yes"),
+									ID:          proto.String("yes_id"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pm := ParseLiveMessage(ev)
+	if len(pm.Buttons) != 2 {
+		t.Fatalf("expected 2 buttons, got %d", len(pm.Buttons))
+	}
+	if pm.Buttons[1].Type != "quick_reply" || pm.Buttons[1].Index != 1 {
+		t.Fatalf("unexpected quick_reply button: %+v", pm.Buttons[1])
+	}
+}
+
 func TestParseButtonsMessage(t *testing.T) {
 	chat, _ := types.ParseJID("123@s.whatsapp.net")
 	sender, _ := types.ParseJID("biz@s.whatsapp.net")


### PR DESCRIPTION
## Summary

Adds `wacli send select` for selecting stored inbound WhatsApp quick-reply buttons and list rows from scripts.

This builds on the existing button/list parsing and storage support by adding the send-side command, delegation support, metadata needed to choose safely, and docs/tests.

## Details

- Adds `wacli send select --to ... --id ... (--label | --button-id | --index)`
- Stores optional `response_type` and `index` metadata for parsed buttons/list rows
- Supports send delegation while `sync --follow` owns the store
- Sends list rows and plain quick replies as quoted text replies to the original message
- Keeps native-flow quick replies explicitly unsupported until the wire format is verified
- Warns if local outbound persistence fails after WhatsApp accepts a send

## Testing

- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `git diff --check`
