### PR TITLE
fix: persist quoted message metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Chats: store unread marker state and numeric `unread_count` separately; migrate existing stores away from sentinel unread values while preserving public chat JSON fields. (#255 - thanks @drelum and @dovocoder)
+- Messages: persist quoted message ID and quoted sender JID metadata from WhatsApp reply context. (#260)
 ### Security
 
 ### Fixed

--- a/cmd/wacli/messages_format.go
+++ b/cmd/wacli/messages_format.go
@@ -79,6 +79,12 @@ func writeMessageShow(dst io.Writer, m store.Message) error {
 	fmt.Fprintf(dst, "ID: %s\n", sanitize(m.MsgID))
 	fmt.Fprintf(dst, "Time: %s\n", m.Timestamp.Local().Format(time.RFC3339))
 	fmt.Fprintf(dst, "From: %s\n", sanitize(messageFromDetail(m)))
+	if m.QuotedMsgID != "" {
+		fmt.Fprintf(dst, "Quoted message: %s\n", sanitize(m.QuotedMsgID))
+	}
+	if m.QuotedSenderJID != "" {
+		fmt.Fprintf(dst, "Quoted sender: %s\n", sanitize(m.QuotedSenderJID))
+	}
 	if m.MediaType != "" {
 		fmt.Fprintf(dst, "Media: %s\n", sanitize(m.MediaType))
 	}

--- a/cmd/wacli/messages_test.go
+++ b/cmd/wacli/messages_test.go
@@ -171,19 +171,21 @@ func TestCallsListCommandHasExpectedFlags(t *testing.T) {
 
 func TestWriteMessageShowPrefersDisplayTextAndMediaDetails(t *testing.T) {
 	msg := store.Message{
-		ChatJID:      "chat@s.whatsapp.net",
-		SenderJID:    "sender@s.whatsapp.net",
-		SenderName:   "Alice",
-		MsgID:        "mid",
-		Timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-		Text:         "raw payload",
-		DisplayText:  "Reacted 👍 to hello",
-		MediaType:    "image",
-		MediaCaption: "caption",
-		Filename:     "pic.jpg",
-		MimeType:     "image/jpeg",
-		LocalPath:    "/tmp/pic.jpg",
-		DownloadedAt: time.Date(2024, 1, 1, 12, 1, 0, 0, time.UTC),
+		ChatJID:         "chat@s.whatsapp.net",
+		SenderJID:       "sender@s.whatsapp.net",
+		SenderName:      "Alice",
+		MsgID:           "mid",
+		Timestamp:       time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		Text:            "raw payload",
+		DisplayText:     "Reacted 👍 to hello",
+		QuotedMsgID:     "quoted",
+		QuotedSenderJID: "quoted-sender@s.whatsapp.net",
+		MediaType:       "image",
+		MediaCaption:    "caption",
+		Filename:        "pic.jpg",
+		MimeType:        "image/jpeg",
+		LocalPath:       "/tmp/pic.jpg",
+		DownloadedAt:    time.Date(2024, 1, 1, 12, 1, 0, 0, time.UTC),
 	}
 
 	var out bytes.Buffer
@@ -193,6 +195,8 @@ func TestWriteMessageShowPrefersDisplayTextAndMediaDetails(t *testing.T) {
 	got := out.String()
 	for _, want := range []string{
 		"From: Alice (sender@s.whatsapp.net)",
+		"Quoted message: quoted",
+		"Quoted sender: quoted-sender@s.whatsapp.net",
 		"Caption: caption",
 		"Filename: pic.jpg",
 		"MIME type: image/jpeg",

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -437,6 +437,8 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 		FromMe:          pm.FromMe,
 		Text:            pm.Text,
 		DisplayText:     displayText,
+		QuotedMsgID:     pm.ReplyToID,
+		QuotedSenderJID: pm.ReplyToSenderJID,
 		Buttons:         waButtonsToStore(pm.Buttons),
 		IsForwarded:     pm.IsForwarded,
 		ForwardingScore: pm.ForwardingScore,

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -1257,7 +1257,8 @@ func TestSyncStoresDisplayText(t *testing.T) {
 			ExtendedTextMessage: &waProto.ExtendedTextMessage{
 				Text: proto.String("reply text"),
 				ContextInfo: &waProto.ContextInfo{
-					StanzaID: proto.String("m-text"),
+					StanzaID:    proto.String("m-text"),
+					Participant: proto.String("123@s.whatsapp.net"),
 					QuotedMessage: &waProto.Message{
 						Conversation: proto.String("quoted text"),
 					},
@@ -1326,6 +1327,9 @@ func TestSyncStoresDisplayText(t *testing.T) {
 	}
 	if msg.DisplayText != "> quoted text\nreply text" {
 		t.Fatalf("unexpected reply display text: %q", msg.DisplayText)
+	}
+	if msg.QuotedMsgID != "m-text" || msg.QuotedSenderJID != "123@s.whatsapp.net" {
+		t.Fatalf("unexpected quoted metadata: id=%q sender=%q", msg.QuotedMsgID, msg.QuotedSenderJID)
 	}
 
 	msg, err = a.db.GetMessage(chat.String(), "m-react")

--- a/internal/store/lid_migration.go
+++ b/internal/store/lid_migration.go
@@ -17,6 +17,8 @@ func (d *DB) HistoricalLIDJIDs() ([]string, error) {
 		UNION
 		SELECT sender_jid FROM messages WHERE sender_jid GLOB '*@lid'
 		UNION
+		SELECT quoted_sender_jid FROM messages WHERE quoted_sender_jid GLOB '*@lid'
+		UNION
 		SELECT chat_jid FROM polls WHERE chat_jid GLOB '*@lid'
 		UNION
 		SELECT sender_jid FROM polls WHERE sender_jid GLOB '*@lid' AND chat_jid NOT GLOB '*@g.us'
@@ -164,6 +166,7 @@ func migrateLIDMessagesToPN(tx *sql.Tx, lidJID, pnJID string) error {
 	if _, err := tx.Exec(`
 		INSERT INTO messages(
 			chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, display_text,
+			quoted_msg_id, quoted_sender_jid,
 			is_forwarded, forwarding_score, reaction_to_id, reaction_emoji,
 			media_type, media_caption, filename, mime_type, direct_path,
 			media_key, file_sha256, file_enc_sha256, file_length, local_path, downloaded_at,
@@ -179,6 +182,8 @@ func migrateLIDMessagesToPN(tx *sql.Tx, lidJID, pnJID string) error {
 			from_me,
 			text,
 			display_text,
+			CASE WHEN revoked != 0 OR deleted_for_me != 0 THEN NULL ELSE quoted_msg_id END,
+			CASE WHEN revoked != 0 OR deleted_for_me != 0 THEN NULL WHEN quoted_sender_jid = ? THEN ? ELSE quoted_sender_jid END,
 			is_forwarded,
 			forwarding_score,
 			reaction_to_id,
@@ -209,6 +214,8 @@ func migrateLIDMessagesToPN(tx *sql.Tx, lidJID, pnJID string) error {
 			from_me = messages.from_me,
 			text = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN excluded.edited != 0 AND (messages.edited = 0 OR excluded.edited_ts > messages.edited_ts) THEN excluded.text WHEN messages.edited != 0 AND excluded.edited = 0 THEN messages.text ELSE COALESCE(NULLIF(messages.text, ''), excluded.text) END,
 			display_text = CASE WHEN messages.deleted_for_me != 0 OR excluded.deleted_for_me != 0 THEN ? WHEN messages.revoked != 0 OR excluded.revoked != 0 THEN ? WHEN excluded.edited != 0 AND (messages.edited = 0 OR excluded.edited_ts > messages.edited_ts) THEN excluded.display_text WHEN messages.edited != 0 AND excluded.edited = 0 THEN messages.display_text ELSE COALESCE(NULLIF(messages.display_text, ''), excluded.display_text) END,
+			quoted_msg_id = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE COALESCE(NULLIF(messages.quoted_msg_id, ''), excluded.quoted_msg_id) END,
+			quoted_sender_jid = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE COALESCE(NULLIF(messages.quoted_sender_jid, ''), excluded.quoted_sender_jid) END,
 			is_forwarded = CASE WHEN messages.is_forwarded != 0 THEN messages.is_forwarded ELSE excluded.is_forwarded END,
 			forwarding_score = max(messages.forwarding_score, excluded.forwarding_score),
 			reaction_to_id = COALESCE(NULLIF(messages.reaction_to_id, ''), excluded.reaction_to_id),
@@ -229,7 +236,7 @@ func migrateLIDMessagesToPN(tx *sql.Tx, lidJID, pnJID string) error {
 			edited = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN 0 WHEN messages.edited != 0 OR excluded.edited != 0 THEN 1 ELSE 0 END,
 			edited_ts = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN 0 ELSE max(COALESCE(messages.edited_ts, 0), COALESCE(excluded.edited_ts, 0)) END,
 			buttons = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE COALESCE(messages.buttons, excluded.buttons) END
-	`, pnJID, lidJID, pnJID, lidJID, DeletedForMeMessageDisplayText, DeletedMessageDisplayText); err != nil {
+	`, pnJID, lidJID, pnJID, lidJID, pnJID, lidJID, DeletedForMeMessageDisplayText, DeletedMessageDisplayText); err != nil {
 		return fmt.Errorf("merge lid messages into pn chat: %w", err)
 	}
 
@@ -242,6 +249,9 @@ func migrateLIDMessagesToPN(tx *sql.Tx, lidJID, pnJID string) error {
 func migrateLIDSenderToPN(tx *sql.Tx, lidJID, pnJID string) error {
 	if _, err := tx.Exec(`UPDATE messages SET sender_jid = ? WHERE sender_jid = ?`, pnJID, lidJID); err != nil {
 		return fmt.Errorf("rewrite lid message senders: %w", err)
+	}
+	if _, err := tx.Exec(`UPDATE messages SET quoted_sender_jid = ? WHERE quoted_sender_jid = ?`, pnJID, lidJID); err != nil {
+		return fmt.Errorf("rewrite lid quoted message senders: %w", err)
 	}
 	return nil
 }

--- a/internal/store/lid_migration_test.go
+++ b/internal/store/lid_migration_test.go
@@ -28,11 +28,13 @@ func TestHistoricalLIDJIDsFindsChatAndMessageColumns(t *testing.T) {
 		t.Fatalf("UpsertMessage lid chat: %v", err)
 	}
 	if err := db.UpsertMessage(UpsertMessageParams{
-		ChatJID:   group,
-		MsgID:     "group-sender",
-		SenderJID: lid,
-		Timestamp: base,
-		Text:      "group sender",
+		ChatJID:         group,
+		MsgID:           "group-sender",
+		SenderJID:       lid,
+		Timestamp:       base,
+		Text:            "group sender",
+		QuotedMsgID:     "quoted",
+		QuotedSenderJID: lid,
 	}); err != nil {
 		t.Fatalf("UpsertMessage group sender: %v", err)
 	}
@@ -109,22 +111,26 @@ func TestMigrateLIDToPNMergesChatsAndMessages(t *testing.T) {
 		t.Fatalf("UpsertMessage lid dupe: %v", err)
 	}
 	if err := db.UpsertMessage(UpsertMessageParams{
-		ChatJID:    lid,
-		ChatName:   "Alice LID",
-		MsgID:      "lid-only",
-		SenderJID:  lid,
-		SenderName: "Alice",
-		Timestamp:  base.Add(6 * time.Second),
-		Text:       "only on lid",
+		ChatJID:         lid,
+		ChatName:        "Alice LID",
+		MsgID:           "lid-only",
+		SenderJID:       lid,
+		SenderName:      "Alice",
+		Timestamp:       base.Add(6 * time.Second),
+		Text:            "only on lid",
+		QuotedMsgID:     "quoted-lid-only",
+		QuotedSenderJID: lid,
 	}); err != nil {
 		t.Fatalf("UpsertMessage lid only: %v", err)
 	}
 	if err := db.UpsertMessage(UpsertMessageParams{
-		ChatJID:   group,
-		MsgID:     "group",
-		SenderJID: lid,
-		Timestamp: base.Add(7 * time.Second),
-		Text:      "group message",
+		ChatJID:         group,
+		MsgID:           "group",
+		SenderJID:       lid,
+		Timestamp:       base.Add(7 * time.Second),
+		Text:            "group message",
+		QuotedMsgID:     "quoted-group",
+		QuotedSenderJID: lid,
 	}); err != nil {
 		t.Fatalf("UpsertMessage group: %v", err)
 	}
@@ -198,6 +204,9 @@ func TestMigrateLIDToPNMergesChatsAndMessages(t *testing.T) {
 	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM messages WHERE sender_jid = ?", lid); got != 0 {
 		t.Fatalf("lid sender rows = %d, want 0", got)
 	}
+	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM messages WHERE quoted_sender_jid = ?", lid); got != 0 {
+		t.Fatalf("lid quoted sender rows = %d, want 0", got)
+	}
 	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM polls WHERE chat_jid = ? OR (sender_jid = ? AND chat_jid NOT GLOB '*@g.us')", lid, lid); got != 0 {
 		t.Fatalf("lid poll rows = %d, want 0", got)
 	}
@@ -235,6 +244,13 @@ func TestMigrateLIDToPNMergesChatsAndMessages(t *testing.T) {
 	if !dupe.Timestamp.Equal(base.Add(5 * time.Second)) {
 		t.Fatalf("merged duplicate timestamp = %s, want %s", dupe.Timestamp, base.Add(5*time.Second))
 	}
+	lidOnly, err := db.GetMessage(pn, "lid-only")
+	if err != nil {
+		t.Fatalf("GetMessage lid-only: %v", err)
+	}
+	if lidOnly.QuotedMsgID != "quoted-lid-only" || lidOnly.QuotedSenderJID != pn {
+		t.Fatalf("lid-only quoted metadata = id %q sender %q", lidOnly.QuotedMsgID, lidOnly.QuotedSenderJID)
+	}
 
 	groupMsg, err := db.GetMessage(group, "group")
 	if err != nil {
@@ -242,6 +258,9 @@ func TestMigrateLIDToPNMergesChatsAndMessages(t *testing.T) {
 	}
 	if groupMsg.SenderJID != pn {
 		t.Fatalf("group sender = %q, want %q", groupMsg.SenderJID, pn)
+	}
+	if groupMsg.QuotedMsgID != "quoted-group" || groupMsg.QuotedSenderJID != pn {
+		t.Fatalf("group quoted metadata = id %q sender %q", groupMsg.QuotedMsgID, groupMsg.QuotedSenderJID)
 	}
 
 	poll, err := db.GetPoll(pn, "poll")
@@ -319,6 +338,46 @@ func TestMigrateLIDToPNPreservesButtons(t *testing.T) {
 		if got.Type != b.Type || got.DisplayText != b.DisplayText || got.ID != b.ID || got.URL != b.URL {
 			t.Fatalf("button[%d]: got %+v, want %+v", i, got, b)
 		}
+	}
+}
+
+func TestMigrateLIDToPNClearsQuotedMetadataOnDeletedMessages(t *testing.T) {
+	db := openTestDB(t)
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	pn := "15551234567@s.whatsapp.net"
+	lid := "999123456789@lid"
+	if err := db.UpsertChat(lid, "dm", "Alice", base); err != nil {
+		t.Fatalf("UpsertChat lid: %v", err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:         lid,
+		MsgID:           "deleted-reply",
+		SenderJID:       lid,
+		Timestamp:       base,
+		QuotedMsgID:     "quoted",
+		QuotedSenderJID: lid,
+		DeletedForMe:    true,
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+	if _, err := db.sql.Exec(`UPDATE messages SET quoted_msg_id = ?, quoted_sender_jid = ? WHERE chat_jid = ? AND msg_id = ?`, "quoted", lid, lid, "deleted-reply"); err != nil {
+		t.Fatalf("seed legacy quoted metadata: %v", err)
+	}
+
+	if err := db.MigrateLIDToPN(lid, pn); err != nil {
+		t.Fatalf("MigrateLIDToPN: %v", err)
+	}
+
+	msg, err := db.GetMessage(pn, "deleted-reply")
+	if err != nil {
+		t.Fatalf("GetMessage after migration: %v", err)
+	}
+	if !msg.DeletedForMe {
+		t.Fatalf("DeletedForMe = false")
+	}
+	if msg.QuotedMsgID != "" || msg.QuotedSenderJID != "" {
+		t.Fatalf("deleted quoted metadata = id %q sender %q", msg.QuotedMsgID, msg.QuotedSenderJID)
 	}
 }
 

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -20,6 +20,8 @@ type UpsertMessageParams struct {
 	FromMe          bool
 	Text            string
 	DisplayText     string
+	QuotedMsgID     string
+	QuotedSenderJID string
 	Buttons         []Button
 	IsForwarded     bool
 	ForwardingScore uint32
@@ -40,7 +42,7 @@ type UpsertMessageParams struct {
 }
 
 func messageSelectColumns(snippet string) string {
-	return fmt.Sprintf(`m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), %s`, snippetSQL(snippet))
+	return fmt.Sprintf(`m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), %s`, snippetSQL(snippet))
 }
 
 func snippetSQL(snippet string) string {
@@ -54,6 +56,8 @@ func (d *DB) UpsertMessage(p UpsertMessageParams) error {
 	if p.Revoked || p.DeletedForMe {
 		p.Text = ""
 		p.Buttons = nil
+		p.QuotedMsgID = ""
+		p.QuotedSenderJID = ""
 		if p.DeletedForMe {
 			p.DisplayText = DeletedForMeMessageDisplayText
 		} else {
@@ -89,6 +93,8 @@ func (d *DB) UpsertMessage(p UpsertMessageParams) error {
 		FromMe:          boolToInt64(p.FromMe),
 		Text:            nullString(p.Text),
 		DisplayText:     nullString(p.DisplayText),
+		QuotedMsgID:     nullString(p.QuotedMsgID),
+		QuotedSenderJid: nullString(p.QuotedSenderJID),
 		IsForwarded:     boolToInt64(p.IsForwarded),
 		ForwardingScore: int64(p.ForwardingScore),
 		ReactionToID:    nullString(p.ReactionToID),
@@ -398,7 +404,7 @@ func (d *DB) scanMessages(query string, args ...interface{}) ([]Message, error) 
 		var revoked int
 		var deletedForMe int
 		var buttonsJSON string
-		if err := rows.Scan(&m.rowID, &m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &m.SenderName, &ts, &fromMe, &m.Text, &m.DisplayText, &forwarded, &forwardingScore, &m.ReactionToID, &m.ReactionEmoji, &m.MediaType, &m.MediaCaption, &m.Filename, &m.MimeType, &m.DirectPath, &m.LocalPath, &downloadedAt, &starred, &starredAt, &revoked, &deletedForMe, &buttonsJSON, &m.Snippet); err != nil {
+		if err := rows.Scan(&m.rowID, &m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &m.SenderName, &ts, &fromMe, &m.Text, &m.DisplayText, &m.QuotedMsgID, &m.QuotedSenderJID, &forwarded, &forwardingScore, &m.ReactionToID, &m.ReactionEmoji, &m.MediaType, &m.MediaCaption, &m.Filename, &m.MimeType, &m.DirectPath, &m.LocalPath, &downloadedAt, &starred, &starredAt, &revoked, &deletedForMe, &buttonsJSON, &m.Snippet); err != nil {
 			return nil, err
 		}
 		m.Timestamp = fromUnix(ts)
@@ -421,37 +427,37 @@ func (d *DB) scanMessages(query string, args ...interface{}) ([]Message, error) 
 func messageFromGetRow(row storedb.GetMessageRow) Message {
 	return messageFromScalars(
 		row.Rowid, row.ChatJid, row.Name, row.MsgID, row.SenderJid, row.SenderName,
-		row.Ts, row.FromMe, row.Text, row.DisplayText, row.IsForwarded,
+		row.Ts, row.FromMe, row.Text, row.DisplayText, row.QuotedMsgID, row.QuotedSenderJid, row.IsForwarded,
 		row.ForwardingScore, row.ReactionToID, row.ReactionEmoji, row.MediaType,
 		row.MediaCaption, row.Filename, row.MimeType, row.DirectPath, row.LocalPath,
-		row.DownloadedAt, row.Column22, row.StarredAt, row.Revoked, row.DeletedForMe,
-		row.Buttons, row.Column27,
+		row.DownloadedAt, row.Column24, row.StarredAt, row.Revoked, row.DeletedForMe,
+		row.Buttons, row.Column29,
 	)
 }
 
 func messageFromBeforeRow(row storedb.MessageContextBeforeRow) Message {
 	return messageFromScalars(
 		row.Rowid, row.ChatJid, row.Name, row.MsgID, row.SenderJid, row.SenderName,
-		row.Ts, row.FromMe, row.Text, row.DisplayText, row.IsForwarded,
+		row.Ts, row.FromMe, row.Text, row.DisplayText, row.QuotedMsgID, row.QuotedSenderJid, row.IsForwarded,
 		row.ForwardingScore, row.ReactionToID, row.ReactionEmoji, row.MediaType,
 		row.MediaCaption, row.Filename, row.MimeType, row.DirectPath, row.LocalPath,
-		row.DownloadedAt, row.Column22, row.StarredAt, row.Revoked, row.DeletedForMe,
-		row.Buttons, row.Column27,
+		row.DownloadedAt, row.Column24, row.StarredAt, row.Revoked, row.DeletedForMe,
+		row.Buttons, row.Column29,
 	)
 }
 
 func messageFromAfterRow(row storedb.MessageContextAfterRow) Message {
 	return messageFromScalars(
 		row.Rowid, row.ChatJid, row.Name, row.MsgID, row.SenderJid, row.SenderName,
-		row.Ts, row.FromMe, row.Text, row.DisplayText, row.IsForwarded,
+		row.Ts, row.FromMe, row.Text, row.DisplayText, row.QuotedMsgID, row.QuotedSenderJid, row.IsForwarded,
 		row.ForwardingScore, row.ReactionToID, row.ReactionEmoji, row.MediaType,
 		row.MediaCaption, row.Filename, row.MimeType, row.DirectPath, row.LocalPath,
-		row.DownloadedAt, row.Column22, row.StarredAt, row.Revoked, row.DeletedForMe,
-		row.Buttons, row.Column27,
+		row.DownloadedAt, row.Column24, row.StarredAt, row.Revoked, row.DeletedForMe,
+		row.Buttons, row.Column29,
 	)
 }
 
-func messageFromScalars(rowID int64, chatJID, chatName, msgID, senderJID, senderName string, ts, fromMe int64, text, displayText string, forwarded, forwardingScore int64, reactionToID, reactionEmoji, mediaType, mediaCaption, filename, mimeType, directPath, localPath string, downloadedAt, starred, starredAt, revoked, deletedForMe int64, buttonsJSON, snippet string) Message {
+func messageFromScalars(rowID int64, chatJID, chatName, msgID, senderJID, senderName string, ts, fromMe int64, text, displayText, quotedMsgID, quotedSenderJID string, forwarded, forwardingScore int64, reactionToID, reactionEmoji, mediaType, mediaCaption, filename, mimeType, directPath, localPath string, downloadedAt, starred, starredAt, revoked, deletedForMe int64, buttonsJSON, snippet string) Message {
 	m := Message{
 		rowID:           rowID,
 		ChatJID:         chatJID,
@@ -463,6 +469,8 @@ func messageFromScalars(rowID int64, chatJID, chatName, msgID, senderJID, sender
 		FromMe:          fromMe != 0,
 		Text:            text,
 		DisplayText:     displayText,
+		QuotedMsgID:     quotedMsgID,
+		QuotedSenderJID: quotedSenderJID,
 		IsForwarded:     forwarded != 0,
 		ForwardingScore: uint32(forwardingScore),
 		ReactionToID:    reactionToID,

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -68,6 +68,78 @@ func TestMessageUpsertIdempotentAndContext(t *testing.T) {
 	}
 }
 
+func TestMessageQuotedMetadataRoundTrip(t *testing.T) {
+	db := openTestDB(t)
+
+	chat := "123@s.whatsapp.net"
+	if err := db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+
+	now := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:         chat,
+		MsgID:           "reply",
+		SenderJID:       chat,
+		Timestamp:       now,
+		Text:            "reply text",
+		QuotedMsgID:     "quoted",
+		QuotedSenderJID: "sender@s.whatsapp.net",
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	msg, err := db.GetMessage(chat, "reply")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if msg.QuotedMsgID != "quoted" || msg.QuotedSenderJID != "sender@s.whatsapp.net" {
+		t.Fatalf("quoted metadata = id %q sender %q", msg.QuotedMsgID, msg.QuotedSenderJID)
+	}
+
+	msgs, err := db.ListMessages(ListMessagesParams{ChatJID: chat, Limit: 1})
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].QuotedMsgID != "quoted" || msgs[0].QuotedSenderJID != "sender@s.whatsapp.net" {
+		t.Fatalf("listed quoted metadata = %+v", msgs)
+	}
+}
+
+func TestUpdateMessageTextPreservesQuotedMetadata(t *testing.T) {
+	db := openTestDB(t)
+
+	chat := "123@s.whatsapp.net"
+	if err := db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:         chat,
+		MsgID:           "reply",
+		SenderJID:       chat,
+		Timestamp:       time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+		Text:            "reply text",
+		QuotedMsgID:     "quoted",
+		QuotedSenderJID: "sender@s.whatsapp.net",
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+	if err := db.UpdateMessageText(chat, "reply", "edited reply"); err != nil {
+		t.Fatalf("UpdateMessageText: %v", err)
+	}
+
+	msg, err := db.GetMessage(chat, "reply")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if msg.Text != "edited reply" {
+		t.Fatalf("text = %q", msg.Text)
+	}
+	if msg.QuotedMsgID != "quoted" || msg.QuotedSenderJID != "sender@s.whatsapp.net" {
+		t.Fatalf("quoted metadata = id %q sender %q", msg.QuotedMsgID, msg.QuotedSenderJID)
+	}
+}
+
 func TestCallEventsUpsertAndList(t *testing.T) {
 	db := openTestDB(t)
 	chat := "123@s.whatsapp.net"

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -32,6 +32,7 @@ var schemaMigrations = []migration{
 	{version: 16, name: "messages edited columns", up: migrateMessagesEditedColumns},
 	{version: 17, name: "status messages", up: migrateStatusMessages},
 	{version: 18, name: "chat unread count column", up: migrateChatUnreadCountColumn},
+	{version: 19, name: "messages quoted columns", up: migrateMessagesQuotedColumns},
 }
 
 func (d *DB) ensureSchema() error {
@@ -101,6 +102,9 @@ func (d *DB) ensureCurrentSchema() error {
 	}
 	if err := migrateChatUnreadCountColumn(d); err != nil {
 		return fmt.Errorf("ensure current chat unread count column: %w", err)
+	}
+	if err := migrateMessagesQuotedColumns(d); err != nil {
+		return fmt.Errorf("ensure current messages quoted columns: %w", err)
 	}
 	return nil
 }
@@ -176,6 +180,23 @@ func addTextColumnIfMissing(d *DB, col, stmt string) error {
 	}
 	if _, err := d.sql.Exec(stmt); err != nil {
 		return fmt.Errorf("add messages.%s column: %w", col, err)
+	}
+	return nil
+}
+
+func migrateMessagesQuotedColumns(d *DB) error {
+	hasTable, err := d.tableExists("messages")
+	if err != nil {
+		return err
+	}
+	if !hasTable {
+		return nil
+	}
+	if err := addTextColumnIfMissing(d, "quoted_msg_id", `ALTER TABLE messages ADD COLUMN quoted_msg_id TEXT`); err != nil {
+		return err
+	}
+	if err := addTextColumnIfMissing(d, "quoted_sender_jid", `ALTER TABLE messages ADD COLUMN quoted_sender_jid TEXT`); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -66,6 +66,8 @@ CREATE TABLE IF NOT EXISTS messages (
     from_me INTEGER NOT NULL,
     text TEXT,
     display_text TEXT,
+    quoted_msg_id TEXT,
+    quoted_sender_jid TEXT,
     is_forwarded INTEGER NOT NULL DEFAULT 0,
     forwarding_score INTEGER NOT NULL DEFAULT 0,
     reaction_to_id TEXT,

--- a/internal/store/schema_test.go
+++ b/internal/store/schema_test.go
@@ -27,6 +27,8 @@ func TestOpenCreatesExpectedSchema(t *testing.T) {
 		"chat_name",
 		"sender_name",
 		"display_text",
+		"quoted_msg_id",
+		"quoted_sender_jid",
 		"is_forwarded",
 		"forwarding_score",
 		"reaction_to_id",

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -170,12 +170,14 @@ DELETE FROM groups WHERE left_at IS NOT NULL AND left_at < ?;
 -- name: UpsertMessage :exec
 INSERT INTO messages(
     chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, display_text,
+    quoted_msg_id, quoted_sender_jid,
     is_forwarded, forwarding_score, reaction_to_id, reaction_emoji,
     media_type, media_caption, filename, mime_type, direct_path,
     media_key, file_sha256, file_enc_sha256, file_length, revoked, deleted_for_me, edited, edited_ts, buttons
 ) VALUES (
     ?, ?, ?, ?, ?,
     ?, ?, ?, ?,
+    ?, ?,
     ?, ?, ?, ?,
     ?, ?, ?, ?, ?,
     ?, ?, ?, ?,
@@ -189,6 +191,8 @@ ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
     from_me=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.from_me ELSE excluded.from_me END,
     text=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.text ELSE excluded.text END,
     display_text=CASE WHEN excluded.deleted_for_me != 0 THEN excluded.display_text WHEN messages.deleted_for_me != 0 THEN messages.display_text WHEN excluded.revoked != 0 THEN excluded.display_text WHEN messages.revoked != 0 THEN messages.display_text WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.display_text WHEN excluded.display_text IS NOT NULL AND excluded.display_text != '' THEN excluded.display_text ELSE messages.display_text END,
+    quoted_msg_id=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.quoted_msg_id ELSE COALESCE(NULLIF(excluded.quoted_msg_id,''), messages.quoted_msg_id) END,
+    quoted_sender_jid=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.quoted_sender_jid ELSE COALESCE(NULLIF(excluded.quoted_sender_jid,''), messages.quoted_sender_jid) END,
     is_forwarded=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.is_forwarded ELSE excluded.is_forwarded END,
     forwarding_score=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.forwarding_score ELSE excluded.forwarding_score END,
     reaction_to_id=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.reaction_to_id ELSE COALESCE(NULLIF(excluded.reaction_to_id,''), messages.reaction_to_id) END,
@@ -216,6 +220,8 @@ SET revoked = 1,
     text = NULL,
     display_text = ?,
     buttons = NULL,
+    quoted_msg_id = NULL,
+    quoted_sender_jid = NULL,
     media_type = NULL,
     media_caption = NULL,
     filename = NULL,
@@ -237,6 +243,8 @@ SET deleted_for_me = 1,
     text = NULL,
     display_text = ?,
     buttons = NULL,
+    quoted_msg_id = NULL,
+    quoted_sender_jid = NULL,
     media_type = NULL,
     media_caption = NULL,
     filename = NULL,
@@ -257,7 +265,9 @@ UPDATE messages
 SET deleted_for_me = 1,
     text = NULL,
     display_text = ?,
-    buttons = NULL
+    buttons = NULL,
+    quoted_msg_id = NULL,
+    quoted_sender_jid = NULL
 WHERE chat_jid = ? AND msg_id = ?;
 
 -- name: UpdateMessageText :execrows
@@ -283,7 +293,7 @@ SET text = ?,
 WHERE chat_jid = ? AND msg_id = ?;
 
 -- name: GetMessage :one
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
@@ -307,7 +317,7 @@ ORDER BY m.ts DESC, m.rowid DESC
 LIMIT 1;
 
 -- name: MessageContextBefore :many
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
@@ -316,7 +326,7 @@ ORDER BY m.ts DESC, m.rowid DESC
 LIMIT ?;
 
 -- name: MessageContextAfter :many
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id

--- a/internal/store/storedb/models.go
+++ b/internal/store/storedb/models.go
@@ -92,6 +92,8 @@ type Message struct {
 	FromMe          int64
 	Text            sql.NullString
 	DisplayText     sql.NullString
+	QuotedMsgID     sql.NullString
+	QuotedSenderJid sql.NullString
 	IsForwarded     int64
 	ForwardingScore int64
 	ReactionToID    sql.NullString

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -431,7 +431,7 @@ func (q *Queries) GetMediaDownloadInfo(ctx context.Context, arg GetMediaDownload
 }
 
 const getMessage = `-- name: GetMessage :one
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
@@ -454,6 +454,8 @@ type GetMessageRow struct {
 	FromMe          int64
 	Text            string
 	DisplayText     string
+	QuotedMsgID     string
+	QuotedSenderJid string
 	IsForwarded     int64
 	ForwardingScore int64
 	ReactionToID    string
@@ -465,12 +467,12 @@ type GetMessageRow struct {
 	DirectPath      string
 	LocalPath       string
 	DownloadedAt    int64
-	Column22        int64
+	Column24        int64
 	StarredAt       int64
 	Revoked         int64
 	DeletedForMe    int64
 	Buttons         string
-	Column27        string
+	Column29        string
 }
 
 func (q *Queries) GetMessage(ctx context.Context, arg GetMessageParams) (GetMessageRow, error) {
@@ -487,6 +489,8 @@ func (q *Queries) GetMessage(ctx context.Context, arg GetMessageParams) (GetMess
 		&i.FromMe,
 		&i.Text,
 		&i.DisplayText,
+		&i.QuotedMsgID,
+		&i.QuotedSenderJid,
 		&i.IsForwarded,
 		&i.ForwardingScore,
 		&i.ReactionToID,
@@ -498,12 +502,12 @@ func (q *Queries) GetMessage(ctx context.Context, arg GetMessageParams) (GetMess
 		&i.DirectPath,
 		&i.LocalPath,
 		&i.DownloadedAt,
-		&i.Column22,
+		&i.Column24,
 		&i.StarredAt,
 		&i.Revoked,
 		&i.DeletedForMe,
 		&i.Buttons,
-		&i.Column27,
+		&i.Column29,
 	)
 	return i, err
 }
@@ -902,6 +906,8 @@ SET deleted_for_me = 1,
     text = NULL,
     display_text = ?,
     buttons = NULL,
+    quoted_msg_id = NULL,
+    quoted_sender_jid = NULL,
     media_type = NULL,
     media_caption = NULL,
     filename = NULL,
@@ -937,7 +943,9 @@ UPDATE messages
 SET deleted_for_me = 1,
     text = NULL,
     display_text = ?,
-    buttons = NULL
+    buttons = NULL,
+    quoted_msg_id = NULL,
+    quoted_sender_jid = NULL
 WHERE chat_jid = ? AND msg_id = ?
 `
 
@@ -961,6 +969,8 @@ SET revoked = 1,
     text = NULL,
     display_text = ?,
     buttons = NULL,
+    quoted_msg_id = NULL,
+    quoted_sender_jid = NULL,
     media_type = NULL,
     media_caption = NULL,
     filename = NULL,
@@ -992,7 +1002,7 @@ func (q *Queries) MarkMessageRevoked(ctx context.Context, arg MarkMessageRevoked
 }
 
 const messageContextAfter = `-- name: MessageContextAfter :many
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
@@ -1020,6 +1030,8 @@ type MessageContextAfterRow struct {
 	FromMe          int64
 	Text            string
 	DisplayText     string
+	QuotedMsgID     string
+	QuotedSenderJid string
 	IsForwarded     int64
 	ForwardingScore int64
 	ReactionToID    string
@@ -1031,12 +1043,12 @@ type MessageContextAfterRow struct {
 	DirectPath      string
 	LocalPath       string
 	DownloadedAt    int64
-	Column22        int64
+	Column24        int64
 	StarredAt       int64
 	Revoked         int64
 	DeletedForMe    int64
 	Buttons         string
-	Column27        string
+	Column29        string
 }
 
 func (q *Queries) MessageContextAfter(ctx context.Context, arg MessageContextAfterParams) ([]MessageContextAfterRow, error) {
@@ -1065,6 +1077,8 @@ func (q *Queries) MessageContextAfter(ctx context.Context, arg MessageContextAft
 			&i.FromMe,
 			&i.Text,
 			&i.DisplayText,
+			&i.QuotedMsgID,
+			&i.QuotedSenderJid,
 			&i.IsForwarded,
 			&i.ForwardingScore,
 			&i.ReactionToID,
@@ -1076,12 +1090,12 @@ func (q *Queries) MessageContextAfter(ctx context.Context, arg MessageContextAft
 			&i.DirectPath,
 			&i.LocalPath,
 			&i.DownloadedAt,
-			&i.Column22,
+			&i.Column24,
 			&i.StarredAt,
 			&i.Revoked,
 			&i.DeletedForMe,
 			&i.Buttons,
-			&i.Column27,
+			&i.Column29,
 		); err != nil {
 			return nil, err
 		}
@@ -1097,7 +1111,7 @@ func (q *Queries) MessageContextAfter(ctx context.Context, arg MessageContextAft
 }
 
 const messageContextBefore = `-- name: MessageContextBefore :many
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
@@ -1125,6 +1139,8 @@ type MessageContextBeforeRow struct {
 	FromMe          int64
 	Text            string
 	DisplayText     string
+	QuotedMsgID     string
+	QuotedSenderJid string
 	IsForwarded     int64
 	ForwardingScore int64
 	ReactionToID    string
@@ -1136,12 +1152,12 @@ type MessageContextBeforeRow struct {
 	DirectPath      string
 	LocalPath       string
 	DownloadedAt    int64
-	Column22        int64
+	Column24        int64
 	StarredAt       int64
 	Revoked         int64
 	DeletedForMe    int64
 	Buttons         string
-	Column27        string
+	Column29        string
 }
 
 func (q *Queries) MessageContextBefore(ctx context.Context, arg MessageContextBeforeParams) ([]MessageContextBeforeRow, error) {
@@ -1170,6 +1186,8 @@ func (q *Queries) MessageContextBefore(ctx context.Context, arg MessageContextBe
 			&i.FromMe,
 			&i.Text,
 			&i.DisplayText,
+			&i.QuotedMsgID,
+			&i.QuotedSenderJid,
 			&i.IsForwarded,
 			&i.ForwardingScore,
 			&i.ReactionToID,
@@ -1181,12 +1199,12 @@ func (q *Queries) MessageContextBefore(ctx context.Context, arg MessageContextBe
 			&i.DirectPath,
 			&i.LocalPath,
 			&i.DownloadedAt,
-			&i.Column22,
+			&i.Column24,
 			&i.StarredAt,
 			&i.Revoked,
 			&i.DeletedForMe,
 			&i.Buttons,
-			&i.Column27,
+			&i.Column29,
 		); err != nil {
 			return nil, err
 		}
@@ -1584,12 +1602,14 @@ func (q *Queries) UpsertGroupWithHierarchy(ctx context.Context, arg UpsertGroupW
 const upsertMessage = `-- name: UpsertMessage :exec
 INSERT INTO messages(
     chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, display_text,
+    quoted_msg_id, quoted_sender_jid,
     is_forwarded, forwarding_score, reaction_to_id, reaction_emoji,
     media_type, media_caption, filename, mime_type, direct_path,
     media_key, file_sha256, file_enc_sha256, file_length, revoked, deleted_for_me, edited, edited_ts, buttons
 ) VALUES (
     ?, ?, ?, ?, ?,
     ?, ?, ?, ?,
+    ?, ?,
     ?, ?, ?, ?,
     ?, ?, ?, ?, ?,
     ?, ?, ?, ?,
@@ -1603,6 +1623,8 @@ ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
     from_me=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.from_me ELSE excluded.from_me END,
     text=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.text ELSE excluded.text END,
     display_text=CASE WHEN excluded.deleted_for_me != 0 THEN excluded.display_text WHEN messages.deleted_for_me != 0 THEN messages.display_text WHEN excluded.revoked != 0 THEN excluded.display_text WHEN messages.revoked != 0 THEN messages.display_text WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.display_text WHEN excluded.display_text IS NOT NULL AND excluded.display_text != '' THEN excluded.display_text ELSE messages.display_text END,
+    quoted_msg_id=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.quoted_msg_id ELSE COALESCE(NULLIF(excluded.quoted_msg_id,''), messages.quoted_msg_id) END,
+    quoted_sender_jid=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.quoted_sender_jid ELSE COALESCE(NULLIF(excluded.quoted_sender_jid,''), messages.quoted_sender_jid) END,
     is_forwarded=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.is_forwarded ELSE excluded.is_forwarded END,
     forwarding_score=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.forwarding_score ELSE excluded.forwarding_score END,
     reaction_to_id=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.reaction_to_id ELSE COALESCE(NULLIF(excluded.reaction_to_id,''), messages.reaction_to_id) END,
@@ -1635,6 +1657,8 @@ type UpsertMessageParams struct {
 	FromMe          int64
 	Text            sql.NullString
 	DisplayText     sql.NullString
+	QuotedMsgID     sql.NullString
+	QuotedSenderJid sql.NullString
 	IsForwarded     int64
 	ForwardingScore int64
 	ReactionToID    sql.NullString
@@ -1666,6 +1690,8 @@ func (q *Queries) UpsertMessage(ctx context.Context, arg UpsertMessageParams) er
 		arg.FromMe,
 		arg.Text,
 		arg.DisplayText,
+		arg.QuotedMsgID,
+		arg.QuotedSenderJid,
 		arg.IsForwarded,
 		arg.ForwardingScore,
 		arg.ReactionToID,

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -78,6 +78,8 @@ type Message struct {
 	FromMe          bool
 	Text            string
 	DisplayText     string
+	QuotedMsgID     string   `json:"quoted_msg_id,omitempty"`
+	QuotedSenderJID string   `json:"quoted_sender_jid,omitempty"`
 	Buttons         []Button `json:",omitempty"`
 	IsForwarded     bool
 	ForwardingScore uint32

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -59,29 +59,30 @@ type PollAddOptionRef struct {
 }
 
 type ParsedMessage struct {
-	Chat            types.JID
-	ID              string
-	SenderJID       string
-	Timestamp       time.Time
-	FromMe          bool
-	Text            string
-	Buttons         []Button
-	Media           *Media
-	Poll            *Poll
-	PollVote        *PollVoteRef
-	PollAdd         *PollAddOptionRef
-	PushName        string
-	ReplyToID       string
-	ReplyToDisplay  string
-	ReactionToID    string
-	ReactionEmoji   string
-	IsForwarded     bool
-	ForwardingScore uint32
-	StarredKnown    bool
-	Starred         bool
-	Edited          bool
-	Revoked         bool
-	Call            *ParsedCallEvent
+	Chat             types.JID
+	ID               string
+	SenderJID        string
+	Timestamp        time.Time
+	FromMe           bool
+	Text             string
+	Buttons          []Button
+	Media            *Media
+	Poll             *Poll
+	PollVote         *PollVoteRef
+	PollAdd          *PollAddOptionRef
+	PushName         string
+	ReplyToID        string
+	ReplyToSenderJID string
+	ReplyToDisplay   string
+	ReactionToID     string
+	ReactionEmoji    string
+	IsForwarded      bool
+	ForwardingScore  uint32
+	StarredKnown     bool
+	Starred          bool
+	Edited           bool
+	Revoked          bool
+	Call             *ParsedCallEvent
 }
 
 func ParseLiveMessage(evt *events.Message) ParsedMessage {
@@ -164,6 +165,9 @@ func extractWAProto(m *waProto.Message, pm *ParsedMessage) {
 	if ctx := contextInfoForMessage(m); ctx != nil {
 		if id := strings.TrimSpace(ctx.GetStanzaID()); id != "" {
 			pm.ReplyToID = id
+		}
+		if sender := strings.TrimSpace(ctx.GetParticipant()); sender != "" {
+			pm.ReplyToSenderJID = sender
 		}
 		if quoted := ctx.GetQuotedMessage(); quoted != nil {
 			pm.ReplyToDisplay = strings.TrimSpace(displayTextForProto(quoted))

--- a/internal/wa/messages_test.go
+++ b/internal/wa/messages_test.go
@@ -295,7 +295,8 @@ func TestParseLiveMessageReply(t *testing.T) {
 			ExtendedTextMessage: &waProto.ExtendedTextMessage{
 				Text: proto.String("reply text"),
 				ContextInfo: &waProto.ContextInfo{
-					StanzaID: proto.String("orig"),
+					StanzaID:    proto.String("orig"),
+					Participant: proto.String("quoted-sender@s.whatsapp.net"),
 					QuotedMessage: &waProto.Message{
 						Conversation: proto.String("quoted"),
 					},
@@ -307,6 +308,9 @@ func TestParseLiveMessageReply(t *testing.T) {
 	pm := ParseLiveMessage(ev)
 	if pm.ReplyToID != "orig" {
 		t.Fatalf("expected ReplyToID to be orig, got %q", pm.ReplyToID)
+	}
+	if pm.ReplyToSenderJID != "quoted-sender@s.whatsapp.net" {
+		t.Fatalf("expected ReplyToSenderJID, got %q", pm.ReplyToSenderJID)
 	}
 	if pm.ReplyToDisplay != "quoted" {
 		t.Fatalf("expected ReplyToDisplay to be quoted, got %q", pm.ReplyToDisplay)


### PR DESCRIPTION
## Summary

- Persist WhatsApp reply context as quoted message ID and quoted sender JID on messages.
- Expose the fields through existing message JSON/store reads and show them in messages show output.
- Preserve or scrub the fields consistently across edits, revokes, deletes, and LID-to-PN migration.

## Tests

- go test ./internal/store ./internal/wa ./internal/app ./cmd/wacli
- pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check
- autoreview --mode local

Closes #260
