### PR TITLE
fix: import completed call logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 ### Added
 
 - Chats: store unread marker state and numeric `unread_count` separately; migrate existing stores away from sentinel unread values while preserving public chat JSON fields. (#255 - thanks @drelum and @dovocoder)
-
 ### Security
 
 ### Fixed
+
+- Calls: import call-log records from full history syncs and the `regular` app-state collection so old call events can be stored even when the live call signaling was missed. (#256)
 
 ### Docs
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -83,6 +83,7 @@ type WAClient interface {
 	RequestAppStateRecovery(ctx context.Context, name string) (types.MessageID, error)
 	Logout(ctx context.Context) error
 	LinkedJID() string
+	LinkedLID() string
 
 	SetProfilePicture(ctx context.Context, avatar []byte) (string, error)
 }

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -26,6 +26,7 @@ type fakeWA struct {
 
 	authed    bool
 	connected bool
+	linkedLID string
 
 	nextHandlerID uint32
 	handlers      map[uint32]func(interface{})
@@ -652,4 +653,13 @@ func (f *fakeWA) LinkedJID() string {
 		return ""
 	}
 	return "1234567890@s.whatsapp.net"
+}
+
+func (f *fakeWA) LinkedLID() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if !f.authed {
+		return ""
+	}
+	return f.linkedLID
 }

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -178,8 +178,9 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 }
 
 func (a *App) syncAppStateDeltas(ctx context.Context) {
-	for _, name := range []appstate.WAPatchName{appstate.WAPatchRegularHigh, appstate.WAPatchRegularLow} {
-		if err := a.wa.FetchAppState(ctx, string(name), false, false); err != nil {
+	for _, name := range []appstate.WAPatchName{appstate.WAPatchRegularHigh, appstate.WAPatchRegularLow, appstate.WAPatchRegular} {
+		fullSync := name == appstate.WAPatchRegular
+		if err := a.wa.FetchAppState(ctx, string(name), fullSync, false); err != nil {
 			a.emitWarning(
 				"app_state_sync_failed",
 				fmt.Sprintf("warning: failed to sync WhatsApp app state %s: %v", name, err),

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -132,10 +132,15 @@ func (a *App) handleDeleteForMeEvent(ctx context.Context, evt *events.DeleteForM
 
 func (a *App) handleLiveCallEvent(ctx context.Context, evt interface{}) {
 	self := a.linkedLiveCallIdentity()
+	var alternateSelf []types.JID
 	if _, ok := evt.(*events.AppState); ok {
-		self = a.linkedCallIdentity()
+		identities := a.linkedCallIdentities()
+		if len(identities) > 0 {
+			self = identities[0]
+			alternateSelf = identities[1:]
+		}
 	}
-	call, ok := wa.ParseLiveCallEvent(evt, self)
+	call, ok := wa.ParseLiveCallEvent(evt, self, alternateSelf...)
 	if ok {
 		if err := a.storeParsedCallEvent(ctx, call, "", ""); err != nil {
 			a.emitWarning(
@@ -160,21 +165,19 @@ func (a *App) handleLiveCallEvent(ctx context.Context, evt interface{}) {
 	}
 }
 
-func (a *App) linkedCallIdentity() types.JID {
-	self := types.JID{}
+func (a *App) linkedCallIdentities() []types.JID {
+	identities := make([]types.JID, 0, 2)
 	if linked := strings.TrimSpace(a.wa.LinkedLID()); linked != "" {
 		if jid, err := types.ParseJID(linked); err == nil {
-			self = jid
+			identities = append(identities, jid)
 		}
 	}
-	if self.IsEmpty() {
-		if linked := strings.TrimSpace(a.wa.LinkedJID()); linked != "" {
-			if jid, err := types.ParseJID(linked); err == nil {
-				self = jid
-			}
+	if linked := strings.TrimSpace(a.wa.LinkedJID()); linked != "" {
+		if jid, err := types.ParseJID(linked); err == nil {
+			identities = append(identities, jid)
 		}
 	}
-	return self
+	return identities
 }
 
 func (a *App) linkedLiveCallIdentity() types.JID {
@@ -370,10 +373,16 @@ func (a *App) storeHistoryCallLogRecords(ctx context.Context, v *events.HistoryS
 	if v == nil || v.Data == nil {
 		return
 	}
-	self := a.linkedCallIdentity()
+	identities := a.linkedCallIdentities()
+	self := types.JID{}
+	var alternateSelf []types.JID
+	if len(identities) > 0 {
+		self = identities[0]
+		alternateSelf = identities[1:]
+	}
 	for _, record := range v.Data.GetCallLogRecords() {
 		lastEvent.Store(nowUTC().UnixNano())
-		call, ok := wa.ParseCallLogRecord(record, self)
+		call, ok := wa.ParseCallLogRecord(record, self, alternateSelf...)
 		if !ok {
 			continue
 		}

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -131,11 +131,9 @@ func (a *App) handleDeleteForMeEvent(ctx context.Context, evt *events.DeleteForM
 }
 
 func (a *App) handleLiveCallEvent(ctx context.Context, evt interface{}) {
-	self := types.JID{}
-	if linked := strings.TrimSpace(a.wa.LinkedJID()); linked != "" {
-		if jid, err := types.ParseJID(linked); err == nil {
-			self = jid
-		}
+	self := a.linkedLiveCallIdentity()
+	if _, ok := evt.(*events.AppState); ok {
+		self = a.linkedCallIdentity()
 	}
 	call, ok := wa.ParseLiveCallEvent(evt, self)
 	if ok {
@@ -160,6 +158,32 @@ func (a *App) handleLiveCallEvent(ctx context.Context, evt interface{}) {
 			map[string]any{"chat_jid": deleted.Chat.String(), "direction": deleted.Direction, "error": err.Error()},
 		)
 	}
+}
+
+func (a *App) linkedCallIdentity() types.JID {
+	self := types.JID{}
+	if linked := strings.TrimSpace(a.wa.LinkedLID()); linked != "" {
+		if jid, err := types.ParseJID(linked); err == nil {
+			self = jid
+		}
+	}
+	if self.IsEmpty() {
+		if linked := strings.TrimSpace(a.wa.LinkedJID()); linked != "" {
+			if jid, err := types.ParseJID(linked); err == nil {
+				self = jid
+			}
+		}
+	}
+	return self
+}
+
+func (a *App) linkedLiveCallIdentity() types.JID {
+	if linked := strings.TrimSpace(a.wa.LinkedJID()); linked != "" {
+		if jid, err := types.ParseJID(linked); err == nil {
+			return jid
+		}
+	}
+	return types.JID{}
 }
 
 func (a *App) handleStarEvent(ctx context.Context, evt *events.Star) {
@@ -283,6 +307,7 @@ func historySyncNotificationFromMessage(v *events.Message) *waE2E.HistorySyncNot
 
 func (a *App) handleHistorySync(ctx context.Context, opts SyncOptions, v *events.HistorySync, messagesStored, lastEvent *atomic.Int64, enqueueMedia func(string, string), limits ...*syncStorageLimits) {
 	a.emitOrPrint("history_sync", map[string]any{"conversations": len(v.Data.Conversations)}, "\nProcessing history sync (%d conversations)...\n", len(v.Data.Conversations))
+	a.storeHistoryCallLogRecords(ctx, v, lastEvent)
 	for _, conv := range v.Data.Conversations {
 		lastEvent.Store(nowUTC().UnixNano())
 		chatID := strings.TrimSpace(conv.GetID())
@@ -338,6 +363,27 @@ func (a *App) handleHistorySync(ctx context.Context, opts SyncOptions, v *events
 	}
 	if !a.eventsEnabled() {
 		a.emitOrPrint("progress", map[string]any{"messages_synced": messagesStored.Load()}, "\rSynced %d messages...", messagesStored.Load())
+	}
+}
+
+func (a *App) storeHistoryCallLogRecords(ctx context.Context, v *events.HistorySync, lastEvent *atomic.Int64) {
+	if v == nil || v.Data == nil {
+		return
+	}
+	self := a.linkedCallIdentity()
+	for _, record := range v.Data.GetCallLogRecords() {
+		lastEvent.Store(nowUTC().UnixNano())
+		call, ok := wa.ParseCallLogRecord(record, self)
+		if !ok {
+			continue
+		}
+		if err := a.storeParsedCallEvent(ctx, call, "", ""); err != nil {
+			a.emitWarning(
+				"history_call_log_store_failed",
+				fmt.Sprintf("warning: failed to store history call log %s: %v", call.CallID, err),
+				map[string]any{"call_id": call.CallID, "error": err.Error()},
+			)
+		}
 	}
 }
 

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -255,6 +255,41 @@ func TestLiveCallOfferStoresCallEvent(t *testing.T) {
 	}
 }
 
+func TestLiveCallOfferUsesPNIdentityWhenLinkedLIDExists(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	f.linkedLID = types.NewJID("999123456789", types.HiddenUserServer).String()
+	a.wa = f
+
+	self, err := types.ParseJID(f.LinkedJID())
+	if err != nil {
+		t.Fatalf("ParseJID linked: %v", err)
+	}
+	remote := types.NewJID("15551234567", types.DefaultUserServer)
+	when := time.Date(2024, 1, 3, 12, 0, 0, 0, time.UTC)
+	a.handleLiveCallEvent(context.Background(), &events.CallOffer{
+		BasicCallMeta: types.BasicCallMeta{
+			From:        remote,
+			CallCreator: self,
+			CallID:      "call-live-lid-1",
+			Timestamp:   when,
+		},
+		Data: &waBinary.Node{Attrs: waBinary.Attrs{"media": "audio"}},
+	})
+
+	calls, err := a.db.ListCallEvents(store.ListCallEventsParams{ChatJID: remote.String(), Limit: 10})
+	if err != nil {
+		t.Fatalf("ListCallEvents: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("calls len = %d, want 1", len(calls))
+	}
+	got := calls[0]
+	if got.CallID != "call-live-lid-1" || got.EventType != "offer" || got.Direction != "outbound" || got.Media != "audio" {
+		t.Fatalf("unexpected call event: %+v", got)
+	}
+}
+
 func TestLiveSyncStoresCallLogMessageAndCallEvent(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()
@@ -302,6 +337,53 @@ func TestLiveSyncStoresCallLogMessageAndCallEvent(t *testing.T) {
 	}
 	got := calls[0]
 	if got.CallID != "call-msg-1" || got.MsgID != "call-msg-1" || got.EventType != "call_log" || got.Direction != "outbound" || got.Outcome != "connected" {
+		t.Fatalf("unexpected call log event: %+v", got)
+	}
+}
+
+func TestHistorySyncStoresCallLogRecords(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.NewJID("15551234567", types.DefaultUserServer)
+	when := time.Date(2024, 1, 3, 12, 0, 0, 0, time.UTC)
+	result := waSyncAction.CallLogRecord_CONNECTED
+	callType := waSyncAction.CallLogRecord_REGULAR
+	history := &events.HistorySync{Data: &waHistorySync.HistorySync{
+		SyncType: waHistorySync.HistorySync_FULL.Enum(),
+		CallLogRecords: []*waSyncAction.CallLogRecord{{
+			CallID:         proto.String("call-history-1"),
+			CallCreatorJID: proto.String(f.LinkedJID()),
+			Participants: []*waSyncAction.CallLogRecord_ParticipantInfo{{
+				UserJID:    proto.String(chat.String()),
+				CallResult: &result,
+			}},
+			CallResult: &result,
+			CallType:   &callType,
+			Duration:   proto.Int64(61),
+			StartTime:  proto.Int64(when.UnixMilli()),
+			IsIncoming: proto.Bool(false),
+			IsVideo:    proto.Bool(false),
+		}},
+	}}
+	var messagesStored atomic.Int64
+	var lastEvent atomic.Int64
+
+	a.handleHistorySync(context.Background(), SyncOptions{}, history, &messagesStored, &lastEvent, func(string, string) {})
+
+	if messagesStored.Load() != 0 {
+		t.Fatalf("messages stored = %d, want 0", messagesStored.Load())
+	}
+	calls, err := a.db.ListCallEvents(store.ListCallEventsParams{ChatJID: chat.String(), Limit: 10})
+	if err != nil {
+		t.Fatalf("ListCallEvents: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("calls len = %d, want 1", len(calls))
+	}
+	got := calls[0]
+	if got.CallID != "call-history-1" || got.EventType != "call_log" || got.Direction != "outbound" || got.Outcome != "connected" || got.DurationSecs != 61 {
 		t.Fatalf("unexpected call log event: %+v", got)
 	}
 }
@@ -525,6 +607,8 @@ func TestSyncFetchesChatAppStateDeltasAfterConnect(t *testing.T) {
 
 	chat := types.NewJID("15551234567", types.DefaultUserServer)
 	base := time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)
+	result := waSyncAction.CallLogRecord_CONNECTED
+	callType := waSyncAction.CallLogRecord_REGULAR
 	if err := a.db.UpsertChat(chat.String(), "dm", "Alice", base); err != nil {
 		t.Fatalf("UpsertChat: %v", err)
 	}
@@ -538,10 +622,13 @@ func TestSyncFetchesChatAppStateDeltasAfterConnect(t *testing.T) {
 		t.Fatalf("UpsertMessage: %v", err)
 	}
 	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
-		if fullSync || onlyIfNotSynced {
+		if onlyIfNotSynced {
 			return nil
 		}
 		if name == string(appstate.WAPatchRegularHigh) {
+			if fullSync {
+				return nil
+			}
 			return &events.DeleteForMe{
 				ChatJID:   chat,
 				MessageID: "m-offline-delete-for-me",
@@ -550,10 +637,37 @@ func TestSyncFetchesChatAppStateDeltasAfterConnect(t *testing.T) {
 			}
 		}
 		if name == string(appstate.WAPatchRegularLow) {
+			if fullSync {
+				return nil
+			}
 			return &events.Archive{
 				JID:       chat,
 				Timestamp: base.Add(2 * time.Minute),
 				Action:    &waSyncAction.ArchiveChatAction{Archived: proto.Bool(true)},
+			}
+		}
+		if name == string(appstate.WAPatchRegular) {
+			if !fullSync {
+				return nil
+			}
+			return &events.AppState{
+				SyncActionValue: &waSyncAction.SyncActionValue{
+					Timestamp: proto.Int64(base.Add(3 * time.Minute).UnixMilli()),
+					CallLogAction: &waSyncAction.CallLogAction{CallLogRecord: &waSyncAction.CallLogRecord{
+						CallID:         proto.String("call-app-state-1"),
+						CallCreatorJID: proto.String(f.LinkedJID()),
+						Participants: []*waSyncAction.CallLogRecord_ParticipantInfo{{
+							UserJID:    proto.String(chat.String()),
+							CallResult: &result,
+						}},
+						CallResult: &result,
+						CallType:   &callType,
+						Duration:   proto.Int64(61),
+						StartTime:  proto.Int64(base.Add(3 * time.Minute).UnixMilli()),
+						IsIncoming: proto.Bool(false),
+						IsVideo:    proto.Bool(false),
+					}},
+				},
 			}
 		}
 		return nil
@@ -572,7 +686,7 @@ func TestSyncFetchesChatAppStateDeltasAfterConnect(t *testing.T) {
 	f.mu.Lock()
 	fetches := append([]fakeAppStateFetch(nil), f.appStateFetches...)
 	f.mu.Unlock()
-	if len(fetches) != 2 {
+	if len(fetches) != 3 {
 		t.Fatalf("app state fetches = %+v", fetches)
 	}
 	if fetches[0].name != string(appstate.WAPatchRegularHigh) || fetches[0].fullSync || fetches[0].onlyIfNotSynced {
@@ -580,6 +694,9 @@ func TestSyncFetchesChatAppStateDeltasAfterConnect(t *testing.T) {
 	}
 	if fetches[1].name != string(appstate.WAPatchRegularLow) || fetches[1].fullSync || fetches[1].onlyIfNotSynced {
 		t.Fatalf("second app state fetch = %+v", fetches[1])
+	}
+	if fetches[2].name != string(appstate.WAPatchRegular) || !fetches[2].fullSync || fetches[2].onlyIfNotSynced {
+		t.Fatalf("third app state fetch = %+v", fetches[2])
 	}
 	msg, err := a.db.GetMessage(chat.String(), "m-offline-delete-for-me")
 	if err != nil {
@@ -594,6 +711,13 @@ func TestSyncFetchesChatAppStateDeltasAfterConnect(t *testing.T) {
 	}
 	if !storedChat.Archived {
 		t.Fatalf("chat was not marked archived from regular_low app state: %+v", storedChat)
+	}
+	calls, err := a.db.ListCallEvents(store.ListCallEventsParams{ChatJID: chat.String(), Limit: 10})
+	if err != nil {
+		t.Fatalf("ListCallEvents: %v", err)
+	}
+	if len(calls) != 1 || calls[0].CallID != "call-app-state-1" || calls[0].DurationSecs != 61 {
+		t.Fatalf("call log was not stored from regular app state: %+v", calls)
 	}
 }
 

--- a/internal/store/calls.go
+++ b/internal/store/calls.go
@@ -39,7 +39,8 @@ func (d *DB) UpsertCallEvent(p UpsertCallEventParams) error {
 		ts = nowUTC().Unix()
 	}
 	callID := strings.TrimSpace(p.CallID)
-	if callID == "" {
+	generatedCallID := callID == ""
+	if generatedCallID {
 		callID = fmt.Sprintf("%s:%d", eventType, ts)
 	}
 	if p.DurationSecs < 0 {
@@ -53,32 +54,13 @@ func (d *DB) UpsertCallEvent(p UpsertCallEventParams) error {
 		}
 	}
 
-	if callID != "" {
-		res, err := d.sql.Exec(`
-			UPDATE call_events SET
-				chat_jid=?,
-				chat_name=COALESCE(NULLIF(?,''), chat_name),
-				sender_jid=COALESCE(NULLIF(?,''), sender_jid),
-				sender_name=COALESCE(NULLIF(?,''), sender_name),
-				msg_id=COALESCE(NULLIF(?,''), msg_id),
-				direction=COALESCE(NULLIF(?,''), direction),
-				media=COALESCE(NULLIF(?,''), media),
-				outcome=COALESCE(NULLIF(?,''), outcome),
-				reason=COALESCE(NULLIF(?,''), reason),
-				call_type=COALESCE(NULLIF(?,''), call_type),
-				duration_secs=CASE WHEN ? > 0 THEN ? ELSE duration_secs END,
-				ts=?,
-				participants=COALESCE(NULLIF(?,''), participants)
-			WHERE call_id=? AND event_type=?
-		`, chatJID, nullIfEmpty(p.ChatName), nullIfEmpty(p.SenderJID), nullIfEmpty(p.SenderName),
-			nullIfEmpty(p.MsgID), nullIfEmpty(p.Direction), nullIfEmpty(p.Media), nullIfEmpty(p.Outcome),
-			nullIfEmpty(p.Reason), nullIfEmpty(p.CallType), p.DurationSecs, p.DurationSecs, ts, participantsJSON,
-			callID, eventType)
+	if !generatedCallID {
+		rowID, ok, err := d.singleCallEventRow(chatJID, callID, eventType)
 		if err != nil {
 			return err
 		}
-		if rows, err := res.RowsAffected(); err == nil && rows > 0 {
-			return nil
+		if ok {
+			return d.updateCallEventRow(rowID, p, chatJID, callID, eventType, ts, participantsJSON)
 		}
 	}
 
@@ -103,6 +85,66 @@ func (d *DB) UpsertCallEvent(p UpsertCallEventParams) error {
 		callID, nullIfEmpty(p.MsgID), eventType, nullIfEmpty(p.Direction), nullIfEmpty(p.Media),
 		nullIfEmpty(p.Outcome), nullIfEmpty(p.Reason), nullIfEmpty(p.CallType), p.DurationSecs, ts, participantsJSON)
 	return err
+}
+
+func (d *DB) singleCallEventRow(chatJID, callID, eventType string) (int64, bool, error) {
+	rows, err := d.sql.Query(`
+		SELECT rowid
+		FROM call_events
+		WHERE chat_jid=? AND call_id=? AND event_type=?
+		ORDER BY ts DESC, rowid DESC
+		LIMIT 2
+	`, chatJID, callID, eventType)
+	if err != nil {
+		return 0, false, err
+	}
+	defer rows.Close()
+
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return 0, false, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, false, err
+	}
+	if len(ids) != 1 {
+		return 0, false, nil
+	}
+	return ids[0], true, nil
+}
+
+func (d *DB) updateCallEventRow(rowID int64, p UpsertCallEventParams, chatJID, callID, eventType string, ts int64, participantsJSON interface{}) error {
+	res, err := d.sql.Exec(`
+			UPDATE call_events SET
+				chat_jid=?,
+				chat_name=COALESCE(NULLIF(?,''), chat_name),
+				sender_jid=COALESCE(NULLIF(?,''), sender_jid),
+				sender_name=COALESCE(NULLIF(?,''), sender_name),
+				msg_id=COALESCE(NULLIF(?,''), msg_id),
+				direction=COALESCE(NULLIF(?,''), direction),
+				media=COALESCE(NULLIF(?,''), media),
+				outcome=COALESCE(NULLIF(?,''), outcome),
+				reason=COALESCE(NULLIF(?,''), reason),
+				call_type=COALESCE(NULLIF(?,''), call_type),
+				duration_secs=CASE WHEN ? > 0 THEN ? ELSE duration_secs END,
+				ts=?,
+				participants=COALESCE(NULLIF(?,''), participants)
+			WHERE rowid=? AND chat_jid=? AND call_id=? AND event_type=?
+	`, chatJID, nullIfEmpty(p.ChatName), nullIfEmpty(p.SenderJID), nullIfEmpty(p.SenderName),
+		nullIfEmpty(p.MsgID), nullIfEmpty(p.Direction), nullIfEmpty(p.Media), nullIfEmpty(p.Outcome),
+		nullIfEmpty(p.Reason), nullIfEmpty(p.CallType), p.DurationSecs, p.DurationSecs, ts, participantsJSON,
+		rowID, chatJID, callID, eventType)
+	if err != nil {
+		return err
+	}
+	if rows, err := res.RowsAffected(); err == nil && rows > 0 {
+		return nil
+	}
+	return nil
 }
 
 type ListCallEventsParams struct {

--- a/internal/store/calls.go
+++ b/internal/store/calls.go
@@ -53,6 +53,35 @@ func (d *DB) UpsertCallEvent(p UpsertCallEventParams) error {
 		}
 	}
 
+	if callID != "" {
+		res, err := d.sql.Exec(`
+			UPDATE call_events SET
+				chat_jid=?,
+				chat_name=COALESCE(NULLIF(?,''), chat_name),
+				sender_jid=COALESCE(NULLIF(?,''), sender_jid),
+				sender_name=COALESCE(NULLIF(?,''), sender_name),
+				msg_id=COALESCE(NULLIF(?,''), msg_id),
+				direction=COALESCE(NULLIF(?,''), direction),
+				media=COALESCE(NULLIF(?,''), media),
+				outcome=COALESCE(NULLIF(?,''), outcome),
+				reason=COALESCE(NULLIF(?,''), reason),
+				call_type=COALESCE(NULLIF(?,''), call_type),
+				duration_secs=CASE WHEN ? > 0 THEN ? ELSE duration_secs END,
+				ts=?,
+				participants=COALESCE(NULLIF(?,''), participants)
+			WHERE call_id=? AND event_type=?
+		`, chatJID, nullIfEmpty(p.ChatName), nullIfEmpty(p.SenderJID), nullIfEmpty(p.SenderName),
+			nullIfEmpty(p.MsgID), nullIfEmpty(p.Direction), nullIfEmpty(p.Media), nullIfEmpty(p.Outcome),
+			nullIfEmpty(p.Reason), nullIfEmpty(p.CallType), p.DurationSecs, p.DurationSecs, ts, participantsJSON,
+			callID, eventType)
+		if err != nil {
+			return err
+		}
+		if rows, err := res.RowsAffected(); err == nil && rows > 0 {
+			return nil
+		}
+	}
+
 	_, err := d.sql.Exec(`
 		INSERT INTO call_events(
 			chat_jid, chat_name, sender_jid, sender_name, call_id, msg_id, event_type,

--- a/internal/store/calls_test.go
+++ b/internal/store/calls_test.go
@@ -48,3 +48,55 @@ func TestUpsertCallEventUpdatesTimestampForSameCall(t *testing.T) {
 		t.Fatalf("call = %+v, want timestamp %s and duration 9", calls[0], newTS)
 	}
 }
+
+func TestUpsertCallEventDoesNotMoveOtherChatsWithSameCallID(t *testing.T) {
+	db, err := Open(filepath.Join(t.TempDir(), "wacli.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	oldTS := time.Date(2026, 5, 22, 10, 45, 0, 0, time.UTC)
+	newTS := oldTS.Add(time.Hour)
+	chatA := "15551234567@s.whatsapp.net"
+	chatB := "15557654321@s.whatsapp.net"
+	for _, chat := range []string{chatA, chatB} {
+		if err := db.UpsertChat(chat, "dm", "", oldTS); err != nil {
+			t.Fatalf("UpsertChat %s: %v", chat, err)
+		}
+		if err := db.UpsertCallEvent(UpsertCallEventParams{
+			ChatJID:   chat,
+			CallID:    "duplicated-call-id",
+			EventType: "call_log",
+			Timestamp: oldTS,
+		}); err != nil {
+			t.Fatalf("UpsertCallEvent %s: %v", chat, err)
+		}
+	}
+
+	if err := db.UpsertCallEvent(UpsertCallEventParams{
+		ChatJID:      chatA,
+		CallID:       "duplicated-call-id",
+		EventType:    "call_log",
+		DurationSecs: 12,
+		Timestamp:    newTS,
+		Participants: []CallParticipant{{JID: chatB}},
+	}); err != nil {
+		t.Fatalf("UpsertCallEvent update: %v", err)
+	}
+
+	callsA, err := db.ListCallEvents(ListCallEventsParams{ChatJID: chatA, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListCallEvents chatA: %v", err)
+	}
+	if len(callsA) != 1 || !callsA[0].Timestamp.Equal(newTS) || callsA[0].DurationSecs != 12 {
+		t.Fatalf("chatA calls = %+v, want one updated row", callsA)
+	}
+	callsB, err := db.ListCallEvents(ListCallEventsParams{ChatJID: chatB, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListCallEvents chatB: %v", err)
+	}
+	if len(callsB) != 1 || !callsB[0].Timestamp.Equal(oldTS) || callsB[0].DurationSecs != 0 {
+		t.Fatalf("chatB calls = %+v, want original row untouched", callsB)
+	}
+}

--- a/internal/store/calls_test.go
+++ b/internal/store/calls_test.go
@@ -1,0 +1,50 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestUpsertCallEventUpdatesTimestampForSameCall(t *testing.T) {
+	db, err := Open(filepath.Join(t.TempDir(), "wacli.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	oldTS := time.Date(1970, 1, 21, 14, 17, 15, 0, time.UTC)
+	newTS := time.Date(2026, 5, 22, 10, 45, 0, 0, time.UTC)
+	chatJID := "15551234567@s.whatsapp.net"
+	if err := db.UpsertChat(chatJID, "dm", "Alice", oldTS); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	base := UpsertCallEventParams{
+		ChatJID:   chatJID,
+		CallID:    "call-1",
+		EventType: "call_log",
+		Direction: "outbound",
+		Media:     "audio",
+		Outcome:   "connected",
+		Timestamp: oldTS,
+	}
+	if err := db.UpsertCallEvent(base); err != nil {
+		t.Fatalf("UpsertCallEvent old: %v", err)
+	}
+	base.Timestamp = newTS
+	base.DurationSecs = 9
+	if err := db.UpsertCallEvent(base); err != nil {
+		t.Fatalf("UpsertCallEvent new: %v", err)
+	}
+
+	calls, err := db.ListCallEvents(ListCallEventsParams{ChatJID: base.ChatJID, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListCallEvents: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("calls len = %d, want 1", len(calls))
+	}
+	if !calls[0].Timestamp.Equal(newTS) || calls[0].DurationSecs != 9 {
+		t.Fatalf("call = %+v, want timestamp %s and duration 9", calls[0], newTS)
+	}
+}

--- a/internal/wa/calls.go
+++ b/internal/wa/calls.go
@@ -59,7 +59,7 @@ func extractCallLog(m *waProto.Message, pm *ParsedMessage) {
 	}
 }
 
-func ParseLiveCallEvent(evt interface{}, self types.JID) (ParsedCallEvent, bool) {
+func ParseLiveCallEvent(evt interface{}, self types.JID, alternateSelf ...types.JID) (ParsedCallEvent, bool) {
 	switch v := evt.(type) {
 	case *events.CallOffer:
 		return callEventFromMeta(v.BasicCallMeta, self, "offer", "", "", mediaFromCallNode(v.Data), ""), true
@@ -78,7 +78,7 @@ func ParseLiveCallEvent(evt interface{}, self types.JID) (ParsedCallEvent, bool)
 	case *events.CallReject:
 		return callEventFromMeta(v.BasicCallMeta, self, "reject", "", "", mediaFromCallNode(v.Data), ""), true
 	case *events.AppState:
-		return parseCallLogAppState(v, self)
+		return parseCallLogAppState(v, selfIdentities(self, alternateSelf...))
 	default:
 		return ParsedCallEvent{}, false
 	}
@@ -127,7 +127,7 @@ func callEventFromMeta(meta types.BasicCallMeta, self types.JID, eventType, outc
 	}
 }
 
-func parseCallLogAppState(evt *events.AppState, self types.JID) (ParsedCallEvent, bool) {
+func parseCallLogAppState(evt *events.AppState, self []types.JID) (ParsedCallEvent, bool) {
 	if evt == nil || evt.SyncActionValue == nil || evt.GetCallLogAction() == nil || evt.GetCallLogAction().GetCallLogRecord() == nil {
 		return ParsedCallEvent{}, false
 	}
@@ -138,11 +138,11 @@ func parseCallLogAppState(evt *events.AppState, self types.JID) (ParsedCallEvent
 	return parseCallLogRecord(evt.GetCallLogAction().GetCallLogRecord(), self, fallback)
 }
 
-func ParseCallLogRecord(record *waSyncAction.CallLogRecord, self types.JID) (ParsedCallEvent, bool) {
-	return parseCallLogRecord(record, self, time.Time{})
+func ParseCallLogRecord(record *waSyncAction.CallLogRecord, self types.JID, alternateSelf ...types.JID) (ParsedCallEvent, bool) {
+	return parseCallLogRecord(record, selfIdentities(self, alternateSelf...), time.Time{})
 }
 
-func parseCallLogRecord(record *waSyncAction.CallLogRecord, self types.JID, fallback time.Time) (ParsedCallEvent, bool) {
+func parseCallLogRecord(record *waSyncAction.CallLogRecord, self []types.JID, fallback time.Time) (ParsedCallEvent, bool) {
 	if record == nil {
 		return ParsedCallEvent{}, false
 	}
@@ -181,7 +181,7 @@ func callLogRecordTimestamp(raw int64, fallback time.Time) time.Time {
 	}
 }
 
-func callLogRecordChatAndSender(record *waSyncAction.CallLogRecord, self types.JID) (types.JID, string) {
+func callLogRecordChatAndSender(record *waSyncAction.CallLogRecord, self []types.JID) (types.JID, string) {
 	if group := strings.TrimSpace(record.GetGroupJID()); group != "" {
 		if jid, err := types.ParseJID(group); err == nil && jid.Server == types.GroupServer {
 			return jid, strings.TrimSpace(record.GetCallCreatorJID())
@@ -189,7 +189,7 @@ func callLogRecordChatAndSender(record *waSyncAction.CallLogRecord, self types.J
 	}
 	creator := strings.TrimSpace(record.GetCallCreatorJID())
 	if creator != "" {
-		if creatorJID, err := types.ParseJID(creator); err == nil && (self.IsEmpty() || creatorJID.ToNonAD() != self.ToNonAD()) {
+		if creatorJID, err := types.ParseJID(creator); err == nil && !isSelfJID(creatorJID, self) {
 			return creatorJID, creator
 		}
 	}
@@ -197,7 +197,7 @@ func callLogRecordChatAndSender(record *waSyncAction.CallLogRecord, self types.J
 		if p == nil || strings.TrimSpace(p.GetUserJID()) == "" {
 			continue
 		}
-		if jid, err := types.ParseJID(p.GetUserJID()); err == nil && (self.IsEmpty() || jid.ToNonAD() != self.ToNonAD()) {
+		if jid, err := types.ParseJID(p.GetUserJID()); err == nil && !isSelfJID(jid, self) {
 			return jid, creator
 		}
 	}
@@ -215,6 +215,38 @@ func callLogRecordChatAndSender(record *waSyncAction.CallLogRecord, self types.J
 		}
 	}
 	return types.JID{}, ""
+}
+
+func selfIdentities(primary types.JID, alternates ...types.JID) []types.JID {
+	ids := make([]types.JID, 0, 1+len(alternates))
+	for _, jid := range append([]types.JID{primary}, alternates...) {
+		if jid.IsEmpty() {
+			continue
+		}
+		seen := false
+		for _, existing := range ids {
+			if existing.ToNonAD() == jid.ToNonAD() {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			ids = append(ids, jid)
+		}
+	}
+	return ids
+}
+
+func isSelfJID(jid types.JID, self []types.JID) bool {
+	if jid.IsEmpty() {
+		return false
+	}
+	for _, candidate := range self {
+		if !candidate.IsEmpty() && jid.ToNonAD() == candidate.ToNonAD() {
+			return true
+		}
+	}
+	return false
 }
 
 func directionFromCallCreator(creator, self types.JID, eventType string) string {

--- a/internal/wa/calls.go
+++ b/internal/wa/calls.go
@@ -131,15 +131,26 @@ func parseCallLogAppState(evt *events.AppState, self types.JID) (ParsedCallEvent
 	if evt == nil || evt.SyncActionValue == nil || evt.GetCallLogAction() == nil || evt.GetCallLogAction().GetCallLogRecord() == nil {
 		return ParsedCallEvent{}, false
 	}
-	record := evt.GetCallLogAction().GetCallLogRecord()
+	var fallback time.Time
+	if evt.GetTimestamp() > 0 {
+		fallback = time.UnixMilli(evt.GetTimestamp()).UTC()
+	}
+	return parseCallLogRecord(evt.GetCallLogAction().GetCallLogRecord(), self, fallback)
+}
+
+func ParseCallLogRecord(record *waSyncAction.CallLogRecord, self types.JID) (ParsedCallEvent, bool) {
+	return parseCallLogRecord(record, self, time.Time{})
+}
+
+func parseCallLogRecord(record *waSyncAction.CallLogRecord, self types.JID, fallback time.Time) (ParsedCallEvent, bool) {
+	if record == nil {
+		return ParsedCallEvent{}, false
+	}
 	chat, sender := callLogRecordChatAndSender(record, self)
 	if chat.IsEmpty() {
 		return ParsedCallEvent{}, false
 	}
-	ts := time.UnixMilli(record.GetStartTime()).UTC()
-	if record.GetStartTime() <= 0 && evt.GetTimestamp() > 0 {
-		ts = time.UnixMilli(evt.GetTimestamp()).UTC()
-	}
+	ts := callLogRecordTimestamp(record.GetStartTime(), fallback)
 	return ParsedCallEvent{
 		Chat:         chat,
 		SenderJID:    sender,
@@ -156,9 +167,23 @@ func parseCallLogAppState(evt *events.AppState, self types.JID) (ParsedCallEvent
 	}, true
 }
 
+func callLogRecordTimestamp(raw int64, fallback time.Time) time.Time {
+	if raw <= 0 {
+		return fallback
+	}
+	switch {
+	case raw < 100_000_000_000:
+		return time.Unix(raw, 0).UTC()
+	case raw < 100_000_000_000_000:
+		return time.UnixMilli(raw).UTC()
+	default:
+		return time.UnixMicro(raw).UTC()
+	}
+}
+
 func callLogRecordChatAndSender(record *waSyncAction.CallLogRecord, self types.JID) (types.JID, string) {
 	if group := strings.TrimSpace(record.GetGroupJID()); group != "" {
-		if jid, err := types.ParseJID(group); err == nil {
+		if jid, err := types.ParseJID(group); err == nil && jid.Server == types.GroupServer {
 			return jid, strings.TrimSpace(record.GetCallCreatorJID())
 		}
 	}

--- a/internal/wa/calls_test.go
+++ b/internal/wa/calls_test.go
@@ -1,0 +1,47 @@
+package wa
+
+import (
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow/proto/waSyncAction"
+	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestCallLogRecordTimestampUnits(t *testing.T) {
+	want := time.Date(2026, 5, 22, 10, 45, 0, 0, time.UTC)
+	for _, raw := range []int64{want.Unix(), want.UnixMilli(), want.UnixMicro()} {
+		if got := callLogRecordTimestamp(raw, time.Time{}); !got.Equal(want) {
+			t.Fatalf("timestamp %d = %s, want %s", raw, got, want)
+		}
+	}
+
+	fallback := time.Date(2026, 5, 22, 11, 0, 0, 0, time.UTC)
+	if got := callLogRecordTimestamp(0, fallback); !got.Equal(fallback) {
+		t.Fatalf("fallback = %s, want %s", got, fallback)
+	}
+}
+
+func TestCallLogRecordChatIgnoresSelfGroupJIDForOneToOne(t *testing.T) {
+	self := types.NewJID("15550000001", types.DefaultUserServer)
+	peer := types.NewJID("15550000002", types.DefaultUserServer)
+	call, ok := ParseCallLogRecord(&waSyncAction.CallLogRecord{
+		CallID:         proto.String("call-1"),
+		CallCreatorJID: proto.String(self.String()),
+		GroupJID:       proto.String(self.String()),
+		Participants: []*waSyncAction.CallLogRecord_ParticipantInfo{{
+			UserJID: proto.String(peer.String()),
+		}},
+		StartTime: proto.Int64(time.Date(2026, 5, 22, 10, 45, 0, 0, time.UTC).Unix()),
+	}, self)
+	if !ok {
+		t.Fatal("ParseCallLogRecord returned false")
+	}
+	if call.Chat != peer {
+		t.Fatalf("chat = %s, want %s", call.Chat, peer)
+	}
+	if call.SenderJID != self.String() {
+		t.Fatalf("sender = %q, want %q", call.SenderJID, self.String())
+	}
+}

--- a/internal/wa/calls_test.go
+++ b/internal/wa/calls_test.go
@@ -45,3 +45,26 @@ func TestCallLogRecordChatIgnoresSelfGroupJIDForOneToOne(t *testing.T) {
 		t.Fatalf("sender = %q, want %q", call.SenderJID, self.String())
 	}
 }
+
+func TestCallLogRecordRecognizesPNAndLIDSelfIdentities(t *testing.T) {
+	selfPN := types.NewJID("15550000001", types.DefaultUserServer)
+	selfLID := types.NewJID("999123456789", types.HiddenUserServer)
+	peer := types.NewJID("15550000002", types.DefaultUserServer)
+
+	for _, creator := range []types.JID{selfPN, selfLID} {
+		call, ok := ParseCallLogRecord(&waSyncAction.CallLogRecord{
+			CallID:         proto.String("call-1"),
+			CallCreatorJID: proto.String(creator.String()),
+			Participants: []*waSyncAction.CallLogRecord_ParticipantInfo{{
+				UserJID: proto.String(peer.String()),
+			}},
+			StartTime: proto.Int64(time.Date(2026, 5, 22, 10, 45, 0, 0, time.UTC).Unix()),
+		}, selfLID, selfPN)
+		if !ok {
+			t.Fatalf("ParseCallLogRecord returned false for creator %s", creator)
+		}
+		if call.Chat != peer {
+			t.Fatalf("creator %s chat = %s, want %s", creator, call.Chat, peer)
+		}
+	}
+}

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -72,6 +72,19 @@ func (c *Client) LinkedJID() string {
 	return c.client.Store.ID.ToNonAD().String()
 }
 
+func (c *Client) LinkedLID() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.client == nil || c.client.Store == nil {
+		return ""
+	}
+	lid := c.client.Store.GetLID()
+	if lid.IsEmpty() {
+		return ""
+	}
+	return lid.ToNonAD().String()
+}
+
 func (c *Client) IsConnected() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()


### PR DESCRIPTION
## Summary

Fixes #256 by importing completed WhatsApp call logs from the app-state/history paths that actually carry them, instead of relying only on live call signaling events.

## What changed

- Replay the `regular` app-state collection during sync so existing call-log records are emitted and stored idempotently.
- Store `HistorySync.callLogRecords` when WhatsApp includes call logs in history sync payloads.
- Decode app-state call records correctly:
  - `startTime` can be seconds, milliseconds, or microseconds
  - self identity prefers the linked-device LID for app-state call records
  - one-to-one records resolve to the peer chat, not the account’s own JID
- Make call-event upserts correct previously imported rows for the same call ID, including timestamp/chat fixes.

## Root cause

`calls list` mostly showed live `offer` events because completed call logs arrive as call-log records in WhatsApp app-state/history data. The `regular` app-state collection was not being replayed, so if WhatsApp had already advanced that collection before wacli knew how to store call logs, later delta syncs could not recover those records. The call-log parser also assumed millisecond timestamps and PN self identity, which made replayed records land under 1970/self-chat in local testing.

## Local verification

Full local gate passed:

```text
pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check
```

Redacted live proof from a local store:

Before the fix, after sync:

```json
{"success":true,"data":{"calls":null},"error":null}
```

After the fix, `sync --once` imported the same-day completed call as a structured call-log row:

```json
{
  "chat_jid": "<peer>@s.whatsapp.net",
  "chat_name": "<redacted>",
  "sender_jid": "<self>@s.whatsapp.net",
  "sender_name": "<redacted>",
  "call_id": "0002...1BC",
  "event_type": "call_log",
  "direction": "outbound",
  "media": "audio",
  "outcome": "connected",
  "call_type": "regular",
  "duration_secs": 9,
  "timestamp": "2026-05-22T07:44:30Z",
  "participants": [
    {"jid": "<peer>@s.whatsapp.net", "outcome": "connected"}
  ]
}
```

This proves the missing completed-call case from #256: the imported row is no longer just an `offer`; it has the peer chat, real timestamp, duration, direction, media, and connected outcome.
