### PR TITLE
feat(contacts): add get-picture command to download avatar JPEG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Groups: add live admin commands for creating groups, setting descriptions, toggling announce-only and admin-only edits, and approving or rejecting join requests. (#265 - thanks @dovocoder)
 - Profile: add commands to remove the profile picture, set About text, set the profile display name, fetch profile picture metadata, fetch a user's About text, and fetch WhatsApp Business profile details. (#267 - thanks @dovocoder)
+- Contacts: add `contacts get-picture` to download a contact's profile picture JPEG to a file (or stdout). Supports `--type preview` (96x96 thumbnail) and `--type image` (full-size up to 640px); maps `ErrProfilePictureNotSet` and `ErrProfilePictureUnauthorized` to friendly error messages. Useful for syncing avatars into local address books for archived chats where the macOS WhatsApp app no longer caches the thumbnail.
 
 ### Security
 

--- a/cmd/wacli/contacts.go
+++ b/cmd/wacli/contacts.go
@@ -21,6 +21,7 @@ func newContactsCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newContactsImportSystemCmd(flags))
 	cmd.AddCommand(newContactsAliasCmd(flags))
 	cmd.AddCommand(newContactsTagsCmd(flags))
+	cmd.AddCommand(newContactsGetPictureCmd(flags))
 	return cmd
 }
 

--- a/cmd/wacli/contacts_get_picture.go
+++ b/cmd/wacli/contacts_get_picture.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/openclaw/wacli/internal/out"
+	"github.com/spf13/cobra"
+	"go.mau.fi/whatsmeow"
+)
+
+const (
+	pictureTypePreview = "preview"
+	pictureTypeImage   = "image"
+)
+
+// pictureMaxBytes caps the JPEG download to defend against a misbehaving CDN.
+// WhatsApp full-size pictures are <=640px JPEG, so 5 MiB is comfortably above
+// any reasonable real value.
+const pictureMaxBytes = 5 * 1024 * 1024
+
+// httpDoer is the subset of *http.Client used by the picture downloader; kept
+// narrow so tests can inject a fake without spinning up a server.
+type httpDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+func newContactsGetPictureCmd(flags *rootFlags) *cobra.Command {
+	var targetRaw, outputPath, pictureType, existingID string
+	cmd := &cobra.Command{
+		Use:   "get-picture",
+		Short: "Download a contact's WhatsApp profile picture to a file",
+		Long: `Download a contact's WhatsApp profile picture as a JPEG.
+
+Fetches metadata via whatsmeow's GetProfilePictureInfo and then downloads the
+JPEG bytes from WhatsApp's CDN. Useful for syncing avatars into local address
+books for contacts whose chat is archived (and therefore not cached by the
+macOS WhatsApp desktop app).
+
+Use --type preview for the 96x96 thumbnail (default) or --type image for the
+full-size picture (up to 640px). Use --output - to stream bytes to stdout;
+--json + --output - is rejected because both write to stdout.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+			preview, err := parsePictureType(pictureType)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(outputPath) == "" {
+				return fmt.Errorf("--output is required")
+			}
+			if flags.asJSON && outputPath == "-" {
+				return fmt.Errorf("--json cannot be combined with --output -")
+			}
+
+			target, err := parseProfileTarget(targetRaw)
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel, a, lk, err := openLiveProfileApp(flags, true)
+			if err != nil {
+				return err
+			}
+			defer cancel()
+			defer closeApp(a, lk)
+
+			info, err := a.WA().GetProfilePictureInfo(ctx, target, preview, existingID)
+			if err != nil {
+				return wrapProfilePictureError(err)
+			}
+			if info == nil {
+				return fmt.Errorf("profile picture is unchanged (matches --existing-id %q)", existingID)
+			}
+			if info.URL == "" {
+				return fmt.Errorf("no profile picture available")
+			}
+
+			data, err := downloadProfilePicture(ctx, http.DefaultClient, info.URL)
+			if err != nil {
+				return err
+			}
+
+			resolved, written, err := writeProfilePicture(outputPath, data)
+			if err != nil {
+				return err
+			}
+
+			result := contactsGetPictureOutput{
+				JID:    target.String(),
+				ID:     info.ID,
+				Type:   info.Type,
+				URL:    info.URL,
+				Output: resolved,
+				Bytes:  written,
+			}
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, result)
+			}
+			if resolved == "-" {
+				return nil // bytes already on stdout
+			}
+			fmt.Fprintf(os.Stdout, "%s (%d bytes)\n", resolved, written)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&targetRaw, "jid", "", "target JID or phone number")
+	cmd.Flags().StringVar(&outputPath, "output", "", "output file path (use - for stdout)")
+	cmd.Flags().StringVar(&pictureType, "type", pictureTypePreview, "preview (96x96 thumbnail) or image (full-size, up to 640px)")
+	cmd.Flags().StringVar(&existingID, "existing-id", "", "skip download if picture ID matches")
+	return cmd
+}
+
+// parsePictureType maps the --type flag to the whatsmeow `preview bool` arg.
+// preview = true → 96x96 thumbnail; preview = false → up to 640px full-size.
+func parsePictureType(s string) (preview bool, err error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case pictureTypePreview, "":
+		return true, nil
+	case pictureTypeImage, "full":
+		return false, nil
+	default:
+		return false, fmt.Errorf("--type must be one of: preview, image (got %q)", s)
+	}
+}
+
+// wrapProfilePictureError converts whatsmeow's profile-picture sentinel errors
+// into the user-facing strings promised by the command spec.
+func wrapProfilePictureError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, whatsmeow.ErrProfilePictureNotSet):
+		return fmt.Errorf("no profile picture available")
+	case errors.Is(err, whatsmeow.ErrProfilePictureUnauthorized):
+		return fmt.Errorf("not authorized to view this profile picture")
+	default:
+		return fmt.Errorf("get profile picture info: %w", err)
+	}
+}
+
+// downloadProfilePicture GETs the WhatsApp CDN URL and returns the body bytes,
+// rejecting any response larger than pictureMaxBytes.
+func downloadProfilePicture(ctx context.Context, client httpDoer, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build profile picture request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download profile picture: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("download profile picture: HTTP %d", resp.StatusCode)
+	}
+	body := io.LimitReader(resp.Body, pictureMaxBytes+1)
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("download profile picture: %w", err)
+	}
+	if int64(len(data)) > pictureMaxBytes {
+		return nil, fmt.Errorf("download profile picture: response exceeds %d bytes", pictureMaxBytes)
+	}
+	return data, nil
+}
+
+// writeProfilePicture writes data to outputPath (or stdout if "-") and returns
+// the resolved path string used for output messages plus the number of bytes
+// written. Non-stdout writes use 0600 to mirror wacli's owner-only convention.
+func writeProfilePicture(outputPath string, data []byte) (string, int, error) {
+	if outputPath == "-" {
+		n, err := os.Stdout.Write(data)
+		if err != nil {
+			return "-", n, fmt.Errorf("write stdout: %w", err)
+		}
+		return "-", n, nil
+	}
+	if err := os.WriteFile(outputPath, data, 0o600); err != nil {
+		return "", 0, fmt.Errorf("write %s: %w", outputPath, err)
+	}
+	abs, err := filepath.Abs(outputPath)
+	if err != nil {
+		abs = outputPath
+	}
+	return abs, len(data), nil
+}
+
+type contactsGetPictureOutput struct {
+	JID    string `json:"jid"`
+	ID     string `json:"id,omitempty"`
+	Type   string `json:"type,omitempty"`
+	URL    string `json:"url,omitempty"`
+	Output string `json:"output"`
+	Bytes  int    `json:"bytes"`
+}

--- a/cmd/wacli/contacts_get_picture_test.go
+++ b/cmd/wacli/contacts_get_picture_test.go
@@ -1,0 +1,311 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.mau.fi/whatsmeow"
+)
+
+// fakeHTTPDoer satisfies httpDoer for tests; either resp or err is returned
+// verbatim from Do.
+type fakeHTTPDoer struct {
+	resp *http.Response
+	err  error
+	last *http.Request
+}
+
+func (f *fakeHTTPDoer) Do(req *http.Request) (*http.Response, error) {
+	f.last = req
+	return f.resp, f.err
+}
+
+func TestParsePictureType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in      string
+		preview bool
+		wantErr bool
+	}{
+		{in: "", preview: true},
+		{in: "preview", preview: true},
+		{in: "PREVIEW", preview: true},
+		{in: " preview ", preview: true},
+		{in: "image", preview: false},
+		{in: "IMAGE", preview: false},
+		{in: "full", preview: false},
+		{in: "thumbnail", wantErr: true},
+		{in: "garbage", wantErr: true},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(fmt.Sprintf("type=%q", tc.in), func(t *testing.T) {
+			t.Parallel()
+			got, err := parsePictureType(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.preview {
+				t.Fatalf("preview = %v, want %v", got, tc.preview)
+			}
+		})
+	}
+}
+
+func TestWrapProfilePictureErrorMapsSentinels(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   error
+		want string
+	}{
+		{name: "nil-passthrough", in: nil, want: ""},
+		{name: "not-set", in: whatsmeow.ErrProfilePictureNotSet, want: "no profile picture available"},
+		{name: "wrapped-not-set", in: fmt.Errorf("outer: %w", whatsmeow.ErrProfilePictureNotSet), want: "no profile picture available"},
+		{name: "unauthorized", in: whatsmeow.ErrProfilePictureUnauthorized, want: "not authorized to view this profile picture"},
+		{name: "generic", in: fmt.Errorf("boom"), want: "get profile picture info: boom"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := wrapProfilePictureError(tc.in)
+			if tc.want == "" {
+				if got != nil {
+					t.Fatalf("expected nil, got %v", got)
+				}
+				return
+			}
+			if got == nil || got.Error() != tc.want {
+				t.Fatalf("got %v, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDownloadProfilePictureSuccess(t *testing.T) {
+	t.Parallel()
+	payload := []byte("\xff\xd8\xff\xe0fakejpegbytes")
+	doer := &fakeHTTPDoer{
+		resp: &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewReader(payload)),
+		},
+	}
+	got, err := downloadProfilePicture(t.Context(), doer, "https://pps.example.invalid/avatar.jpg")
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("got %q, want %q", got, payload)
+	}
+	if doer.last == nil || doer.last.URL.Host != "pps.example.invalid" {
+		t.Fatalf("request URL not propagated: %v", doer.last)
+	}
+}
+
+func TestDownloadProfilePictureHTTPError(t *testing.T) {
+	t.Parallel()
+	doer := &fakeHTTPDoer{
+		resp: &http.Response{
+			StatusCode: 404,
+			Body:       io.NopCloser(strings.NewReader("not found")),
+		},
+	}
+	_, err := downloadProfilePicture(t.Context(), doer, "https://pps.example.invalid/avatar.jpg")
+	if err == nil {
+		t.Fatal("expected HTTP 404 error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Fatalf("error does not mention 404: %v", err)
+	}
+}
+
+func TestDownloadProfilePictureRejectsOversize(t *testing.T) {
+	t.Parallel()
+	// Stream pictureMaxBytes+1 bytes to force the size guard to trip.
+	body := bytes.Repeat([]byte{0xab}, pictureMaxBytes+1)
+	doer := &fakeHTTPDoer{
+		resp: &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+		},
+	}
+	_, err := downloadProfilePicture(t.Context(), doer, "https://pps.example.invalid/avatar.jpg")
+	if err == nil {
+		t.Fatal("expected oversize rejection")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("error does not mention oversize: %v", err)
+	}
+}
+
+func TestDownloadProfilePictureTransportError(t *testing.T) {
+	t.Parallel()
+	doer := &fakeHTTPDoer{err: fmt.Errorf("connection refused")}
+	_, err := downloadProfilePicture(t.Context(), doer, "https://pps.example.invalid/avatar.jpg")
+	if err == nil || !strings.Contains(err.Error(), "connection refused") {
+		t.Fatalf("expected wrapped transport error, got %v", err)
+	}
+}
+
+func TestWriteProfilePictureToFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "alice.jpg")
+	data := []byte("jpegcontents")
+
+	resolved, n, err := writeProfilePicture(path, data)
+	if err != nil {
+		t.Fatalf("writeProfilePicture: %v", err)
+	}
+	if n != len(data) {
+		t.Fatalf("wrote %d bytes, want %d", n, len(data))
+	}
+	if !filepath.IsAbs(resolved) {
+		t.Fatalf("resolved should be absolute: %q", resolved)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("file contents differ: got %q, want %q", got, data)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	// Sanity-check owner-only perms; ignore on Windows (CI runs Linux/macOS).
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("perm = %o, want 0600", mode)
+	}
+}
+
+func TestWriteProfilePictureRejectsBadPath(t *testing.T) {
+	t.Parallel()
+	// Writing into a non-existent nested directory should fail before clobbering.
+	missing := filepath.Join(t.TempDir(), "does", "not", "exist", "avatar.jpg")
+	_, _, err := writeProfilePicture(missing, []byte("x"))
+	if err == nil {
+		t.Fatal("expected error when parent directory is missing")
+	}
+}
+
+func TestContactsCommandIncludesGetPicture(t *testing.T) {
+	t.Parallel()
+	cmd := newContactsCmd(&rootFlags{})
+	if _, _, err := cmd.Find([]string{"get-picture"}); err != nil {
+		t.Fatalf("missing contacts get-picture command: %v", err)
+	}
+}
+
+func TestContactsGetPictureExposesFlags(t *testing.T) {
+	t.Parallel()
+	cmd := newContactsGetPictureCmd(&rootFlags{})
+	for _, name := range []string{"jid", "output", "type", "existing-id"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Fatalf("missing --%s flag", name)
+		}
+	}
+}
+
+func TestContactsGetPictureRejectsConflictingStdoutJSON(t *testing.T) {
+	t.Parallel()
+	cmd := newContactsGetPictureCmd(&rootFlags{asJSON: true})
+	cmd.SetArgs([]string{"--jid", "15551234567@s.whatsapp.net", "--output", "-"})
+	// Silence cobra's usage spam on error.
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected --json + --output - to be rejected")
+	}
+	if !strings.Contains(err.Error(), "--json cannot be combined with --output -") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestContactsGetPictureRejectsMissingOutput(t *testing.T) {
+	t.Parallel()
+	cmd := newContactsGetPictureCmd(&rootFlags{})
+	cmd.SetArgs([]string{"--jid", "15551234567@s.whatsapp.net"})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--output is required") {
+		t.Fatalf("expected --output required error, got %v", err)
+	}
+}
+
+func TestContactsGetPictureRejectsBadType(t *testing.T) {
+	t.Parallel()
+	cmd := newContactsGetPictureCmd(&rootFlags{})
+	cmd.SetArgs([]string{"--jid", "15551234567@s.whatsapp.net", "--output", "/tmp/x.jpg", "--type", "garbage"})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--type must be one of") {
+		t.Fatalf("expected bad --type error, got %v", err)
+	}
+}
+
+func TestContactsGetPictureOutputJSONShape(t *testing.T) {
+	t.Parallel()
+	result := contactsGetPictureOutput{
+		JID:    "15551234567@s.whatsapp.net",
+		ID:     "abc123",
+		Type:   "image",
+		URL:    "https://pps.example.invalid/avatar.jpg",
+		Output: "/tmp/alice.jpg",
+		Bytes:  4321,
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(data)
+	for _, field := range []string{`"jid":"15551234567@s.whatsapp.net"`, `"id":"abc123"`, `"type":"image"`, `"url":"https://pps.example.invalid/avatar.jpg"`, `"output":"/tmp/alice.jpg"`, `"bytes":4321`} {
+		if !strings.Contains(got, field) {
+			t.Fatalf("missing %s in JSON: %s", field, got)
+		}
+	}
+}
+
+func TestContactsGetPictureOutputJSONOmitsEmptyOptionals(t *testing.T) {
+	t.Parallel()
+	result := contactsGetPictureOutput{
+		JID:    "15551234567@s.whatsapp.net",
+		Output: "-",
+		Bytes:  0,
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(data)
+	for _, omit := range []string{`"id"`, `"type"`, `"url"`} {
+		if strings.Contains(got, omit) {
+			t.Fatalf("expected %s to be omitted, got %s", omit, got)
+		}
+	}
+}

--- a/docs/contacts.md
+++ b/docs/contacts.md
@@ -15,6 +15,7 @@ wacli contacts alias set --jid JID --alias NAME
 wacli contacts alias rm --jid JID
 wacli contacts tags add --jid JID --tag TAG
 wacli contacts tags rm --jid JID --tag TAG
+wacli contacts get-picture --jid JID --output PATH [--type preview|image] [--existing-id ID]
 ```
 
 ## Notes
@@ -28,6 +29,7 @@ wacli contacts tags rm --jid JID --tag TAG
 - Use `import-system --dry-run` before writing. Use `import-system --clear` to remove imported system names.
 - See [contacts import-system](contacts-import-system.md) for the full import workflow, JSON shape, file format, and verification steps.
 - Tags are local grouping metadata for scripts and future workflows.
+- `get-picture` fetches the live profile picture from WhatsApp's CDN (the macOS WhatsApp app stops caching the thumbnail when a chat is archived, so this is the easiest way to recover an avatar for an archived contact). Default `--type preview` returns the 96x96 thumbnail; `--type image` returns the full-size picture (up to 640px). Pass `--output -` to stream JPEG bytes to stdout. `--existing-id` skips the download when the picture ID matches the supplied value. Combine `--json` with a file `--output` to get metadata (`id`, `type`, `url`, `output`, `bytes`) alongside the saved file; `--json` plus `--output -` is rejected because both would write to stdout. Errors are mapped: `no profile picture available` (`ErrProfilePictureNotSet`), `not authorized to view this profile picture` (`ErrProfilePictureUnauthorized`).
 
 ## Examples
 
@@ -38,4 +40,6 @@ wacli contacts refresh
 wacli contacts import-system --dry-run
 wacli contacts alias set --jid 1234567890@s.whatsapp.net --alias mom
 wacli contacts tags add --jid 1234567890@s.whatsapp.net --tag family
+wacli contacts get-picture --jid 1234567890@s.whatsapp.net --output /tmp/alice.jpg
+wacli contacts get-picture --jid 1234567890@s.whatsapp.net --type image --output /tmp/alice-full.jpg --json
 ```


### PR DESCRIPTION
## What

Adds `wacli contacts get-picture --jid JID --output PATH` to download a contact's WhatsApp profile picture as a JPEG file (or stream to stdout). Wraps the existing `Client.GetProfilePictureInfo` and then downloads the JPEG bytes from the returned CDN URL.

```bash
wacli contacts get-picture --jid 1234567890@s.whatsapp.net --output /tmp/avatar.jpg
wacli contacts get-picture --jid 1234567890@s.whatsapp.net --output /tmp/avatar.jpg --type image --json
wacli contacts get-picture --jid 1234567890@s.whatsapp.net --output -  # stdout
```

## Why

I'm syncing my WhatsApp contacts into macOS Contacts (one address book for everyone). The macOS WhatsApp app caches a thumbnail at `Media/Profile/<jid>.thumb` for active chats, but **stops caching as soon as the chat is archived** — even though the avatar still shows up in the UI (loaded in-memory). For archived contacts there is no on-disk thumb to copy into Contacts.app.

`wacli profile picture-info` already returns the CDN URL, but you then have to wrangle `curl` (with the WhatsApp `Referer` quirk in some flows) to actually get the bytes. `contacts get-picture` does the metadata fetch + download + write in one call, with the same flag conventions as the rest of `wacli contacts`.

## How

- `cmd/wacli/contacts_get_picture.go` — new subcommand registered in `newContactsCmd`. Uses the same `openLiveProfileApp` / `parseProfileTarget` helpers as `profile picture-info`.
- `--type preview` (default) → 96×96 thumbnail (`preview=true` to whatsmeow)
- `--type image` → full-size up to 640px (`preview=false`)
- `--output -` → stream JPEG bytes to stdout
- `--existing-id` → skip the download when the picture ID matches (mirrors `profile picture-info`)
- `--json` → metadata (`id`, `type`, `url`, `output`, `bytes`) — rejected when combined with `--output -` because both would write to stdout
- Maps `whatsmeow.ErrProfilePictureNotSet` → `no profile picture available` and `whatsmeow.ErrProfilePictureUnauthorized` → `not authorized to view this profile picture`
- Caps the HTTP response at 5 MiB (full-size WhatsApp pics are ≤640px JPEG, well under)
- Writes files with `0600` to match the rest of wacli's owner-only convention
- No new dependencies; uses `net/http` directly. The CDN URL whatsmeow returns is a plain hashed HTTPS URL that does not require auth headers.

## Tests

`cmd/wacli/contacts_get_picture_test.go` — table-driven unit tests:

- `parsePictureType` — preview/image/full/invalid
- `wrapProfilePictureError` — sentinel-error mapping (incl. `errors.Is` wrapping)
- `downloadProfilePicture` — success, HTTP error, oversize rejection, transport error (via `httpDoer` interface so no real socket is opened)
- `writeProfilePicture` — file write + perm check, missing parent rejection
- Cobra wiring — command registered under `contacts`, all four flags exposed
- Flag validation — `--json + --output -` rejected, `--output` required, bad `--type` rejected
- JSON shape — required fields present, empty optionals omitted

Local verification on macOS arm64:

```
$ pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check
# all green
$ ./dist/wacli contacts get-picture --jid <active>@s.whatsapp.net --output /tmp/a.jpg
# JPEG 96x96 progressive, ~2.8 KB
$ ./dist/wacli contacts get-picture --jid <archived>@s.whatsapp.net --output /tmp/b.jpg
# JPEG 96x96 progressive, ~2.7 KB  ← archived case works
$ ./dist/wacli contacts get-picture --jid <active>@s.whatsapp.net --output /tmp/c.jpg --type image --json
{"jid":"...","id":"<elided>","type":"image","url":"https://pps.whatsapp.net/...","output":"/tmp/c.jpg","bytes":48630}
# JPEG 640x640 baseline
```

## Docs

- `CHANGELOG.md` — entry under `0.11.1 - Unreleased > Added`
- `docs/contacts.md` — synopsis line + notes paragraph + 2 examples (preview, full-size + json)
