### PR TITLE
fix: reconnect after WhatsApp stream replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Sync: reconnect after WhatsApp replaces the linked-device stream instead of leaving `sync --follow` offline. (#266 - thanks @ngutman)
+
 ## 0.11.0 - 2026-05-22
 
 ### Added

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -200,6 +200,12 @@ func (f *fakeWA) RemoveEventHandler(id uint32) {
 }
 
 func (f *fakeWA) ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay time.Duration) error {
+	f.mu.Lock()
+	connected := f.connected
+	f.mu.Unlock()
+	if connected {
+		return nil
+	}
 	return f.Connect(ctx, wa.ConnectOptions{AllowQR: false})
 }
 

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -93,6 +93,9 @@ func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, message
 			}
 		case *events.StreamReplaced:
 			a.emitOrPrint("stream_replaced", nil, "\nStream replaced.\n")
+			// whatsmeow emits StreamReplaced before onDisconnect necessarily
+			// clears the socket, so force-close before reconnecting.
+			a.wa.Close()
 			select {
 			case disconnected <- struct{}{}:
 			default:

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -91,6 +91,12 @@ func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, message
 			case disconnected <- struct{}{}:
 			default:
 			}
+		case *events.StreamReplaced:
+			a.emitOrPrint("stream_replaced", nil, "\nStream replaced.\n")
+			select {
+			case disconnected <- struct{}{}:
+			default:
+			}
 		case *events.AppStateSyncError:
 			a.handleAppStateSyncError(ctx, v, &appStateRecoveries)
 		}

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -1589,6 +1589,61 @@ func TestSyncOnceIdleExitStartsAfterConnected(t *testing.T) {
 	}
 }
 
+func TestSyncFollowReconnectsAfterStreamReplaced(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	reconnected := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				f.mu.Lock()
+				connectCalls := f.connectCalls
+				f.mu.Unlock()
+				if connectCalls >= 2 {
+					close(reconnected)
+					cancel()
+					return
+				}
+			}
+		}
+	}()
+
+	_, err := a.Sync(ctx, SyncOptions{
+		Mode:         SyncModeFollow,
+		AllowQR:      false,
+		MaxReconnect: time.Second,
+		AfterConnect: func(context.Context) error {
+			f.mu.Lock()
+			f.connected = false
+			f.mu.Unlock()
+			f.emit(&events.StreamReplaced{})
+			return nil
+		},
+	})
+	if err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	select {
+	case <-reconnected:
+	default:
+		f.mu.Lock()
+		connectCalls := f.connectCalls
+		f.mu.Unlock()
+		t.Fatalf("expected StreamReplaced to trigger reconnect, connect calls = %d", connectCalls)
+	}
+}
+
 func TestSyncRetriesTransientAuthConnectFailure(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -1623,9 +1623,6 @@ func TestSyncFollowReconnectsAfterStreamReplaced(t *testing.T) {
 		AllowQR:      false,
 		MaxReconnect: time.Second,
 		AfterConnect: func(context.Context) error {
-			f.mu.Lock()
-			f.connected = false
-			f.mu.Unlock()
 			f.emit(&events.StreamReplaced{})
 			return nil
 		},


### PR DESCRIPTION
## Summary
- handle whatsmeow `StreamReplaced` events in the sync event handler
- route stream replacement through the existing reconnect path used for disconnects
- add a regression test that verifies follow mode reconnects after stream replacement

## Tests
- `go test ./...`
