### PR TITLE
feat: add message revoke and forward commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@
 ### Added
 
 - Chats: store unread marker state and numeric `unread_count` separately; migrate existing stores away from sentinel unread values while preserving public chat JSON fields. (#255 - thanks @drelum and @dovocoder)
+- Messages: add explicit `messages revoke` and `messages forward` commands for stored text and media/document messages.
 
 ### Security
 
 ### Fixed
+
+- Sync: store messages sent from other linked devices in the destination chat as outgoing messages.
 
 ### Docs
 

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -13,7 +13,9 @@ import (
 	"github.com/openclaw/wacli/internal/wa"
 	"github.com/spf13/cobra"
 	"go.mau.fi/whatsmeow"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
 	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
 )
 
 func newMessagesCmd(flags *rootFlags) *cobra.Command {
@@ -28,7 +30,9 @@ func newMessagesCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newMessagesContextCmd(flags))
 	cmd.AddCommand(newMessagesExportCmd(flags))
 	cmd.AddCommand(newMessagesDeleteCmd(flags))
+	cmd.AddCommand(newMessagesRevokeCmd(flags))
 	cmd.AddCommand(newMessagesEditCmd(flags))
+	cmd.AddCommand(newMessagesForwardCmd(flags))
 	return cmd
 }
 
@@ -582,6 +586,85 @@ func newMessagesDeleteCmd(flags *rootFlags) *cobra.Command {
 	return cmd
 }
 
+func newMessagesRevokeCmd(flags *rootFlags) *cobra.Command {
+	var chat string
+	var id string
+	postSendWait := postSendRetryReceiptWait
+
+	cmd := &cobra.Command{
+		Use:   "revoke",
+		Short: "Delete one of your sent messages for everyone",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(chat) == "" || strings.TrimSpace(id) == "" {
+				return fmt.Errorf("--chat and --id are required")
+			}
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			msg, chatJID, found, err := loadMessageRevokeTarget(ctx, a, chat, id)
+			if err != nil {
+				return err
+			}
+			if found {
+				if err := validateMessageCanRevoke(msg); err != nil {
+					return err
+				}
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+			if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
+				return err
+			}
+			targetID := id
+			if found {
+				targetID = msg.MsgID
+			}
+			sentID, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (types.MessageID, error) {
+				return a.WA().RevokeMessage(ctx, chatJID, types.MessageID(targetID))
+			})
+			if err != nil {
+				return err
+			}
+			if found {
+				if err := a.DB().MarkMessageRevoked(msg.ChatJID, msg.MsgID); err != nil {
+					return fmt.Errorf("store deleted message state: %w", err)
+				}
+			}
+
+			waitForPostSendRetryReceipts(ctx, postSendWait)
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"revoked": true,
+					"to":      chatJID.String(),
+					"id":      sentID,
+					"target":  id,
+				})
+			}
+			fmt.Fprintf(os.Stdout, "Revoked message %s in %s (id %s)\n", id, chatJID.String(), sentID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&chat, "chat", "", "chat JID, phone number, or contact/group/chat name")
+	cmd.Flags().StringVar(&id, "id", "", "message ID to revoke")
+	cmd.Flags().DurationVar(&postSendWait, "post-send-wait", postSendRetryReceiptWait, "keep the connection alive after revoke so retry receipts can be handled (0 disables)")
+	return cmd
+}
+
 func newMessagesEditCmd(flags *rootFlags) *cobra.Command {
 	var chat string
 	var id string
@@ -656,6 +739,123 @@ func newMessagesEditCmd(flags *rootFlags) *cobra.Command {
 	return cmd
 }
 
+func newMessagesForwardCmd(flags *rootFlags) *cobra.Command {
+	var chat string
+	var id string
+	var to string
+	var pick int
+	postSendWait := postSendRetryReceiptWait
+
+	cmd := &cobra.Command{
+		Use:   "forward",
+		Short: "Forward a stored message",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(chat) == "" || strings.TrimSpace(id) == "" || strings.TrimSpace(to) == "" {
+				return fmt.Errorf("--chat, --id, and --to are required")
+			}
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			source, _, err := loadMessageMutationTarget(ctx, a, chat, id)
+			if err != nil {
+				return err
+			}
+			if err := validateMessageCanForward(source); err != nil {
+				return err
+			}
+			var mediaInfo *store.MediaDownloadInfo
+			if strings.TrimSpace(source.MediaType) != "" {
+				info, err := a.DB().GetMediaDownloadInfo(source.ChatJID, source.MsgID)
+				if err != nil {
+					return err
+				}
+				mediaInfo = &info
+			}
+			toJID, err := resolveRecipient(a, to, recipientOptions{pick: pick, asJSON: flags.asJSON})
+			if err != nil {
+				return err
+			}
+			if mediaInfo != nil && toJID.Server == types.NewsletterServer {
+				return fmt.Errorf("media forwarding to channels is not supported")
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+			toJID = warmupRecipient(ctx, a.WA(), toJID, os.Stderr)
+			if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
+				return err
+			}
+			payload, err := buildForwardedMessage(source, mediaInfo)
+			if err != nil {
+				return err
+			}
+			sentID, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (types.MessageID, error) {
+				return a.WA().SendProtoMessage(ctx, toJID, payload.Message)
+			})
+			if err != nil {
+				return err
+			}
+
+			now := time.Now().UTC()
+			chatName := a.WA().ResolveChatName(ctx, toJID, "")
+			_ = a.DB().UpsertChat(toJID.String(), chatKindFromJID(toJID), chatName, now)
+			_ = a.DB().UpsertMessage(store.UpsertMessageParams{
+				ChatJID:         toJID.String(),
+				ChatName:        chatName,
+				MsgID:           string(sentID),
+				SenderName:      "me",
+				Timestamp:       now,
+				FromMe:          true,
+				Text:            payload.Text,
+				DisplayText:     payload.Text,
+				MediaType:       payload.MediaType,
+				MediaCaption:    payload.MediaCaption,
+				Filename:        payload.Filename,
+				MimeType:        payload.MimeType,
+				DirectPath:      payload.DirectPath,
+				MediaKey:        payload.MediaKey,
+				FileSHA256:      payload.FileSHA256,
+				FileEncSHA256:   payload.FileEncSHA256,
+				FileLength:      payload.FileLength,
+				IsForwarded:     true,
+				ForwardingScore: payload.ForwardingScore,
+			})
+
+			waitForPostSendRetryReceipts(ctx, postSendWait)
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"forwarded": true,
+					"to":        toJID.String(),
+					"id":        sentID,
+					"source":    source.MsgID,
+				})
+			}
+			fmt.Fprintf(os.Stdout, "Forwarded message %s to %s (id %s)\n", source.MsgID, toJID.String(), sentID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&chat, "chat", "", "source chat JID, phone number, or contact/group/chat name")
+	cmd.Flags().StringVar(&id, "id", "", "source message ID to forward")
+	cmd.Flags().StringVar(&to, "to", "", "recipient JID, phone number, or contact/group/chat name")
+	cmd.Flags().IntVar(&pick, "pick", 0, "when --to is ambiguous, pick the Nth match (1-indexed)")
+	cmd.Flags().DurationVar(&postSendWait, "post-send-wait", postSendRetryReceiptWait, "keep the connection alive after forward so retry receipts can be handled (0 disables)")
+	return cmd
+}
+
 func loadMessageMutationTarget(ctx context.Context, a *app.App, chat, id string) (store.Message, types.JID, error) {
 	chatJIDs, err := messageChatJIDFilter(ctx, a, chat)
 	if err != nil {
@@ -670,6 +870,21 @@ func loadMessageMutationTarget(ctx context.Context, a *app.App, chat, id string)
 		return store.Message{}, types.JID{}, fmt.Errorf("stored chat JID is invalid: %w", err)
 	}
 	return msg, chatJID, nil
+}
+
+func loadMessageRevokeTarget(ctx context.Context, a *app.App, chat, id string) (store.Message, types.JID, bool, error) {
+	msg, chatJID, err := loadMessageMutationTarget(ctx, a, chat, id)
+	if err == nil {
+		return msg, chatJID, true, nil
+	}
+	if !isNoRows(err) {
+		return store.Message{}, types.JID{}, false, err
+	}
+	chatJID, parseErr := wa.ParseUserOrJID(chat)
+	if parseErr != nil {
+		return store.Message{}, types.JID{}, false, err
+	}
+	return store.Message{}, chatJID, false, nil
 }
 
 func deleteLocalMediaIfRequested(deleteMedia bool, localPath string) (bool, error) {
@@ -748,4 +963,184 @@ func validateMessageCanEdit(msg store.Message, now time.Time) error {
 		return fmt.Errorf("message %s is older than WhatsApp's %s edit window", msg.MsgID, whatsmeow.EditWindow)
 	}
 	return nil
+}
+
+func validateMessageCanForward(msg store.Message) error {
+	if msg.Revoked {
+		return fmt.Errorf("message %s is deleted", msg.MsgID)
+	}
+	if msg.DeletedForMe {
+		return fmt.Errorf("message %s was deleted for me", msg.MsgID)
+	}
+	if strings.TrimSpace(msg.ReactionToID) != "" {
+		return fmt.Errorf("reaction messages cannot be forwarded")
+	}
+	mediaType := strings.ToLower(strings.TrimSpace(msg.MediaType))
+	if mediaType != "" && !isForwardableMediaType(mediaType) {
+		return fmt.Errorf("%s messages cannot be forwarded", mediaType)
+	}
+	if mediaType == "" && strings.TrimSpace(messageForwardText(msg)) == "" {
+		return fmt.Errorf("only text messages can be forwarded")
+	}
+	return nil
+}
+
+func messageForwardText(msg store.Message) string {
+	if text := strings.TrimSpace(msg.Text); text != "" {
+		return text
+	}
+	return strings.TrimSpace(msg.DisplayText)
+}
+
+type forwardedMessagePayload struct {
+	Message         *waProto.Message
+	Text            string
+	MediaType       string
+	MediaCaption    string
+	Filename        string
+	MimeType        string
+	DirectPath      string
+	MediaKey        []byte
+	FileSHA256      []byte
+	FileEncSHA256   []byte
+	FileLength      uint64
+	ForwardingScore uint32
+}
+
+func buildForwardedMessage(msg store.Message, mediaInfo *store.MediaDownloadInfo) (forwardedMessagePayload, error) {
+	forwardingScore := msg.ForwardingScore + 1
+	mediaType := strings.ToLower(strings.TrimSpace(msg.MediaType))
+	if mediaType == "" {
+		text := messageForwardText(msg)
+		return forwardedMessagePayload{
+			Message:         buildForwardedTextMessage(text, forwardingScore),
+			Text:            text,
+			ForwardingScore: forwardingScore,
+		}, nil
+	}
+	if mediaInfo == nil {
+		return forwardedMessagePayload{}, fmt.Errorf("message has no media metadata")
+	}
+	if err := validateForwardMediaInfo(*mediaInfo); err != nil {
+		return forwardedMessagePayload{}, err
+	}
+
+	payload := forwardedMessagePayload{
+		Text:            msg.MediaCaption,
+		MediaType:       mediaType,
+		MediaCaption:    msg.MediaCaption,
+		Filename:        mediaInfo.Filename,
+		MimeType:        mediaInfo.MimeType,
+		DirectPath:      mediaInfo.DirectPath,
+		MediaKey:        append([]byte(nil), mediaInfo.MediaKey...),
+		FileSHA256:      append([]byte(nil), mediaInfo.FileSHA256...),
+		FileEncSHA256:   append([]byte(nil), mediaInfo.FileEncSHA256...),
+		FileLength:      mediaInfo.FileLength,
+		ForwardingScore: forwardingScore,
+	}
+	ctx := forwardedContextInfo(forwardingScore)
+	switch mediaType {
+	case "image":
+		payload.Message = &waProto.Message{ImageMessage: &waProto.ImageMessage{
+			DirectPath:    proto.String(mediaInfo.DirectPath),
+			MediaKey:      mediaInfo.MediaKey,
+			FileSHA256:    mediaInfo.FileSHA256,
+			FileEncSHA256: mediaInfo.FileEncSHA256,
+			FileLength:    proto.Uint64(mediaInfo.FileLength),
+			Mimetype:      proto.String(mediaInfo.MimeType),
+			Caption:       proto.String(msg.MediaCaption),
+			ContextInfo:   ctx,
+		}}
+	case "video", "gif":
+		payload.Message = &waProto.Message{VideoMessage: &waProto.VideoMessage{
+			DirectPath:    proto.String(mediaInfo.DirectPath),
+			MediaKey:      mediaInfo.MediaKey,
+			FileSHA256:    mediaInfo.FileSHA256,
+			FileEncSHA256: mediaInfo.FileEncSHA256,
+			FileLength:    proto.Uint64(mediaInfo.FileLength),
+			Mimetype:      proto.String(mediaInfo.MimeType),
+			Caption:       proto.String(msg.MediaCaption),
+			GifPlayback:   proto.Bool(mediaType == "gif"),
+			ContextInfo:   ctx,
+		}}
+	case "audio":
+		payload.Message = &waProto.Message{AudioMessage: &waProto.AudioMessage{
+			DirectPath:    proto.String(mediaInfo.DirectPath),
+			MediaKey:      mediaInfo.MediaKey,
+			FileSHA256:    mediaInfo.FileSHA256,
+			FileEncSHA256: mediaInfo.FileEncSHA256,
+			FileLength:    proto.Uint64(mediaInfo.FileLength),
+			Mimetype:      proto.String(mediaInfo.MimeType),
+			ContextInfo:   ctx,
+		}}
+	case "document":
+		name := strings.TrimSpace(mediaInfo.Filename)
+		if name == "" {
+			name = "document"
+		}
+		payload.Filename = name
+		payload.Message = &waProto.Message{DocumentMessage: &waProto.DocumentMessage{
+			DirectPath:    proto.String(mediaInfo.DirectPath),
+			MediaKey:      mediaInfo.MediaKey,
+			FileSHA256:    mediaInfo.FileSHA256,
+			FileEncSHA256: mediaInfo.FileEncSHA256,
+			FileLength:    proto.Uint64(mediaInfo.FileLength),
+			Mimetype:      proto.String(mediaInfo.MimeType),
+			FileName:      proto.String(name),
+			Title:         proto.String(name),
+			Caption:       proto.String(msg.MediaCaption),
+			ContextInfo:   ctx,
+		}}
+	case "sticker":
+		payload.Message = &waProto.Message{StickerMessage: &waProto.StickerMessage{
+			DirectPath:    proto.String(mediaInfo.DirectPath),
+			MediaKey:      mediaInfo.MediaKey,
+			FileSHA256:    mediaInfo.FileSHA256,
+			FileEncSHA256: mediaInfo.FileEncSHA256,
+			FileLength:    proto.Uint64(mediaInfo.FileLength),
+			Mimetype:      proto.String(mediaInfo.MimeType),
+			ContextInfo:   ctx,
+		}}
+	default:
+		return forwardedMessagePayload{}, fmt.Errorf("%s messages cannot be forwarded", mediaType)
+	}
+	return payload, nil
+}
+
+func isForwardableMediaType(mediaType string) bool {
+	switch strings.ToLower(strings.TrimSpace(mediaType)) {
+	case "image", "video", "gif", "audio", "document", "sticker":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateForwardMediaInfo(info store.MediaDownloadInfo) error {
+	if strings.TrimSpace(info.DirectPath) == "" || len(info.MediaKey) == 0 || len(info.FileSHA256) == 0 || len(info.FileEncSHA256) == 0 || info.FileLength == 0 {
+		return fmt.Errorf("message has incomplete media metadata (run `wacli sync` first)")
+	}
+	if strings.TrimSpace(info.MimeType) == "" {
+		return fmt.Errorf("message has incomplete media MIME metadata")
+	}
+	return nil
+}
+
+func buildForwardedTextMessage(text string, forwardingScore uint32) *waProto.Message {
+	return &waProto.Message{
+		ExtendedTextMessage: &waProto.ExtendedTextMessage{
+			Text:        proto.String(text),
+			ContextInfo: forwardedContextInfo(forwardingScore),
+		},
+	}
+}
+
+func forwardedContextInfo(forwardingScore uint32) *waProto.ContextInfo {
+	if forwardingScore == 0 {
+		forwardingScore = 1
+	}
+	return &waProto.ContextInfo{
+		IsForwarded:     proto.Bool(true),
+		ForwardingScore: proto.Uint32(forwardingScore),
+	}
 }

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -986,10 +986,13 @@ func validateMessageCanForward(msg store.Message) error {
 }
 
 func messageForwardText(msg store.Message) string {
-	if text := strings.TrimSpace(msg.Text); text != "" {
-		return text
+	if strings.TrimSpace(msg.Text) != "" {
+		return msg.Text
 	}
-	return strings.TrimSpace(msg.DisplayText)
+	if strings.TrimSpace(msg.DisplayText) != "" {
+		return msg.DisplayText
+	}
+	return ""
 }
 
 type forwardedMessagePayload struct {

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -659,7 +659,7 @@ func newMessagesRevokeCmd(flags *rootFlags) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&chat, "chat", "", "chat JID, phone number, or contact/group/chat name")
+	cmd.Flags().StringVar(&chat, "chat", "", "chat JID or phone number")
 	cmd.Flags().StringVar(&id, "id", "", "message ID to revoke")
 	cmd.Flags().DurationVar(&postSendWait, "post-send-wait", postSendRetryReceiptWait, "keep the connection alive after revoke so retry receipts can be handled (0 disables)")
 	return cmd
@@ -848,7 +848,7 @@ func newMessagesForwardCmd(flags *rootFlags) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&chat, "chat", "", "source chat JID, phone number, or contact/group/chat name")
+	cmd.Flags().StringVar(&chat, "chat", "", "source chat JID or phone number")
 	cmd.Flags().StringVar(&id, "id", "", "source message ID to forward")
 	cmd.Flags().StringVar(&to, "to", "", "recipient JID, phone number, or contact/group/chat name")
 	cmd.Flags().IntVar(&pick, "pick", 0, "when --to is ambiguous, pick the Nth match (1-indexed)")

--- a/cmd/wacli/messages_test.go
+++ b/cmd/wacli/messages_test.go
@@ -446,6 +446,20 @@ func TestBuildForwardedTextMessageMarksContext(t *testing.T) {
 	}
 }
 
+func TestBuildForwardedTextMessagePreservesWhitespace(t *testing.T) {
+	payload, err := buildForwardedMessage(store.Message{MsgID: "mid", Text: "  code\n"}, nil)
+	if err != nil {
+		t.Fatalf("buildForwardedMessage: %v", err)
+	}
+	if payload.Text != "  code\n" {
+		t.Fatalf("payload text = %q", payload.Text)
+	}
+	ext := payload.Message.GetExtendedTextMessage()
+	if ext.GetText() != "  code\n" {
+		t.Fatalf("message text = %q", ext.GetText())
+	}
+}
+
 func TestMessagesExportCommandAppliesDateFilters(t *testing.T) {
 	storeDir := t.TempDir()
 	db, err := store.Open(filepath.Join(storeDir, "wacli.db"))

--- a/cmd/wacli/messages_test.go
+++ b/cmd/wacli/messages_test.go
@@ -276,7 +276,9 @@ func TestMessagesExportCommandExposesDateFilters(t *testing.T) {
 func TestMessagesMutationCommandsExposeSafetyFlags(t *testing.T) {
 	for _, cmd := range []*cobra.Command{
 		newMessagesDeleteCmd(&rootFlags{}),
+		newMessagesRevokeCmd(&rootFlags{}),
 		newMessagesEditCmd(&rootFlags{}),
+		newMessagesForwardCmd(&rootFlags{}),
 	} {
 		for _, name := range []string{"chat", "id", "post-send-wait"} {
 			if cmd.Flags().Lookup(name) == nil {
@@ -286,6 +288,12 @@ func TestMessagesMutationCommandsExposeSafetyFlags(t *testing.T) {
 	}
 	if newMessagesEditCmd(&rootFlags{}).Flags().Lookup("message") == nil {
 		t.Fatalf("edit missing --message")
+	}
+	if newMessagesForwardCmd(&rootFlags{}).Flags().Lookup("to") == nil {
+		t.Fatalf("forward missing --to")
+	}
+	if newMessagesForwardCmd(&rootFlags{}).Flags().Lookup("pick") == nil {
+		t.Fatalf("forward missing --pick")
 	}
 }
 
@@ -341,6 +349,100 @@ func TestMessagesDeleteForMeValidation(t *testing.T) {
 	msg.DeletedForMe = true
 	if err := validateMessageCanDeleteForMe(msg); err == nil || !strings.Contains(err.Error(), "deleted for me") {
 		t.Fatalf("deleted-for-me error = %v", err)
+	}
+}
+
+func TestMessagesForwardValidation(t *testing.T) {
+	msg := store.Message{MsgID: "mid", Text: "hello"}
+	if err := validateMessageCanForward(msg); err != nil {
+		t.Fatalf("validateMessageCanForward: %v", err)
+	}
+
+	msg.Revoked = true
+	if err := validateMessageCanForward(msg); err == nil || !strings.Contains(err.Error(), "deleted") {
+		t.Fatalf("revoked error = %v", err)
+	}
+
+	msg.Revoked = false
+	msg.DeletedForMe = true
+	if err := validateMessageCanForward(msg); err == nil || !strings.Contains(err.Error(), "deleted for me") {
+		t.Fatalf("deleted-for-me error = %v", err)
+	}
+
+	msg.DeletedForMe = false
+	msg.MediaType = "image"
+	if err := validateMessageCanForward(msg); err != nil {
+		t.Fatalf("media validation error = %v", err)
+	}
+
+	msg.MediaType = ""
+	msg.ReactionToID = "target"
+	if err := validateMessageCanForward(msg); err == nil || !strings.Contains(err.Error(), "reaction") {
+		t.Fatalf("reaction error = %v", err)
+	}
+
+	msg.ReactionToID = ""
+	msg.Text = ""
+	if err := validateMessageCanForward(msg); err == nil || !strings.Contains(err.Error(), "text messages") {
+		t.Fatalf("empty text error = %v", err)
+	}
+}
+
+func TestBuildForwardedMediaMessageMarksContext(t *testing.T) {
+	media := store.MediaDownloadInfo{
+		MediaType:     "document",
+		Filename:      "report.pdf",
+		MimeType:      "application/pdf",
+		DirectPath:    "/v/t62/report",
+		MediaKey:      []byte{1, 2, 3},
+		FileSHA256:    []byte{4, 5, 6},
+		FileEncSHA256: []byte{7, 8, 9},
+		FileLength:    1234,
+	}
+	payload, err := buildForwardedMessage(store.Message{
+		MsgID:           "mid",
+		MediaType:       "document",
+		MediaCaption:    "the report",
+		ForwardingScore: 2,
+	}, &media)
+	if err != nil {
+		t.Fatalf("buildForwardedMessage: %v", err)
+	}
+	doc := payload.Message.GetDocumentMessage()
+	if doc.GetFileName() != "report.pdf" {
+		t.Fatalf("FileName = %q", doc.GetFileName())
+	}
+	if doc.GetCaption() != "the report" {
+		t.Fatalf("Caption = %q", doc.GetCaption())
+	}
+	ctx := doc.GetContextInfo()
+	if !ctx.GetIsForwarded() || ctx.GetForwardingScore() != 3 {
+		t.Fatalf("unexpected forwarded context: forwarded=%v score=%d", ctx.GetIsForwarded(), ctx.GetForwardingScore())
+	}
+	if payload.MediaType != "document" || payload.FileLength != 1234 || string(payload.MediaKey) != string(media.MediaKey) {
+		t.Fatalf("unexpected payload metadata: %+v", payload)
+	}
+}
+
+func TestBuildForwardedMediaMessageRequiresCompleteMetadata(t *testing.T) {
+	_, err := buildForwardedMessage(store.Message{MsgID: "mid", MediaType: "image"}, &store.MediaDownloadInfo{MediaType: "image"})
+	if err == nil || !strings.Contains(err.Error(), "incomplete media metadata") {
+		t.Fatalf("error = %v, want incomplete media metadata", err)
+	}
+}
+
+func TestBuildForwardedTextMessageMarksContext(t *testing.T) {
+	msg := buildForwardedTextMessage("hello", 4)
+	ext := msg.GetExtendedTextMessage()
+	if ext.GetText() != "hello" {
+		t.Fatalf("text = %q", ext.GetText())
+	}
+	ctx := ext.GetContextInfo()
+	if !ctx.GetIsForwarded() {
+		t.Fatal("IsForwarded = false")
+	}
+	if ctx.GetForwardingScore() != 4 {
+		t.Fatalf("ForwardingScore = %d, want 4", ctx.GetForwardingScore())
 	}
 }
 

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -1,8 +1,8 @@
 # messages
 
-Read when: listing, searching, exporting, showing, or inspecting local message context.
+Read when: listing, searching, exporting, showing, inspecting local message context, or mutating stored messages.
 
-Most `wacli messages` commands read from the local store. `messages edit` and `messages delete` are remote WhatsApp mutations and require an authenticated, writable store.
+Most `wacli messages` commands read from the local store. `messages edit`, `messages delete`, `messages revoke`, and `messages forward` are remote WhatsApp mutations and require an authenticated, writable store.
 WhatsApp status broadcasts are stored separately in `status_messages`; they are not returned by `messages list`, `messages search`, or `messages export`.
 
 ## Commands
@@ -16,6 +16,8 @@ wacli messages show --chat JID --id MSG_ID
 wacli messages context --chat JID --id MSG_ID [--before N] [--after N]
 wacli messages edit --chat JID --id MSG_ID --message TEXT [--post-send-wait 2s]
 wacli messages delete --chat JID --id MSG_ID [--for-me] [--delete-media] [--post-send-wait 2s]
+wacli messages revoke --chat JID --id MSG_ID [--post-send-wait 2s]
+wacli messages forward --chat JID --id MSG_ID --to RECIPIENT [--pick N] [--post-send-wait 2s]
 ```
 
 ## Search
@@ -43,9 +45,10 @@ wacli messages delete --chat JID --id MSG_ID [--for-me] [--delete-media] [--post
 ## Edit and Delete
 
 - `messages edit` updates one of your own recent sent text messages. WhatsApp only accepts edits inside its current edit window.
-- `messages delete` revokes one of your own sent messages for everyone.
+- `messages delete` revokes one of your own sent messages for everyone. `messages revoke` is the explicit form of the same delete-for-everyone operation.
 - `messages delete --for-me` removes a stored message only for your WhatsApp account using WhatsApp's `deleteMessageForMe` app-state patch; it can target messages sent by you or by others. `--delete-media` is only valid with `--for-me`.
-- Both commands look up the target in the local store first and honor `--read-only`/`WACLI_READONLY`. Delete-for-everyone and edit require a message sent by you.
+- `messages forward` forwards a stored text, image, video, GIF, audio, sticker, or document message to another recipient and marks the outgoing copy as forwarded. Media forwards require synced media metadata; reaction forwarding is not supported.
+- These commands look up the target in the local store first and honor `--read-only`/`WACLI_READONLY`. Delete-for-everyone and edit require a message sent by you.
 - Deleted messages and WhatsApp delete-for-me events are kept as local tombstones for direct `messages show`, but are hidden from normal list/search/starred/export results.
 
 ## LID mapping
@@ -66,4 +69,6 @@ wacli messages context --chat 1234567890@s.whatsapp.net --id ABC123 --before 3 -
 wacli messages edit --chat 1234567890@s.whatsapp.net --id ABC123 --message "updated text"
 wacli messages delete --chat 1234567890@s.whatsapp.net --id ABC123
 wacli messages delete --chat 1234567890@s.whatsapp.net --id ABC123 --for-me
+wacli messages revoke --chat 1234567890@s.whatsapp.net --id ABC123
+wacli messages forward --chat 1234567890@s.whatsapp.net --id ABC123 --to "Family"
 ```

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -29,6 +29,7 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--max-mes
 - `WACLI_SYNC_MAX_MESSAGES` and `WACLI_SYNC_MAX_DB_SIZE` apply the same caps to `auth` bootstrap sync and `sync`.
 - While `sync --follow` is running, `send text`, `send file`, `send sticker`, `send voice`, and `send react` commands for the same store are delegated to the running sync process so they do not fail on the store lock.
 - After connecting, sync fetches WhatsApp chat app-state deltas (`regular_high` and `regular_low`) so starred, delete-for-me, mute, archive, pin, and mark-read changes made while `wacli` was offline are caught up instead of relying only on live push notifications.
+- Sync imports messages sent from your other linked devices into the destination chat with `from_me=true`, so local history covers both incoming and outgoing conversation sides.
 - If whatsmeow reports an app-state LTHash mismatch, sync asks the primary device for the official recovery snapshot once for that app-state collection. If recovery also fails, the warning is printed and sync keeps handling normal message/history events.
 - Sync stores WhatsApp call signaling and call-log metadata in `call_events`; inspect it with `wacli calls list`.
 - Sync stores WhatsApp status broadcasts in `status_messages`, separate from normal chat `messages`.

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -198,6 +198,52 @@ func TestHistorySyncStoresConversationUnreadCount(t *testing.T) {
 	}
 }
 
+func TestHistorySyncStoresDeviceSentMessagesInDestinationChat(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	self := types.NewJID("1111111111", types.DefaultUserServer)
+	dest := types.NewJID("15551234567", types.DefaultUserServer)
+	base := time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)
+	msg := &waWeb.WebMessageInfo{
+		Key: &waCommon.MessageKey{
+			RemoteJID: proto.String(self.String()),
+			FromMe:    proto.Bool(false),
+			ID:        proto.String("device-sent-1"),
+		},
+		MessageTimestamp: proto.Uint64(uint64(base.Unix())),
+		Message: &waProto.Message{
+			DeviceSentMessage: &waProto.DeviceSentMessage{
+				DestinationJID: proto.String(dest.String()),
+				Message:        &waProto.Message{Conversation: proto.String("sent from phone")},
+			},
+		},
+	}
+	history := &events.HistorySync{Data: &waHistorySync.HistorySync{
+		SyncType: waHistorySync.HistorySync_FULL.Enum(),
+		Conversations: []*waHistorySync.Conversation{{
+			ID:       proto.String(self.String()),
+			Messages: []*waHistorySync.HistorySyncMsg{{Message: msg}},
+		}},
+	}}
+
+	var messagesStored atomic.Int64
+	var lastEvent atomic.Int64
+	a.handleHistorySync(context.Background(), SyncOptions{}, history, &messagesStored, &lastEvent, func(string, string) {})
+
+	stored, err := a.db.GetMessage(dest.String(), "device-sent-1")
+	if err != nil {
+		t.Fatalf("GetMessage destination: %v", err)
+	}
+	if !stored.FromMe || stored.Text != "sent from phone" || stored.ChatJID != dest.String() {
+		t.Fatalf("unexpected stored sent message: %+v", stored)
+	}
+	if _, err := a.db.GetMessage(self.String(), "device-sent-1"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("self-chat message lookup err = %v, want sql.ErrNoRows", err)
+	}
+}
+
 func TestHistorySyncStoresMarkedUnreadWithoutCountAsMarkerOnly(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -95,6 +95,9 @@ func ParseLiveMessage(evt *events.Message) ParsedMessage {
 	if s := evt.Info.Sender.String(); s != "" {
 		msg.SenderJID = s
 	}
+	if evt.Info.DeviceSentMeta != nil {
+		applyDeviceSentDestination(evt.Info.DeviceSentMeta.DestinationJID, &msg)
+	}
 
 	extractWAProto(evt.Message, &msg)
 	return msg
@@ -137,6 +140,11 @@ func extractWAProto(m *waProto.Message, pm *ParsedMessage) {
 		return
 	}
 
+	if deviceSent := m.GetDeviceSentMessage(); deviceSent.GetMessage() != nil {
+		applyDeviceSentDestination(deviceSent.GetDestinationJID(), pm)
+		extractWAProto(deviceSent.GetMessage(), pm)
+		return
+	}
 	if edited := m.GetEditedMessage().GetMessage(); edited != nil {
 		if edited.MessageContextInfo == nil && m.MessageContextInfo != nil {
 			edited.MessageContextInfo = m.MessageContextInfo
@@ -170,6 +178,16 @@ func extractWAProto(m *waProto.Message, pm *ParsedMessage) {
 		}
 		pm.ForwardingScore = ctx.GetForwardingScore()
 		pm.IsForwarded = ctx.GetIsForwarded() || pm.ForwardingScore > 0
+	}
+}
+
+func applyDeviceSentDestination(destination string, pm *ParsedMessage) {
+	if pm == nil {
+		return
+	}
+	pm.FromMe = true
+	if chat, err := types.ParseJID(strings.TrimSpace(destination)); err == nil && !chat.IsEmpty() {
+		pm.Chat = chat
 	}
 }
 

--- a/internal/wa/messages_test.go
+++ b/internal/wa/messages_test.go
@@ -33,6 +33,63 @@ func TestParseHistoryMessageTextAndSender(t *testing.T) {
 	}
 }
 
+func TestParseHistoryMessageDeviceSentUsesDestinationChat(t *testing.T) {
+	h := &waProto.WebMessageInfo{
+		Key: &waProto.MessageKey{
+			ID:        proto.String("sent-from-phone"),
+			FromMe:    proto.Bool(false),
+			RemoteJID: proto.String("me@s.whatsapp.net"),
+		},
+		MessageTimestamp: proto.Uint64(uint64(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Unix())),
+		Message: &waProto.Message{
+			DeviceSentMessage: &waProto.DeviceSentMessage{
+				DestinationJID: proto.String("15551234567@s.whatsapp.net"),
+				Message:        &waProto.Message{Conversation: proto.String("sent elsewhere")},
+			},
+		},
+	}
+
+	pm := ParseHistoryMessage("me@s.whatsapp.net", h)
+	if !pm.FromMe {
+		t.Fatalf("FromMe = false, want true")
+	}
+	if pm.Chat.String() != "15551234567@s.whatsapp.net" {
+		t.Fatalf("Chat = %q, want destination", pm.Chat.String())
+	}
+	if pm.ID != "sent-from-phone" || pm.Text != "sent elsewhere" {
+		t.Fatalf("unexpected parsed message: %+v", pm)
+	}
+}
+
+func TestParseLiveMessageDeviceSentMetaUsesDestinationChat(t *testing.T) {
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     types.NewJID("me", types.DefaultUserServer),
+				Sender:   types.NewJID("me", types.DefaultUserServer),
+				IsFromMe: false,
+			},
+			DeviceSentMeta: &types.DeviceSentMeta{
+				DestinationJID: "15551234567@s.whatsapp.net",
+			},
+			ID:        "live-sent-from-phone",
+			Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{Conversation: proto.String("live sent")},
+	}
+
+	pm := ParseLiveMessage(evt)
+	if !pm.FromMe {
+		t.Fatalf("FromMe = false, want true")
+	}
+	if pm.Chat.String() != "15551234567@s.whatsapp.net" {
+		t.Fatalf("Chat = %q, want destination", pm.Chat.String())
+	}
+	if pm.Text != "live sent" {
+		t.Fatalf("Text = %q", pm.Text)
+	}
+}
+
 func TestParseHistoryMessageCallLog(t *testing.T) {
 	outcome := waProto.CallLogMessage_CONNECTED
 	callType := waProto.CallLogMessage_REGULAR


### PR DESCRIPTION
## Summary
- Add explicit `messages revoke` command for deleting sent messages for everyone.
- Add `messages forward` command for forwarding stored text and media/document messages to another recipient.
- Support forwarding metadata such as media keys, direct paths, filenames, captions, mime types, and forwarding context.
- Allow `messages revoke` to target an explicit `--chat` + `--id` even when the target is not present in the local message store.
- Fix outgoing message sync for messages sent from another linked device: WhatsApp `DeviceSentMessage` wrappers are now parsed and stored in the actual destination chat with `from_me=true`, instead of being missed or associated with the wrong/self chat.
- Update messages and sync docs plus changelog.

## Why
This PR covers two connected message-lifecycle gaps:

1. The CLI did not expose direct user-facing commands for revoking and forwarding messages.
2. Outgoing messages sent from another linked WhatsApp device were not reliably represented in the local store. Those messages arrive wrapped as `DeviceSentMessage`; without unwrapping that metadata, `wacli` can miss the real destination chat and fail later workflows that depend on finding the outgoing message locally.

By fixing the outgoing-message import path and adding explicit lifecycle commands, `wacli` can now sync, find, forward, and revoke those messages more reliably.

## Testing
- `pnpm format:check`
- `pnpm lint`
- `pnpm -s test:go`
- `pnpm -s test:fts`
- `pnpm -s test:windows-lock`
- `pnpm -s test:cgo-required`
- `pnpm build`
- `git diff --check`
- Manual live smoke:
  - forwarded latest outbound Assistent image to Automator
  - revoked the forwarded message by explicit chat/id after loosening revoke lookup


## Live behavior proof (redacted)
Run on 2026-05-22 against an authenticated local WhatsApp store. The recipient/source chat was the account's own WhatsApp JID so no third-party chat was targeted. Phone number, chat name, and message IDs are redacted.

```console
$ ./dist/wacli --json send text --to <redacted-self>@s.whatsapp.net --message "wacli PR259 live proof <timestamp>" --post-send-wait 3s
{"success":true,"data":{"id":"<source-msg-id>","sent":true,"to":"<redacted-self>@s.whatsapp.net"},"error":null}

$ ./dist/wacli --json messages forward --chat <redacted-self>@s.whatsapp.net --id <source-msg-id> --to <redacted-self>@s.whatsapp.net --post-send-wait 3s
{"success":true,"data":{"forwarded":true,"id":"<forwarded-msg-id>","source":"<source-msg-id>","to":"<redacted-self>@s.whatsapp.net"},"error":null}

$ ./dist/wacli --read-only --json messages show --chat <redacted-self>@s.whatsapp.net --id <forwarded-msg-id>
{"success":true,"data":{"ChatJID":"<redacted-self>@s.whatsapp.net","ChatName":"<redacted-chat-name>","MsgID":"<forwarded-msg-id>","SenderJID":"","SenderName":"me","Timestamp":"2026-05-22T13:47:55Z","FromMe":true,"Text":"wacli PR259 live proof <timestamp>","DisplayText":"wacli PR259 live proof <timestamp>","IsForwarded":true,"ForwardingScore":1,"Revoked":false,"DeletedForMe":false},"error":null}

$ ./dist/wacli --json messages revoke --chat <redacted-self>@s.whatsapp.net --id <forwarded-msg-id> --post-send-wait 3s
{"success":true,"data":{"id":"<revoke-action-msg-id>","revoked":true,"target":"<forwarded-msg-id>","to":"<redacted-self>@s.whatsapp.net"},"error":null}

$ ./dist/wacli --read-only --json messages show --chat <redacted-self>@s.whatsapp.net --id <forwarded-msg-id>
{"success":true,"data":{"ChatJID":"<redacted-self>@s.whatsapp.net","ChatName":"<redacted-chat-name>","MsgID":"<forwarded-msg-id>","SenderJID":"","SenderName":"me","Timestamp":"2026-05-22T13:47:55Z","FromMe":true,"Text":"","DisplayText":"This message was deleted","IsForwarded":true,"ForwardingScore":1,"Revoked":true,"DeletedForMe":false},"error":null}
```

Validation after merge with current `origin/main`:

```console
$ go test ./cmd/wacli ./internal/app ./internal/store ./internal/wa
ok  github.com/openclaw/wacli/cmd/wacli
ok  github.com/openclaw/wacli/internal/app
ok  github.com/openclaw/wacli/internal/store
ok  github.com/openclaw/wacli/internal/wa

$ pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check
# passed
```
