### PR TITLE
feat: add group admin commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Groups: add live admin commands for creating groups, setting descriptions, toggling announce-only and admin-only edits, and approving or rejecting join requests.
+
 ### Security
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Groups: add live admin commands for creating groups, setting descriptions, toggling announce-only and admin-only edits, and approving or rejecting join requests.
+- Groups: add live admin commands for creating groups, setting descriptions, toggling announce-only and admin-only edits, and approving or rejecting join requests. (#265 - thanks @dovocoder)
 
 ### Security
 

--- a/cmd/wacli/groups.go
+++ b/cmd/wacli/groups.go
@@ -7,11 +7,17 @@ func newGroupsCmd(flags *rootFlags) *cobra.Command {
 		Use:   "groups",
 		Short: "Group management",
 	}
+	cmd.AddCommand(newGroupsCreateCmd(flags))
 	cmd.AddCommand(newGroupsListCmd(flags))
 	cmd.AddCommand(newGroupsRefreshCmd(flags))
 	cmd.AddCommand(newGroupsInfoCmd(flags))
 	cmd.AddCommand(newGroupsRenameCmd(flags))
+	cmd.AddCommand(newGroupsTopicCmd(flags, "topic"))
+	cmd.AddCommand(newGroupsTopicCmd(flags, "description"))
+	cmd.AddCommand(newGroupsAnnounceOnlyCmd(flags))
+	cmd.AddCommand(newGroupsLockedCmd(flags))
 	cmd.AddCommand(newGroupsParticipantsCmd(flags))
+	cmd.AddCommand(newGroupsRequestsCmd(flags))
 	cmd.AddCommand(newGroupsInviteCmd(flags))
 	cmd.AddCommand(newGroupsJoinCmd(flags))
 	cmd.AddCommand(newGroupsLeaveCmd(flags))

--- a/cmd/wacli/groups_admin.go
+++ b/cmd/wacli/groups_admin.go
@@ -1,0 +1,364 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	appcore "github.com/openclaw/wacli/internal/app"
+	"github.com/openclaw/wacli/internal/out"
+	"github.com/openclaw/wacli/internal/wa"
+	"github.com/spf13/cobra"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func newGroupsCreateCmd(flags *rootFlags) *cobra.Command {
+	var name string
+	var users []string
+	var announceOnly bool
+	var locked bool
+	var joinApproval bool
+	var parent bool
+	var linkedParent string
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a group",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(name) == "" {
+				return fmt.Errorf("--name is required")
+			}
+			if parent && strings.TrimSpace(linkedParent) != "" {
+				return fmt.Errorf("--community and --linked-parent cannot be combined")
+			}
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+
+			participants, err := parseGroupUserJIDs(users)
+			if err != nil {
+				return err
+			}
+			var parentJID types.JID
+			if strings.TrimSpace(linkedParent) != "" {
+				parentJID, err = parseGroupJID(linkedParent)
+				if err != nil {
+					return fmt.Errorf("parse --linked-parent: %w", err)
+				}
+			}
+			info, err := a.WA().CreateGroup(ctx, wa.CreateGroupRequest{
+				Name:                   name,
+				Participants:           participants,
+				IsAnnounce:             announceOnly,
+				IsLocked:               locked,
+				IsJoinApprovalRequired: joinApproval,
+				IsParent:               parent,
+				LinkedParentJID:        parentJID,
+			})
+			if err != nil {
+				return err
+			}
+			if info != nil {
+				_ = persistGroupInfo(a.DB(), info)
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, info)
+			}
+			if info == nil {
+				fmt.Fprintln(os.Stdout, "OK")
+				return nil
+			}
+			fmt.Fprintf(os.Stdout, "JID: %s\nName: %s\n", info.JID.String(), sanitize(info.GroupName.Name))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&name, "name", "", "group name")
+	cmd.Flags().StringSliceVar(&users, "user", nil, "initial participant phone number (+E164 and formatting ok) or JID (repeatable)")
+	cmd.Flags().BoolVar(&announceOnly, "announce-only", false, "only admins can send messages")
+	cmd.Flags().BoolVar(&locked, "locked", false, "only admins can edit group info")
+	cmd.Flags().BoolVar(&joinApproval, "join-approval", false, "require admin approval for new join requests")
+	cmd.Flags().BoolVar(&parent, "community", false, "create a community parent group")
+	cmd.Flags().StringVar(&linkedParent, "linked-parent", "", "community parent group JID for a new subgroup")
+	return cmd
+}
+
+func newGroupsTopicCmd(flags *rootFlags, use string) *cobra.Command {
+	var jidStr string
+	var text string
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: "Set group topic/description",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(jidStr) == "" || !cmd.Flags().Changed("text") {
+				return fmt.Errorf("--jid and --text are required")
+			}
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+			gjid, err := parseGroupJID(jidStr)
+			if err != nil {
+				return err
+			}
+			if err := a.WA().SetGroupTopic(ctx, gjid, text); err != nil {
+				return err
+			}
+			if info, err := a.WA().GetGroupInfo(ctx, gjid); err == nil && info != nil {
+				_ = persistGroupInfo(a.DB(), info)
+			}
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{"jid": gjid.String(), "topic": text})
+			}
+			fmt.Fprintln(os.Stdout, "OK")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&jidStr, "jid", "", "group JID (…@g.us)")
+	cmd.Flags().StringVar(&text, "text", "", "new topic/description text (empty string clears it)")
+	return cmd
+}
+
+func newGroupsAnnounceOnlyCmd(flags *rootFlags) *cobra.Command {
+	return newGroupsToggleCmd(flags, "announce-only", "Set whether only admins can send messages", func(ctx context.Context, client appcore.WAClient, jid types.JID, enabled bool) error {
+		return client.SetGroupAnnounce(ctx, jid, enabled)
+	}, "announce_only")
+}
+
+func newGroupsLockedCmd(flags *rootFlags) *cobra.Command {
+	return newGroupsToggleCmd(flags, "locked", "Set whether only admins can edit group info", func(ctx context.Context, client appcore.WAClient, jid types.JID, enabled bool) error {
+		return client.SetGroupLocked(ctx, jid, enabled)
+	}, "locked")
+}
+
+func newGroupsToggleCmd(flags *rootFlags, use, short string, apply func(context.Context, appcore.WAClient, types.JID, bool) error, jsonKey string) *cobra.Command {
+	var jidStr string
+	var on bool
+	var off bool
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(jidStr) == "" {
+				return fmt.Errorf("--jid is required")
+			}
+			enabled, err := parseOnOffFlags(cmd)
+			if err != nil {
+				return err
+			}
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+			gjid, err := parseGroupJID(jidStr)
+			if err != nil {
+				return err
+			}
+			if err := apply(ctx, a.WA(), gjid, enabled); err != nil {
+				return err
+			}
+			if info, err := a.WA().GetGroupInfo(ctx, gjid); err == nil && info != nil {
+				_ = persistGroupInfo(a.DB(), info)
+			}
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{"jid": gjid.String(), jsonKey: enabled})
+			}
+			fmt.Fprintln(os.Stdout, "OK")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&jidStr, "jid", "", "group JID (…@g.us)")
+	cmd.Flags().BoolVar(&on, "on", false, "enable setting")
+	cmd.Flags().BoolVar(&off, "off", false, "disable setting")
+	return cmd
+}
+
+func newGroupsRequestsCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "requests",
+		Short: "Manage group join requests",
+	}
+	cmd.AddCommand(newGroupsRequestsListCmd(flags))
+	cmd.AddCommand(newGroupsRequestsActionCmd(flags, "approve"))
+	cmd.AddCommand(newGroupsRequestsActionCmd(flags, "reject"))
+	return cmd
+}
+
+func newGroupsRequestsListCmd(flags *rootFlags) *cobra.Command {
+	var jidStr string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List pending group join requests",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(jidStr) == "" {
+				return fmt.Errorf("--jid is required")
+			}
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+			gjid, err := parseGroupJID(jidStr)
+			if err != nil {
+				return err
+			}
+			requests, err := a.WA().GetGroupRequestParticipants(ctx, gjid)
+			if err != nil {
+				return err
+			}
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, requests)
+			}
+			for _, req := range requests {
+				fmt.Fprintf(os.Stdout, "%s\t%s\n", req.JID.String(), req.RequestedAt.Local().Format("2006-01-02 15:04:05"))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&jidStr, "jid", "", "group JID (…@g.us)")
+	return cmd
+}
+
+func newGroupsRequestsActionCmd(flags *rootFlags, action string) *cobra.Command {
+	var jidStr string
+	var users []string
+	cmd := &cobra.Command{
+		Use:   action,
+		Short: action + " group join requests",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(jidStr) == "" || len(users) == 0 {
+				return fmt.Errorf("--jid and at least one --user are required")
+			}
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+			gjid, err := parseGroupJID(jidStr)
+			if err != nil {
+				return err
+			}
+			jids, err := parseGroupUserJIDs(users)
+			if err != nil {
+				return err
+			}
+			updated, err := a.WA().UpdateGroupRequestParticipants(ctx, gjid, jids, wa.GroupParticipantRequestAction(action))
+			if err != nil {
+				return err
+			}
+			if info, err := a.WA().GetGroupInfo(ctx, gjid); err == nil && info != nil {
+				_ = persistGroupInfo(a.DB(), info)
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, updated)
+			}
+			fmt.Fprintln(os.Stdout, "OK")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&jidStr, "jid", "", "group JID (…@g.us)")
+	cmd.Flags().StringSliceVar(&users, "user", nil, "requesting user phone number (+E164 and formatting ok) or JID (repeatable)")
+	return cmd
+}
+
+func parseOnOffFlags(cmd *cobra.Command) (bool, error) {
+	onChanged := cmd.Flags().Changed("on")
+	offChanged := cmd.Flags().Changed("off")
+	if onChanged == offChanged {
+		return false, fmt.Errorf("exactly one of --on or --off is required")
+	}
+	if onChanged {
+		return true, nil
+	}
+	return false, nil
+}
+
+func parseGroupJID(raw string) (types.JID, error) {
+	jid, err := types.ParseJID(strings.TrimSpace(raw))
+	if err != nil {
+		return types.JID{}, err
+	}
+	if jid.Server != types.GroupServer {
+		return types.JID{}, fmt.Errorf("expected group JID ending in @g.us, got %s", jid.String())
+	}
+	return jid, nil
+}
+
+func parseGroupUserJIDs(users []string) ([]types.JID, error) {
+	jids := make([]types.JID, 0, len(users))
+	for _, user := range users {
+		jid, err := wa.ParseUserOrJID(user)
+		if err != nil {
+			return nil, err
+		}
+		jids = append(jids, jid)
+	}
+	return jids, nil
+}

--- a/cmd/wacli/groups_admin.go
+++ b/cmd/wacli/groups_admin.go
@@ -171,7 +171,7 @@ func newGroupsToggleCmd(flags *rootFlags, use, short string, apply func(context.
 			if strings.TrimSpace(jidStr) == "" {
 				return fmt.Errorf("--jid is required")
 			}
-			enabled, err := parseOnOffFlags(cmd)
+			enabled, err := parseOnOffFlags(cmd, on, off)
 			if err != nil {
 				return err
 			}
@@ -328,14 +328,20 @@ func newGroupsRequestsActionCmd(flags *rootFlags, action string) *cobra.Command 
 	return cmd
 }
 
-func parseOnOffFlags(cmd *cobra.Command) (bool, error) {
+func parseOnOffFlags(cmd *cobra.Command, on, off bool) (bool, error) {
 	onChanged := cmd.Flags().Changed("on")
 	offChanged := cmd.Flags().Changed("off")
 	if onChanged == offChanged {
 		return false, fmt.Errorf("exactly one of --on or --off is required")
 	}
 	if onChanged {
+		if !on {
+			return false, fmt.Errorf("--on=false does not select a mode; use --off to disable")
+		}
 		return true, nil
+	}
+	if !off {
+		return false, fmt.Errorf("--off=false does not select a mode; use --on to enable")
 	}
 	return false, nil
 }

--- a/cmd/wacli/groups_admin_test.go
+++ b/cmd/wacli/groups_admin_test.go
@@ -44,7 +44,7 @@ func TestParseGroupUserJIDsAcceptsPhonesAndJIDs(t *testing.T) {
 
 func TestParseOnOffFlagsRequiresExactlyOneMode(t *testing.T) {
 	cmd := toggleTestCmd()
-	if _, err := parseOnOffFlags(cmd); err == nil {
+	if _, err := parseOnOffFlags(cmd, false, false); err == nil {
 		t.Fatal("expected missing toggle error")
 	}
 
@@ -55,7 +55,7 @@ func TestParseOnOffFlagsRequiresExactlyOneMode(t *testing.T) {
 	if err := cmd.Flags().Set("off", "true"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := parseOnOffFlags(cmd); err == nil {
+	if _, err := parseOnOffFlags(cmd, true, true); err == nil {
 		t.Fatal("expected conflicting toggle error")
 	}
 
@@ -63,7 +63,7 @@ func TestParseOnOffFlagsRequiresExactlyOneMode(t *testing.T) {
 	if err := cmd.Flags().Set("on", "true"); err != nil {
 		t.Fatal(err)
 	}
-	got, err := parseOnOffFlags(cmd)
+	got, err := parseOnOffFlags(cmd, true, false)
 	if err != nil || !got {
 		t.Fatalf("--on = %v, %v; want true, nil", got, err)
 	}
@@ -72,9 +72,27 @@ func TestParseOnOffFlagsRequiresExactlyOneMode(t *testing.T) {
 	if err := cmd.Flags().Set("off", "true"); err != nil {
 		t.Fatal(err)
 	}
-	got, err = parseOnOffFlags(cmd)
+	got, err = parseOnOffFlags(cmd, false, true)
 	if err != nil || got {
 		t.Fatalf("--off = %v, %v; want false, nil", got, err)
+	}
+}
+
+func TestParseOnOffFlagsRejectsExplicitFalseModes(t *testing.T) {
+	cmd := toggleTestCmd()
+	if err := cmd.Flags().Set("on", "false"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseOnOffFlags(cmd, false, false); err == nil || !strings.Contains(err.Error(), "--on=false") {
+		t.Fatalf("--on=false error = %v, want explicit false rejection", err)
+	}
+
+	cmd = toggleTestCmd()
+	if err := cmd.Flags().Set("off", "false"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseOnOffFlags(cmd, false, false); err == nil || !strings.Contains(err.Error(), "--off=false") {
+		t.Fatalf("--off=false error = %v, want explicit false rejection", err)
 	}
 }
 

--- a/cmd/wacli/groups_admin_test.go
+++ b/cmd/wacli/groups_admin_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestGroupsAdminCommandsRegistered(t *testing.T) {
+	cmd := newGroupsCmd(&rootFlags{})
+	for _, name := range []string{"create", "topic", "description", "announce-only", "locked", "requests"} {
+		if got, _, err := cmd.Find([]string{name}); err != nil || got == nil || got.Name() != name {
+			t.Fatalf("groups command %q not registered: got=%v err=%v", name, got, err)
+		}
+	}
+}
+
+func TestParseGroupJIDRejectsNonGroup(t *testing.T) {
+	_, err := parseGroupJID("123@s.whatsapp.net")
+	if err == nil || !strings.Contains(err.Error(), "@g.us") {
+		t.Fatalf("parseGroupJID error = %v, want group JID rejection", err)
+	}
+
+	jid, err := parseGroupJID("123@g.us")
+	if err != nil {
+		t.Fatalf("parseGroupJID: %v", err)
+	}
+	if jid.Server != types.GroupServer {
+		t.Fatalf("server = %q, want %q", jid.Server, types.GroupServer)
+	}
+}
+
+func TestParseGroupUserJIDsAcceptsPhonesAndJIDs(t *testing.T) {
+	jids, err := parseGroupUserJIDs([]string{"+1 (234) 567-8900", "111@s.whatsapp.net"})
+	if err != nil {
+		t.Fatalf("parseGroupUserJIDs: %v", err)
+	}
+	if len(jids) != 2 || jids[0].User != "12345678900" || jids[1].String() != "111@s.whatsapp.net" {
+		t.Fatalf("unexpected JIDs: %+v", jids)
+	}
+}
+
+func TestParseOnOffFlagsRequiresExactlyOneMode(t *testing.T) {
+	cmd := toggleTestCmd()
+	if _, err := parseOnOffFlags(cmd); err == nil {
+		t.Fatal("expected missing toggle error")
+	}
+
+	cmd = toggleTestCmd()
+	if err := cmd.Flags().Set("on", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("off", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseOnOffFlags(cmd); err == nil {
+		t.Fatal("expected conflicting toggle error")
+	}
+
+	cmd = toggleTestCmd()
+	if err := cmd.Flags().Set("on", "true"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := parseOnOffFlags(cmd)
+	if err != nil || !got {
+		t.Fatalf("--on = %v, %v; want true, nil", got, err)
+	}
+
+	cmd = toggleTestCmd()
+	if err := cmd.Flags().Set("off", "true"); err != nil {
+		t.Fatal(err)
+	}
+	got, err = parseOnOffFlags(cmd)
+	if err != nil || got {
+		t.Fatalf("--off = %v, %v; want false, nil", got, err)
+	}
+}
+
+func toggleTestCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("on", false, "")
+	cmd.Flags().Bool("off", false, "")
+	return cmd
+}

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -9,13 +9,21 @@ Read when: listing, refreshing, inspecting, renaming, joining, leaving, inviting
 ```bash
 wacli groups list [--query TEXT] [--limit N]
 wacli groups refresh
+wacli groups create --name NAME [--user PHONE_OR_JID ...] [--announce-only] [--locked] [--join-approval] [--community|--linked-parent GROUP_JID]
 wacli groups info --jid GROUP_JID
 wacli groups rename --jid GROUP_JID --name NAME
+wacli groups topic --jid GROUP_JID --text TEXT
+wacli groups description --jid GROUP_JID --text TEXT
+wacli groups announce-only --jid GROUP_JID (--on|--off)
+wacli groups locked --jid GROUP_JID (--on|--off)
 wacli groups leave --jid GROUP_JID
 wacli groups participants add --jid GROUP_JID --user PHONE_OR_JID [--user ...]
 wacli groups participants remove --jid GROUP_JID --user PHONE_OR_JID [--user ...]
 wacli groups participants promote --jid GROUP_JID --user PHONE_OR_JID [--user ...]
 wacli groups participants demote --jid GROUP_JID --user PHONE_OR_JID [--user ...]
+wacli groups requests list --jid GROUP_JID
+wacli groups requests approve --jid GROUP_JID --user PHONE_OR_JID [--user ...]
+wacli groups requests reject --jid GROUP_JID --user PHONE_OR_JID [--user ...]
 wacli groups invite link get --jid GROUP_JID
 wacli groups invite link revoke --jid GROUP_JID
 wacli groups join --code INVITE_CODE
@@ -29,6 +37,11 @@ wacli groups prune [--days N] [--left-only=false|--include-active] [--dry-run] [
 - `list --json` includes `IsParent` for communities and `LinkedParentJID` for subgroups.
 - `refresh` fetches joined groups live and updates local rows, including WhatsApp Community hierarchy metadata exposed by whatsmeow.
 - `info` fetches one group live and persists it, including whether the chat is a Community parent or linked subgroup.
+- `create` returns the new live group info and persists it locally. Use `--community` to create a community parent, or `--linked-parent` to create a subgroup inside an existing community.
+- `topic` and `description` both set the WhatsApp group description. Passing `--text ""` clears it.
+- `announce-only --on` makes the group admin-send-only; `--off` restores participant sends.
+- `locked --on` makes group info editable only by admins; `--off` allows member edits again.
+- `requests` lists, approves, or rejects pending join requests for groups with join approval enabled.
 - `leave` marks the group left locally after WhatsApp confirms.
 - `prune` only deletes local group/chat/message rows from `wacli.db`. It does not leave WhatsApp groups or delete anything from WhatsApp servers.
 - `prune` defaults to groups marked left locally. `--days N` limits left-group pruning to groups left more than `N` days ago.
@@ -42,9 +55,13 @@ wacli groups prune [--days N] [--left-only=false|--include-active] [--dry-run] [
 ```bash
 wacli groups list --query family
 wacli groups refresh
+wacli groups create --name "Project launch" --user "+1 (234) 567-8900" --announce-only
 wacli groups info --jid 123456789@g.us
 wacli groups rename --jid 123456789@g.us --name "New name"
+wacli groups topic --jid 123456789@g.us --text "Launch planning"
+wacli groups announce-only --jid 123456789@g.us --on
 wacli groups participants add --jid 123456789@g.us --user "+1 (234) 567-8900"
+wacli groups requests approve --jid 123456789@g.us --user "+1 (234) 567-8900"
 wacli groups invite link get --jid 123456789@g.us
 wacli groups join --code AbCdEfGhIjK
 wacli groups prune --dry-run

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -41,8 +41,14 @@ type WAClient interface {
 
 	GetJoinedGroups(ctx context.Context) ([]*types.GroupInfo, error)
 	GetGroupInfo(ctx context.Context, jid types.JID) (*types.GroupInfo, error)
+	CreateGroup(ctx context.Context, req wa.CreateGroupRequest) (*types.GroupInfo, error)
 	SetGroupName(ctx context.Context, jid types.JID, name string) error
+	SetGroupTopic(ctx context.Context, jid types.JID, topic string) error
+	SetGroupAnnounce(ctx context.Context, jid types.JID, announce bool) error
+	SetGroupLocked(ctx context.Context, jid types.JID, locked bool) error
 	UpdateGroupParticipants(ctx context.Context, group types.JID, users []types.JID, action wa.GroupParticipantAction) ([]types.GroupParticipant, error)
+	GetGroupRequestParticipants(ctx context.Context, group types.JID) ([]types.GroupParticipantRequest, error)
+	UpdateGroupRequestParticipants(ctx context.Context, group types.JID, users []types.JID, action wa.GroupParticipantRequestAction) ([]types.GroupParticipant, error)
 	GetGroupInviteLink(ctx context.Context, group types.JID, reset bool) (string, error)
 	JoinGroupWithLink(ctx context.Context, code string) (types.JID, error)
 	LeaveGroup(ctx context.Context, group types.JID) error

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -298,6 +298,28 @@ func (f *fakeWA) GetGroupInfo(ctx context.Context, jid types.JID) (*types.GroupI
 	return f.groups[jid], nil
 }
 
+func (f *fakeWA) CreateGroup(ctx context.Context, req wa.CreateGroupRequest) (*types.GroupInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	jid := types.NewJID(fmt.Sprintf("group-%d", len(f.groups)+1), types.GroupServer)
+	g := &types.GroupInfo{
+		JID:           jid,
+		GroupName:     types.GroupName{Name: req.Name},
+		GroupAnnounce: types.GroupAnnounce{IsAnnounce: req.IsAnnounce},
+		GroupLocked:   types.GroupLocked{IsLocked: req.IsLocked},
+		GroupMembershipApprovalMode: types.GroupMembershipApprovalMode{
+			IsJoinApprovalRequired: req.IsJoinApprovalRequired,
+		},
+		GroupParent:       types.GroupParent{IsParent: req.IsParent},
+		GroupLinkedParent: types.GroupLinkedParent{LinkedParentJID: req.LinkedParentJID},
+	}
+	for _, p := range req.Participants {
+		g.Participants = append(g.Participants, types.GroupParticipant{JID: p})
+	}
+	f.groups[jid] = g
+	return g, nil
+}
+
 func (f *fakeWA) SetGroupName(ctx context.Context, jid types.JID, name string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -307,6 +329,42 @@ func (f *fakeWA) SetGroupName(ctx context.Context, jid types.JID, name string) e
 		f.groups[jid] = g
 	}
 	g.GroupName.Name = name
+	return nil
+}
+
+func (f *fakeWA) SetGroupTopic(ctx context.Context, jid types.JID, topic string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	g := f.groups[jid]
+	if g == nil {
+		g = &types.GroupInfo{JID: jid}
+		f.groups[jid] = g
+	}
+	g.GroupTopic.Topic = topic
+	return nil
+}
+
+func (f *fakeWA) SetGroupAnnounce(ctx context.Context, jid types.JID, announce bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	g := f.groups[jid]
+	if g == nil {
+		g = &types.GroupInfo{JID: jid}
+		f.groups[jid] = g
+	}
+	g.GroupAnnounce.IsAnnounce = announce
+	return nil
+}
+
+func (f *fakeWA) SetGroupLocked(ctx context.Context, jid types.JID, locked bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	g := f.groups[jid]
+	if g == nil {
+		g = &types.GroupInfo{JID: jid}
+		f.groups[jid] = g
+	}
+	g.GroupLocked.IsLocked = locked
 	return nil
 }
 
@@ -339,6 +397,18 @@ func (f *fakeWA) UpdateGroupParticipants(ctx context.Context, group types.JID, u
 		// promote/demote ignored for tests
 	}
 	return g.Participants, nil
+}
+
+func (f *fakeWA) GetGroupRequestParticipants(ctx context.Context, group types.JID) ([]types.GroupParticipantRequest, error) {
+	return nil, nil
+}
+
+func (f *fakeWA) UpdateGroupRequestParticipants(ctx context.Context, group types.JID, users []types.JID, action wa.GroupParticipantRequestAction) ([]types.GroupParticipant, error) {
+	out := make([]types.GroupParticipant, 0, len(users))
+	for _, u := range users {
+		out = append(out, types.GroupParticipant{JID: u})
+	}
+	return out, nil
 }
 
 func (f *fakeWA) GetGroupInviteLink(ctx context.Context, group types.JID, reset bool) (string, error) {

--- a/internal/wa/groups.go
+++ b/internal/wa/groups.go
@@ -8,6 +8,44 @@ import (
 	"go.mau.fi/whatsmeow/types"
 )
 
+type CreateGroupRequest struct {
+	Name                   string
+	Participants           []types.JID
+	IsAnnounce             bool
+	IsLocked               bool
+	IsJoinApprovalRequired bool
+	IsParent               bool
+	LinkedParentJID        types.JID
+}
+
+func (c *Client) CreateGroup(ctx context.Context, req CreateGroupRequest) (*types.GroupInfo, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return nil, fmt.Errorf("not connected")
+	}
+	return cli.CreateGroup(ctx, whatsmeow.ReqCreateGroup{
+		Name:         req.Name,
+		Participants: req.Participants,
+		GroupAnnounce: types.GroupAnnounce{
+			IsAnnounce: req.IsAnnounce,
+		},
+		GroupLocked: types.GroupLocked{
+			IsLocked: req.IsLocked,
+		},
+		GroupMembershipApprovalMode: types.GroupMembershipApprovalMode{
+			IsJoinApprovalRequired: req.IsJoinApprovalRequired,
+		},
+		GroupParent: types.GroupParent{
+			IsParent: req.IsParent,
+		},
+		GroupLinkedParent: types.GroupLinkedParent{
+			LinkedParentJID: req.LinkedParentJID,
+		},
+	})
+}
+
 func (c *Client) GetJoinedGroups(ctx context.Context) ([]*types.GroupInfo, error) {
 	c.mu.Lock()
 	cli := c.client
@@ -26,6 +64,36 @@ func (c *Client) SetGroupName(ctx context.Context, jid types.JID, name string) e
 		return fmt.Errorf("not connected")
 	}
 	return cli.SetGroupName(ctx, jid, name)
+}
+
+func (c *Client) SetGroupTopic(ctx context.Context, jid types.JID, topic string) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	return cli.SetGroupTopic(ctx, jid, "", "", topic)
+}
+
+func (c *Client) SetGroupAnnounce(ctx context.Context, jid types.JID, announce bool) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	return cli.SetGroupAnnounce(ctx, jid, announce)
+}
+
+func (c *Client) SetGroupLocked(ctx context.Context, jid types.JID, locked bool) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	return cli.SetGroupLocked(ctx, jid, locked)
 }
 
 type GroupParticipantAction string
@@ -60,6 +128,44 @@ func (c *Client) UpdateGroupParticipants(ctx context.Context, group types.JID, u
 	}
 
 	return cli.UpdateGroupParticipants(ctx, group, users, a)
+}
+
+type GroupParticipantRequestAction string
+
+const (
+	GroupParticipantRequestApprove GroupParticipantRequestAction = "approve"
+	GroupParticipantRequestReject  GroupParticipantRequestAction = "reject"
+)
+
+func (c *Client) GetGroupRequestParticipants(ctx context.Context, group types.JID) ([]types.GroupParticipantRequest, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return nil, fmt.Errorf("not connected")
+	}
+	return cli.GetGroupRequestParticipants(ctx, group)
+}
+
+func (c *Client) UpdateGroupRequestParticipants(ctx context.Context, group types.JID, users []types.JID, action GroupParticipantRequestAction) ([]types.GroupParticipant, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return nil, fmt.Errorf("not connected")
+	}
+
+	var a whatsmeow.ParticipantRequestChange
+	switch action {
+	case GroupParticipantRequestApprove:
+		a = whatsmeow.ParticipantChangeApprove
+	case GroupParticipantRequestReject:
+		a = whatsmeow.ParticipantChangeReject
+	default:
+		return nil, fmt.Errorf("unknown participant request action: %s", action)
+	}
+
+	return cli.UpdateGroupRequestParticipants(ctx, group, users, a)
 }
 
 func (c *Client) GetGroupInviteLink(ctx context.Context, group types.JID, reset bool) (string, error) {


### PR DESCRIPTION
## Summary

- Add live group administration commands: create, topic/description, announce-only toggle, locked/admin-only-edits toggle, and join request list/approve/reject.
- Add whatsmeow wrapper methods and app interface coverage for the new group mutations.
- Document the new command surface and update the changelog.

## Live Test

Performed against a real linked WhatsApp session using contacts named `Assistent` and `Automator`.

- Created live test group `120363428272512126@g.us` named `wacli live test 2026-05-23` with Assistent and Automator invited.
- Verified `groups topic` set the group description live.
- Verified `groups description` alias updated the group description live.
- Verified `groups announce-only --on` via `groups info`: `IsAnnounce=true`.
- Verified `groups locked --on` via `groups info`: `IsLocked=true`.
- Restored `announce-only --off` and `locked --off`; final `groups info` showed `IsAnnounce=false` and `IsLocked=false`.
- Cleared the description; final `Topic` was empty.
- Verified `groups requests list` hit the live endpoint successfully and returned an empty list because there were no pending join requests.
- Cleanup: removed Assistent and Automator from the throwaway group; final participant list contained only the owner account.

## Automated Checks

- `pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`
