### PR TITLE
feat: expand profile management commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Groups: add live admin commands for creating groups, setting descriptions, toggling announce-only and admin-only edits, and approving or rejecting join requests. (#265 - thanks @dovocoder)
-- Profile: add commands to remove the profile picture, set About text, set the profile display name, fetch profile picture metadata, fetch a user's About text, and fetch WhatsApp Business profile details.
+- Profile: add commands to remove the profile picture, set About text, set the profile display name, fetch profile picture metadata, fetch a user's About text, and fetch WhatsApp Business profile details. (#267 - thanks @dovocoder)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Groups: add live admin commands for creating groups, setting descriptions, toggling announce-only and admin-only edits, and approving or rejecting join requests. (#265 - thanks @dovocoder)
+- Profile: add commands to remove the profile picture, set About text, set the profile display name, fetch profile picture metadata, fetch a user's About text, and fetch WhatsApp Business profile details.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Full documentation: **<https://wacli.sh>**
 - **Offline message store** — SQLite with FTS5 search (LIKE fallback), filterable by chat, sender, direction, time, and media type, with status broadcasts stored separately.
 - **Sending** — text with mentions/replies/link-previews, files (image/video/audio/document, ≤100 MiB), stickers, voice notes, reactions, and status broadcasts; rapid-send guardrails and retry-receipt grace.
 - **History backfill** — best-effort per-chat requests to your primary device for older messages.
-- **Contacts / chats / groups / channels** — search, alias, tag, archive, pin, mute, mark-read, rename, prune, manage participants and invite links, send to channels.
+- **Contacts / chats / groups / channels / profile** — search, alias, tag, archive, pin, mute, mark-read, rename, prune, manage participants and invite links, send to channels, and manage profile metadata.
 - **Diagnostics + safety** — `doctor`, read-only mode, store locks with owner reporting, panic recovery, bounded media queue, owner-only DB perms.
 - **Scriptable** — `--json` everywhere, `--events` NDJSON lifecycle stream, deterministic exit codes.
 

--- a/cmd/wacli/profile.go
+++ b/cmd/wacli/profile.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"image"
 	"image/color"
@@ -10,9 +11,14 @@ import (
 	"image/jpeg"
 	_ "image/png"
 	"os"
+	"strings"
 
+	"github.com/openclaw/wacli/internal/app"
+	"github.com/openclaw/wacli/internal/lock"
 	"github.com/openclaw/wacli/internal/out"
+	"github.com/openclaw/wacli/internal/wa"
 	"github.com/spf13/cobra"
+	"go.mau.fi/whatsmeow/types"
 )
 
 // profileMaxPx is the max dimension WhatsApp accepts for profile pictures.
@@ -26,6 +32,12 @@ func newProfileCmd(flags *rootFlags) *cobra.Command {
 		Short: "Manage your WhatsApp profile",
 	}
 	cmd.AddCommand(newProfileSetPictureCmd(flags))
+	cmd.AddCommand(newProfileRemovePictureCmd(flags))
+	cmd.AddCommand(newProfilePictureInfoCmd(flags))
+	cmd.AddCommand(newProfileSetAboutCmd(flags))
+	cmd.AddCommand(newProfileGetAboutCmd(flags))
+	cmd.AddCommand(newProfileSetNameCmd(flags))
+	cmd.AddCommand(newProfileBusinessCmd(flags))
 	return cmd
 }
 
@@ -73,6 +85,299 @@ func newProfileSetPictureCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	return cmd
+}
+
+func newProfileRemovePictureCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove-picture",
+		Short: "Remove your WhatsApp profile picture",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+			ctx, cancel, a, lk, err := openLiveProfileApp(flags, true)
+			if err != nil {
+				return err
+			}
+			defer cancel()
+			defer closeApp(a, lk)
+			pictureID, err := a.WA().SetProfilePicture(ctx, nil)
+			if err != nil {
+				return fmt.Errorf("remove profile picture: %w", err)
+			}
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{"removed": true, "picture_id": pictureID})
+			}
+			fmt.Fprintln(os.Stdout, "Profile picture removed.")
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newProfileSetAboutCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set-about <text>",
+		Short: "Set your WhatsApp profile About text",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+			about := strings.TrimSpace(args[0])
+			if about == "" {
+				return fmt.Errorf("about text is required")
+			}
+			ctx, cancel, a, lk, err := openLiveProfileApp(flags, true)
+			if err != nil {
+				return err
+			}
+			defer cancel()
+			defer closeApp(a, lk)
+			if err := a.WA().SetStatusMessage(ctx, about); err != nil {
+				return fmt.Errorf("set profile about: %w", err)
+			}
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{"about": about})
+			}
+			fmt.Fprintln(os.Stdout, "Profile About updated.")
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newProfileSetNameCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set-name <name>",
+		Short: "Set your WhatsApp profile display name",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+			name := strings.TrimSpace(args[0])
+			if name == "" {
+				return fmt.Errorf("profile name is required")
+			}
+			ctx, cancel, a, lk, err := openLiveProfileApp(flags, true)
+			if err != nil {
+				return err
+			}
+			defer cancel()
+			defer closeApp(a, lk)
+			if err := a.WA().SetProfileName(ctx, name); err != nil {
+				return fmt.Errorf("set profile name: %w", err)
+			}
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{"name": name})
+			}
+			fmt.Fprintln(os.Stdout, "Profile name updated.")
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newProfilePictureInfoCmd(flags *rootFlags) *cobra.Command {
+	var targetRaw, existingID string
+	var preview bool
+	cmd := &cobra.Command{
+		Use:   "picture-info --jid <jid-or-phone>",
+		Short: "Fetch WhatsApp profile picture metadata",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target, err := parseProfileTarget(targetRaw)
+			if err != nil {
+				return err
+			}
+			ctx, cancel, a, lk, err := openLiveProfileApp(flags, false)
+			if err != nil {
+				return err
+			}
+			defer cancel()
+			defer closeApp(a, lk)
+			info, err := a.WA().GetProfilePictureInfo(ctx, target, preview, existingID)
+			if err != nil {
+				return fmt.Errorf("get profile picture info: %w", err)
+			}
+			output := formatProfilePictureInfo(target, info)
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, output)
+			}
+			if info == nil {
+				fmt.Fprintf(os.Stdout, "%s profile picture is unchanged.\n", target.String())
+				return nil
+			}
+			fmt.Fprintf(os.Stdout, "JID: %s\nID: %s\nType: %s\nURL: %s\nDirect path: %s\n", output.JID, output.ID, output.Type, output.URL, output.DirectPath)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&targetRaw, "jid", "", "target JID or phone number")
+	cmd.Flags().BoolVar(&preview, "preview", false, "fetch preview picture metadata")
+	cmd.Flags().StringVar(&existingID, "existing-id", "", "last known picture ID; unchanged pictures return null metadata")
+	return cmd
+}
+
+func newProfileGetAboutCmd(flags *rootFlags) *cobra.Command {
+	var targetRaw string
+	cmd := &cobra.Command{
+		Use:   "get-about --jid <jid-or-phone>",
+		Short: "Fetch a user's WhatsApp profile About text",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target, err := parseProfileTarget(targetRaw)
+			if err != nil {
+				return err
+			}
+			ctx, cancel, a, lk, err := openLiveProfileApp(flags, false)
+			if err != nil {
+				return err
+			}
+			defer cancel()
+			defer closeApp(a, lk)
+			output, err := fetchProfileAbout(ctx, a.WA(), target)
+			if err != nil {
+				return fmt.Errorf("get profile about: %w", err)
+			}
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, output)
+			}
+			fmt.Fprintf(os.Stdout, "JID: %s\nAbout: %s\n", output.JID, output.About)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&targetRaw, "jid", "", "target JID or phone number")
+	return cmd
+}
+
+func newProfileBusinessCmd(flags *rootFlags) *cobra.Command {
+	var targetRaw string
+	cmd := &cobra.Command{
+		Use:   "business --jid <jid-or-phone>",
+		Short: "Fetch a WhatsApp business profile",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target, err := parseProfileTarget(targetRaw)
+			if err != nil {
+				return err
+			}
+			ctx, cancel, a, lk, err := openLiveProfileApp(flags, false)
+			if err != nil {
+				return err
+			}
+			defer cancel()
+			defer closeApp(a, lk)
+			profile, err := a.WA().GetBusinessProfile(ctx, target)
+			if err != nil {
+				return fmt.Errorf("get business profile: %w", err)
+			}
+			output := formatBusinessProfile(profile)
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, output)
+			}
+			fmt.Fprintf(os.Stdout, "JID: %s\nAddress: %s\nEmail: %s\nTimezone: %s\n", output.JID, output.Address, output.Email, output.BusinessHoursTimeZone)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&targetRaw, "jid", "", "target JID or phone number")
+	return cmd
+}
+
+func openLiveProfileApp(flags *rootFlags, needLock bool) (context.Context, context.CancelFunc, *app.App, *lock.Lock, error) {
+	ctx, cancel := withTimeout(context.Background(), flags)
+	a, lk, err := newApp(ctx, flags, needLock, false)
+	if err != nil {
+		cancel()
+		return nil, nil, nil, nil, err
+	}
+	if err := a.EnsureAuthed(); err != nil {
+		cancel()
+		closeApp(a, lk)
+		return nil, nil, nil, nil, err
+	}
+	if err := a.Connect(ctx, false, nil); err != nil {
+		cancel()
+		closeApp(a, lk)
+		return nil, nil, nil, nil, err
+	}
+	return ctx, cancel, a, lk, nil
+}
+
+func parseProfileTarget(raw string) (types.JID, error) {
+	if strings.TrimSpace(raw) == "" {
+		return types.JID{}, fmt.Errorf("--jid is required")
+	}
+	return wa.ParseUserOrJID(raw)
+}
+
+type profilePictureInfoOutput struct {
+	JID        string `json:"jid"`
+	ID         string `json:"id,omitempty"`
+	URL        string `json:"url,omitempty"`
+	Type       string `json:"type,omitempty"`
+	DirectPath string `json:"direct_path,omitempty"`
+	Hash       string `json:"hash,omitempty"`
+	Unchanged  bool   `json:"unchanged,omitempty"`
+}
+
+func formatProfilePictureInfo(jid types.JID, info *types.ProfilePictureInfo) profilePictureInfoOutput {
+	output := profilePictureInfoOutput{JID: jid.String()}
+	if info == nil {
+		output.Unchanged = true
+		return output
+	}
+	output.ID = info.ID
+	output.URL = info.URL
+	output.Type = info.Type
+	output.DirectPath = info.DirectPath
+	if len(info.Hash) > 0 {
+		output.Hash = base64.StdEncoding.EncodeToString(info.Hash)
+	}
+	return output
+}
+
+type profileAboutOutput struct {
+	JID   string `json:"jid"`
+	About string `json:"about"`
+}
+
+type profileUserInfoGetter interface {
+	GetUserInfo(ctx context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error)
+}
+
+func fetchProfileAbout(ctx context.Context, client profileUserInfoGetter, target types.JID) (profileAboutOutput, error) {
+	infos, err := client.GetUserInfo(ctx, []types.JID{target})
+	if err != nil {
+		return profileAboutOutput{}, err
+	}
+	return profileAboutOutput{JID: target.String(), About: infos[target].Status}, nil
+}
+
+type businessProfileOutput struct {
+	JID                   string                      `json:"jid"`
+	Address               string                      `json:"address,omitempty"`
+	Email                 string                      `json:"email,omitempty"`
+	Categories            []types.Category            `json:"categories,omitempty"`
+	ProfileOptions        map[string]string           `json:"profile_options,omitempty"`
+	BusinessHoursTimeZone string                      `json:"business_hours_timezone,omitempty"`
+	BusinessHours         []types.BusinessHoursConfig `json:"business_hours,omitempty"`
+}
+
+func formatBusinessProfile(profile *types.BusinessProfile) businessProfileOutput {
+	if profile == nil {
+		return businessProfileOutput{}
+	}
+	return businessProfileOutput{
+		JID:                   profile.JID.String(),
+		Address:               profile.Address,
+		Email:                 profile.Email,
+		Categories:            profile.Categories,
+		ProfileOptions:        profile.ProfileOptions,
+		BusinessHoursTimeZone: profile.BusinessHoursTimeZone,
+		BusinessHours:         profile.BusinessHours,
+	}
 }
 
 // readAsJPEG reads the file at path, decodes it, resizes to <=profileMaxPx if

--- a/cmd/wacli/profile.go
+++ b/cmd/wacli/profile.go
@@ -188,6 +188,9 @@ func newProfilePictureInfoCmd(flags *rootFlags) *cobra.Command {
 		Short: "Fetch WhatsApp profile picture metadata",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
 			target, err := parseProfileTarget(targetRaw)
 			if err != nil {
 				return err
@@ -227,6 +230,9 @@ func newProfileGetAboutCmd(flags *rootFlags) *cobra.Command {
 		Short: "Fetch a user's WhatsApp profile About text",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
 			target, err := parseProfileTarget(targetRaw)
 			if err != nil {
 				return err
@@ -259,6 +265,9 @@ func newProfileBusinessCmd(flags *rootFlags) *cobra.Command {
 		Short: "Fetch a WhatsApp business profile",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
 			target, err := parseProfileTarget(targetRaw)
 			if err != nil {
 				return err

--- a/cmd/wacli/profile.go
+++ b/cmd/wacli/profile.go
@@ -361,7 +361,11 @@ func fetchProfileAbout(ctx context.Context, client profileUserInfoGetter, target
 	if err != nil {
 		return profileAboutOutput{}, err
 	}
-	return profileAboutOutput{JID: target.String(), About: infos[target].Status}, nil
+	info, ok := infos[target]
+	if !ok {
+		return profileAboutOutput{}, fmt.Errorf("profile about unavailable for %s", target.String())
+	}
+	return profileAboutOutput{JID: target.String(), About: info.Status}, nil
 }
 
 type businessProfileOutput struct {

--- a/cmd/wacli/profile.go
+++ b/cmd/wacli/profile.go
@@ -192,7 +192,7 @@ func newProfilePictureInfoCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			ctx, cancel, a, lk, err := openLiveProfileApp(flags, false)
+			ctx, cancel, a, lk, err := openLiveProfileApp(flags, true)
 			if err != nil {
 				return err
 			}
@@ -207,10 +207,10 @@ func newProfilePictureInfoCmd(flags *rootFlags) *cobra.Command {
 				return out.WriteJSON(os.Stdout, output)
 			}
 			if info == nil {
-				fmt.Fprintf(os.Stdout, "%s profile picture is unchanged.\n", target.String())
+				fmt.Fprintf(os.Stdout, "%s profile picture is unchanged.\n", sanitize(target.String()))
 				return nil
 			}
-			fmt.Fprintf(os.Stdout, "JID: %s\nID: %s\nType: %s\nURL: %s\nDirect path: %s\n", output.JID, output.ID, output.Type, output.URL, output.DirectPath)
+			fmt.Fprintf(os.Stdout, "JID: %s\nID: %s\nType: %s\nURL: %s\nDirect path: %s\n", sanitize(output.JID), sanitize(output.ID), sanitize(output.Type), sanitize(output.URL), sanitize(output.DirectPath))
 			return nil
 		},
 	}
@@ -231,7 +231,7 @@ func newProfileGetAboutCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			ctx, cancel, a, lk, err := openLiveProfileApp(flags, false)
+			ctx, cancel, a, lk, err := openLiveProfileApp(flags, true)
 			if err != nil {
 				return err
 			}
@@ -244,7 +244,7 @@ func newProfileGetAboutCmd(flags *rootFlags) *cobra.Command {
 			if flags.asJSON {
 				return out.WriteJSON(os.Stdout, output)
 			}
-			fmt.Fprintf(os.Stdout, "JID: %s\nAbout: %s\n", output.JID, output.About)
+			fmt.Fprintf(os.Stdout, "JID: %s\nAbout: %s\n", sanitize(output.JID), sanitize(output.About))
 			return nil
 		},
 	}
@@ -263,7 +263,7 @@ func newProfileBusinessCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			ctx, cancel, a, lk, err := openLiveProfileApp(flags, false)
+			ctx, cancel, a, lk, err := openLiveProfileApp(flags, true)
 			if err != nil {
 				return err
 			}
@@ -277,7 +277,7 @@ func newProfileBusinessCmd(flags *rootFlags) *cobra.Command {
 			if flags.asJSON {
 				return out.WriteJSON(os.Stdout, output)
 			}
-			fmt.Fprintf(os.Stdout, "JID: %s\nAddress: %s\nEmail: %s\nTimezone: %s\n", output.JID, output.Address, output.Email, output.BusinessHoursTimeZone)
+			fmt.Fprintf(os.Stdout, "JID: %s\nAddress: %s\nEmail: %s\nTimezone: %s\n", sanitize(output.JID), sanitize(output.Address), sanitize(output.Email), sanitize(output.BusinessHoursTimeZone))
 			return nil
 		},
 	}

--- a/cmd/wacli/profile_test.go
+++ b/cmd/wacli/profile_test.go
@@ -123,6 +123,14 @@ func TestFetchProfileAboutReturnsTargetStatus(t *testing.T) {
 	}
 }
 
+func TestFetchProfileAboutErrorsWhenTargetMissing(t *testing.T) {
+	target := types.NewJID("15551234567", types.DefaultUserServer)
+	_, err := fetchProfileAbout(context.Background(), fakeProfileClient{userInfo: map[types.JID]types.UserInfo{}}, target)
+	if err == nil {
+		t.Fatal("expected missing target error")
+	}
+}
+
 type fakeProfileClient struct {
 	userInfo map[types.JID]types.UserInfo
 }

--- a/cmd/wacli/profile_test.go
+++ b/cmd/wacli/profile_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"image"
 	"image/color"
 	"image/jpeg"
@@ -9,6 +11,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/spf13/cobra"
+	"go.mau.fi/whatsmeow/types"
 )
 
 func TestReadAsJPEGResizesAndFlattensAlpha(t *testing.T) {
@@ -56,4 +61,75 @@ func TestResizeIfNeededKeepsSmallImage(t *testing.T) {
 	if got := resizeIfNeeded(img, profileMaxPx); got != img {
 		t.Fatal("resizeIfNeeded should return small images unchanged")
 	}
+}
+
+func TestProfileCommandExposesProfileManagementSubcommands(t *testing.T) {
+	cmd := newProfileCmd(&rootFlags{})
+	for _, name := range []string{"set-picture", "remove-picture", "picture-info", "set-about", "get-about", "set-name", "business"} {
+		if _, _, err := cmd.Find([]string{name}); err != nil {
+			t.Fatalf("missing profile %s command: %v", name, err)
+		}
+	}
+}
+
+func TestProfileReadCommandsExposeTargetFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{name: "picture-info", cmd: newProfilePictureInfoCmd(&rootFlags{})},
+		{name: "get-about", cmd: newProfileGetAboutCmd(&rootFlags{})},
+		{name: "business", cmd: newProfileBusinessCmd(&rootFlags{})},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.cmd.Flags().Lookup("jid") == nil {
+				t.Fatalf("missing --jid flag")
+			}
+		})
+	}
+}
+
+func TestProfilePictureInfoJSONOmitsHashBytesWhenEmpty(t *testing.T) {
+	info := profilePictureInfoOutput{
+		JID:        "15551234567@s.whatsapp.net",
+		ID:         "abc",
+		URL:        "https://example.invalid/avatar.jpg",
+		Type:       "image",
+		DirectPath: "/mms/path",
+	}
+	data, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if bytes.Contains(data, []byte("hash")) {
+		t.Fatalf("empty hash should be omitted: %s", data)
+	}
+}
+
+func TestFetchProfileAboutReturnsTargetStatus(t *testing.T) {
+	target := types.NewJID("15551234567", types.DefaultUserServer)
+	client := fakeProfileClient{
+		userInfo: map[types.JID]types.UserInfo{
+			target: {Status: "Available"},
+		},
+	}
+	got, err := fetchProfileAbout(context.Background(), client, target)
+	if err != nil {
+		t.Fatalf("fetchProfileAbout: %v", err)
+	}
+	if got.JID != target.String() || got.About != "Available" {
+		t.Fatalf("unexpected output: %+v", got)
+	}
+}
+
+type fakeProfileClient struct {
+	userInfo map[types.JID]types.UserInfo
+}
+
+func (f fakeProfileClient) GetUserInfo(_ context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error) {
+	if len(jids) != 1 {
+		return nil, nil
+	}
+	return f.userInfo, nil
 }

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -36,7 +36,7 @@ Read when: you need the user-facing command map, global flags, store model, or l
 - [channels](channels.md) - list, inspect, join, leave, and send to WhatsApp Channels.
 - [history](history.md) - inspect archive coverage and request older per-chat history from the primary device.
 - [presence](presence.md) - send typing/paused indicators.
-- [profile](profile.md) - set the authenticated account profile picture.
+- [profile](profile.md) - manage profile picture, About text, display name, and fetch profile metadata.
 - [doctor](doctor.md) - diagnose store, auth, search, and optional live connectivity.
 - [docs](docs.md) - print the hosted documentation URL.
 - [version](version.md) - print the CLI version.

--- a/docs/profile.md
+++ b/docs/profile.md
@@ -1,6 +1,6 @@
 # profile
 
-Read when: setting the profile picture for the authenticated WhatsApp account.
+Read when: managing the authenticated WhatsApp profile or fetching profile metadata for a WhatsApp user.
 
 `wacli profile` manages account-level WhatsApp profile settings for the linked account.
 
@@ -8,19 +8,37 @@ Read when: setting the profile picture for the authenticated WhatsApp account.
 
 ```bash
 wacli profile set-picture <image>
+wacli profile remove-picture
+wacli profile set-about <text>
+wacli profile set-name <name>
+wacli profile picture-info --jid <jid-or-phone> [--preview] [--existing-id ID]
+wacli profile get-about --jid <jid-or-phone>
+wacli profile business --jid <jid-or-phone>
 ```
 
 ## Notes
 
-- `set-picture` requires authentication, a live connection, and writable mode.
+- Mutating commands (`set-picture`, `remove-picture`, `set-about`, `set-name`) require authentication, a live connection, writable mode, and the store lock.
 - Input can be JPEG or PNG.
 - PNG transparency is flattened onto a white background before upload.
 - Images larger than 640 px on either side are resized before upload.
-- The command prints the picture ID returned by WhatsApp; use `--json` for machine-readable output.
+- `set-picture` prints the picture ID returned by WhatsApp; use `--json` for machine-readable output.
+- `set-about` updates the profile About text, not ephemeral status broadcasts. Use `send status` for WhatsApp status posts.
+- `set-name` updates the WhatsApp push/display name through whatsmeow app-state support.
+- `picture-info` fetches metadata and a CDN URL for the target's profile picture. Pass `--preview` for preview metadata or `--existing-id` to let WhatsApp report unchanged pictures.
+- `get-about` fetches a target user's current About text.
+- `business` fetches a target WhatsApp Business profile when available.
+- Live fetch commands do not mutate WhatsApp profile settings, but they still open the WhatsApp session store and therefore cannot run with `--read-only`.
 
 ## Examples
 
 ```bash
 wacli profile set-picture ./avatar.jpg
 wacli profile set-picture ./avatar.png --json
+wacli profile remove-picture
+wacli profile set-about "Available today"
+wacli profile set-name "Ops Desk"
+wacli profile picture-info --jid +15551234567 --json
+wacli profile get-about --jid 15551234567@s.whatsapp.net
+wacli profile business --jid +15551234567 --json
 ```

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -92,6 +92,10 @@ type WAClient interface {
 	LinkedLID() string
 
 	SetProfilePicture(ctx context.Context, avatar []byte) (string, error)
+	GetProfilePictureInfo(ctx context.Context, jid types.JID, preview bool, existingID string) (*types.ProfilePictureInfo, error)
+	SetStatusMessage(ctx context.Context, msg string) error
+	SetProfileName(ctx context.Context, name string) error
+	GetBusinessProfile(ctx context.Context, jid types.JID) (*types.BusinessProfile, error)
 }
 
 type Options struct {

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -724,6 +724,22 @@ func (f *fakeWA) SetProfilePicture(ctx context.Context, avatar []byte) (string, 
 	return "pic-id-fake", nil
 }
 
+func (f *fakeWA) GetProfilePictureInfo(ctx context.Context, jid types.JID, preview bool, existingID string) (*types.ProfilePictureInfo, error) {
+	return &types.ProfilePictureInfo{ID: "pic-id-fake", URL: "https://example.invalid/avatar.jpg", Type: "image"}, nil
+}
+
+func (f *fakeWA) SetStatusMessage(ctx context.Context, msg string) error {
+	return nil
+}
+
+func (f *fakeWA) SetProfileName(ctx context.Context, name string) error {
+	return nil
+}
+
+func (f *fakeWA) GetBusinessProfile(ctx context.Context, jid types.JID) (*types.BusinessProfile, error) {
+	return &types.BusinessProfile{JID: jid}, nil
+}
+
 func (f *fakeWA) LinkedJID() string {
 	if !f.IsAuthed() {
 		return ""

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -850,6 +850,55 @@ func (c *Client) SetProfilePicture(ctx context.Context, avatar []byte) (string, 
 	return pictureID, nil
 }
 
+func (c *Client) GetProfilePictureInfo(ctx context.Context, jid types.JID, preview bool, existingID string) (*types.ProfilePictureInfo, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return nil, fmt.Errorf("not connected")
+	}
+	return cli.GetProfilePictureInfo(ctx, jid, &whatsmeow.GetProfilePictureParams{
+		Preview:    preview,
+		ExistingID: existingID,
+	})
+}
+
+func (c *Client) SetStatusMessage(ctx context.Context, msg string) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	return cli.SetStatusMessage(ctx, msg)
+}
+
+func (c *Client) SetProfileName(ctx context.Context, name string) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	if err := cli.SendAppState(ctx, appstate.BuildSettingPushName(name)); err != nil {
+		return err
+	}
+	if cli.Store != nil {
+		cli.Store.PushName = name
+	}
+	return nil
+}
+
+func (c *Client) GetBusinessProfile(ctx context.Context, jid types.JID) (*types.BusinessProfile, error) {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return nil, fmt.Errorf("not connected")
+	}
+	return cli.GetBusinessProfile(ctx, jid)
+}
+
 // Reconnect loop helper.
 func (c *Client) ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay time.Duration) error {
 	delay := minDelay


### PR DESCRIPTION
## Summary
- Add profile commands to remove the account picture, set About text, and set the display name
- Add read commands for profile picture metadata, user About text, and WhatsApp Business profile details
- Document the expanded profile workflow and JSON-friendly outputs

## Why
This makes `wacli profile` useful for both account profile maintenance and scriptable profile metadata lookups, without requiring users to write custom whatsmeow code for common profile operations.

## Test plan
- `go test ./...`
- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `git diff --check`