### PR TITLE
fix: bound direct media HTTP downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Security
 
+- Media: bound direct WhatsApp media downloads with a response-header timeout while preserving the caller's body download budget. (#271 - thanks @jason-allen-oneal)
+
 ### Fixed
 
 - Sync: reconnect after WhatsApp replaces the linked-device stream instead of leaving `sync --follow` offline. (#266 - thanks @ngutman)

--- a/internal/wa/media.go
+++ b/internal/wa/media.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -29,21 +28,10 @@ var directMediaBaseURL = "https://mmg.whatsapp.net"
 var directMediaHTTPClient = newDirectMediaHTTPClient()
 
 func newDirectMediaHTTPClient() *http.Client {
-	dialer := &net.Dialer{
-		Timeout:   10 * time.Second,
-		KeepAlive: 30 * time.Second,
-	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = 10 * time.Second
 	return &http.Client{
-		Transport: &http.Transport{
-			Proxy:                 http.ProxyFromEnvironment,
-			DialContext:           dialer.DialContext,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ResponseHeaderTimeout: 10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-			IdleConnTimeout:       30 * time.Second,
-			MaxIdleConns:          10,
-			MaxIdleConnsPerHost:   4,
-		},
+		Transport: transport,
 	}
 }
 

--- a/internal/wa/media.go
+++ b/internal/wa/media.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/openclaw/wacli/internal/fsutil"
 	"go.mau.fi/whatsmeow"
@@ -23,6 +24,21 @@ import (
 const MaxMediaDownloadSize = 100 * 1024 * 1024
 
 var directMediaBaseURL = "https://mmg.whatsapp.net"
+
+var directMediaHTTPClient = newDirectMediaHTTPClient()
+
+func newDirectMediaHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			ResponseHeaderTimeout: 10 * time.Second,
+			IdleConnTimeout:       30 * time.Second,
+			MaxIdleConns:          10,
+			MaxIdleConnsPerHost:   4,
+		},
+	}
+}
 
 // WhatsApp writes encrypted media as padded ciphertext plus a 10-byte MAC before
 // truncating and decrypting it in place.
@@ -258,7 +274,7 @@ func downloadDirectBytes(ctx context.Context, mediaURL string) ([]byte, error) {
 	}
 	req.Header.Set("Origin", socket.Origin)
 	req.Header.Set("Referer", socket.Origin+"/")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := directMediaHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/wa/media.go
+++ b/internal/wa/media.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -28,11 +29,17 @@ var directMediaBaseURL = "https://mmg.whatsapp.net"
 var directMediaHTTPClient = newDirectMediaHTTPClient()
 
 func newDirectMediaHTTPClient() *http.Client {
+	dialer := &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
 	return &http.Client{
-		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
 			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           dialer.DialContext,
+			TLSHandshakeTimeout:   10 * time.Second,
 			ResponseHeaderTimeout: 10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
 			IdleConnTimeout:       30 * time.Second,
 			MaxIdleConns:          10,
 			MaxIdleConnsPerHost:   4,

--- a/internal/wa/media_timeout_test.go
+++ b/internal/wa/media_timeout_test.go
@@ -46,6 +46,9 @@ func TestNewDirectMediaHTTPClientBoundsPhasesWithoutTotalBodyTimeout(t *testing.
 	if transport.MaxIdleConnsPerHost <= 0 {
 		t.Fatalf("max idle connections per host = %d, want positive limit", transport.MaxIdleConnsPerHost)
 	}
+
+	t.Logf("direct media behavior: client.Timeout=%s, so valid response bodies keep the caller context budget", client.Timeout)
+	t.Logf("direct media behavior: phase bounds active: TLSHandshakeTimeout=%s ResponseHeaderTimeout=%s ExpectContinueTimeout=%s IdleConnTimeout=%s MaxIdleConns=%d MaxIdleConnsPerHost=%d", transport.TLSHandshakeTimeout, transport.ResponseHeaderTimeout, transport.ExpectContinueTimeout, transport.IdleConnTimeout, transport.MaxIdleConns, transport.MaxIdleConnsPerHost)
 }
 
 func TestDownloadDirectBytesUsesDedicatedHTTPClient(t *testing.T) {
@@ -60,6 +63,7 @@ func TestDownloadDirectBytesUsesDedicatedHTTPClient(t *testing.T) {
 			if req.Header.Get("Origin") == "" || req.Header.Get("Referer") == "" {
 				t.Fatalf("missing WhatsApp media request headers")
 			}
+			t.Logf("direct media behavior: dedicated directMediaHTTPClient handled request host=%s path=%s origin_header_present=%t referer_header_present=%t", req.URL.Host, req.URL.Path, req.Header.Get("Origin") != "", req.Header.Get("Referer") != "")
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     make(http.Header),
@@ -82,6 +86,7 @@ func TestDownloadDirectBytesUsesDedicatedHTTPClient(t *testing.T) {
 	if string(got) != "media bytes" {
 		t.Fatalf("downloadDirectBytes = %q, want media bytes", string(got))
 	}
+	t.Logf("direct media behavior: downloadDirectBytes used dedicated client and returned %d bytes", len(got))
 }
 
 func TestDownloadDirectBytesFailsFastWhenServerStallsBeforeHeaders(t *testing.T) {
@@ -103,12 +108,14 @@ func TestDownloadDirectBytesFailsFastWhenServerStallsBeforeHeaders(t *testing.T)
 
 	start := time.Now()
 	_, err := downloadDirectBytes(context.Background(), server.URL+"/voice.ogg")
+	elapsed := time.Since(start)
 	if err == nil {
 		t.Fatalf("downloadDirectBytes succeeded, want response header timeout error")
 	}
-	if elapsed := time.Since(start); elapsed > time.Second {
+	if elapsed > time.Second {
 		t.Fatalf("downloadDirectBytes elapsed = %s, want bounded failure under 1s", elapsed)
 	}
+	t.Logf("direct media behavior: pre-header stall failed in %s with error %q", elapsed, err.Error())
 }
 
 func TestDownloadDirectBytesAllowsSlowBodyAfterHeaders(t *testing.T) {
@@ -130,11 +137,17 @@ func TestDownloadDirectBytesAllowsSlowBodyAfterHeaders(t *testing.T) {
 		directMediaHTTPClient = oldClient
 	}()
 
+	start := time.Now()
 	got, err := downloadDirectBytes(context.Background(), server.URL+"/voice.ogg")
+	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("downloadDirectBytes: %v", err)
 	}
 	if string(got) != "slow body" {
 		t.Fatalf("downloadDirectBytes = %q, want slow body", string(got))
 	}
+	if elapsed < 150*time.Millisecond {
+		t.Fatalf("downloadDirectBytes elapsed = %s, want slow body delay to be observed", elapsed)
+	}
+	t.Logf("direct media behavior: headers arrived before the 50ms ResponseHeaderTimeout, then slow body completed in %s and returned %d bytes", elapsed, len(got))
 }

--- a/internal/wa/media_timeout_test.go
+++ b/internal/wa/media_timeout_test.go
@@ -16,17 +16,26 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
-func TestNewDirectMediaHTTPClientHasTimeouts(t *testing.T) {
+func TestNewDirectMediaHTTPClientBoundsPhasesWithoutTotalBodyTimeout(t *testing.T) {
 	client := newDirectMediaHTTPClient()
-	if client.Timeout <= 0 {
-		t.Fatalf("direct media HTTP client timeout = %s, want positive timeout", client.Timeout)
+	if client.Timeout != 0 {
+		t.Fatalf("direct media HTTP client timeout = %s, want zero to preserve caller/body budget", client.Timeout)
 	}
 	transport, ok := client.Transport.(*http.Transport)
 	if !ok {
 		t.Fatalf("direct media HTTP client transport = %T, want *http.Transport", client.Transport)
 	}
+	if transport.DialContext == nil {
+		t.Fatalf("dial context is nil, want bounded dialer")
+	}
+	if transport.TLSHandshakeTimeout <= 0 {
+		t.Fatalf("TLS handshake timeout = %s, want positive timeout", transport.TLSHandshakeTimeout)
+	}
 	if transport.ResponseHeaderTimeout <= 0 {
 		t.Fatalf("response header timeout = %s, want positive timeout", transport.ResponseHeaderTimeout)
+	}
+	if transport.ExpectContinueTimeout <= 0 {
+		t.Fatalf("expect continue timeout = %s, want positive timeout", transport.ExpectContinueTimeout)
 	}
 	if transport.IdleConnTimeout <= 0 {
 		t.Fatalf("idle connection timeout = %s, want positive timeout", transport.IdleConnTimeout)
@@ -75,7 +84,7 @@ func TestDownloadDirectBytesUsesDedicatedHTTPClient(t *testing.T) {
 	}
 }
 
-func TestDownloadDirectBytesFailsFastWhenServerStalls(t *testing.T) {
+func TestDownloadDirectBytesFailsFastWhenServerStallsBeforeHeaders(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
 		case <-r.Context().Done():
@@ -85,7 +94,9 @@ func TestDownloadDirectBytesFailsFastWhenServerStalls(t *testing.T) {
 	defer server.Close()
 
 	oldClient := directMediaHTTPClient
-	directMediaHTTPClient = &http.Client{Timeout: 50 * time.Millisecond}
+	directMediaHTTPClient = &http.Client{
+		Transport: &http.Transport{ResponseHeaderTimeout: 50 * time.Millisecond},
+	}
 	defer func() {
 		directMediaHTTPClient = oldClient
 	}()
@@ -93,9 +104,37 @@ func TestDownloadDirectBytesFailsFastWhenServerStalls(t *testing.T) {
 	start := time.Now()
 	_, err := downloadDirectBytes(context.Background(), server.URL+"/voice.ogg")
 	if err == nil {
-		t.Fatalf("downloadDirectBytes succeeded, want timeout error")
+		t.Fatalf("downloadDirectBytes succeeded, want response header timeout error")
 	}
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Fatalf("downloadDirectBytes elapsed = %s, want bounded failure under 1s", elapsed)
+	}
+}
+
+func TestDownloadDirectBytesAllowsSlowBodyAfterHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		time.Sleep(150 * time.Millisecond)
+		_, _ = w.Write([]byte("slow body"))
+	}))
+	defer server.Close()
+
+	oldClient := directMediaHTTPClient
+	directMediaHTTPClient = &http.Client{
+		Transport: &http.Transport{ResponseHeaderTimeout: 50 * time.Millisecond},
+	}
+	defer func() {
+		directMediaHTTPClient = oldClient
+	}()
+
+	got, err := downloadDirectBytes(context.Background(), server.URL+"/voice.ogg")
+	if err != nil {
+		t.Fatalf("downloadDirectBytes: %v", err)
+	}
+	if string(got) != "slow body" {
+		t.Fatalf("downloadDirectBytes = %q, want slow body", string(got))
 	}
 }

--- a/internal/wa/media_timeout_test.go
+++ b/internal/wa/media_timeout_test.go
@@ -1,0 +1,57 @@
+package wa
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewDirectMediaHTTPClientHasTimeouts(t *testing.T) {
+	client := newDirectMediaHTTPClient()
+	if client.Timeout <= 0 {
+		t.Fatalf("direct media HTTP client timeout = %s, want positive timeout", client.Timeout)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("direct media HTTP client transport = %T, want *http.Transport", client.Transport)
+	}
+	if transport.ResponseHeaderTimeout <= 0 {
+		t.Fatalf("response header timeout = %s, want positive timeout", transport.ResponseHeaderTimeout)
+	}
+	if transport.IdleConnTimeout <= 0 {
+		t.Fatalf("idle connection timeout = %s, want positive timeout", transport.IdleConnTimeout)
+	}
+	if transport.MaxIdleConns <= 0 {
+		t.Fatalf("max idle connections = %d, want positive limit", transport.MaxIdleConns)
+	}
+	if transport.MaxIdleConnsPerHost <= 0 {
+		t.Fatalf("max idle connections per host = %d, want positive limit", transport.MaxIdleConnsPerHost)
+	}
+}
+
+func TestDownloadDirectBytesUsesBoundedHTTPClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(5 * time.Second):
+		}
+	}))
+	defer server.Close()
+
+	oldClient := directMediaHTTPClient
+	directMediaHTTPClient = &http.Client{Timeout: 50 * time.Millisecond}
+	defer func() {
+		directMediaHTTPClient = oldClient
+	}()
+
+	start := time.Now()
+	_, err := downloadDirectBytes(context.Background(), server.URL+"/voice.ogg")
+	if err == nil {
+		t.Fatalf("downloadDirectBytes succeeded, want timeout error")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("downloadDirectBytes elapsed = %s, want bounded failure under 1s", elapsed)
+	}
+}

--- a/internal/wa/media_timeout_test.go
+++ b/internal/wa/media_timeout_test.go
@@ -26,7 +26,10 @@ func TestNewDirectMediaHTTPClientBoundsPhasesWithoutTotalBodyTimeout(t *testing.
 		t.Fatalf("direct media HTTP client transport = %T, want *http.Transport", client.Transport)
 	}
 	if transport.DialContext == nil {
-		t.Fatalf("dial context is nil, want bounded dialer")
+		t.Fatalf("dial context is nil, want default transport dialer")
+	}
+	if !transport.ForceAttemptHTTP2 {
+		t.Fatalf("ForceAttemptHTTP2 = false, want default transport HTTP/2 behavior preserved")
 	}
 	if transport.TLSHandshakeTimeout <= 0 {
 		t.Fatalf("TLS handshake timeout = %s, want positive timeout", transport.TLSHandshakeTimeout)
@@ -43,12 +46,9 @@ func TestNewDirectMediaHTTPClientBoundsPhasesWithoutTotalBodyTimeout(t *testing.
 	if transport.MaxIdleConns <= 0 {
 		t.Fatalf("max idle connections = %d, want positive limit", transport.MaxIdleConns)
 	}
-	if transport.MaxIdleConnsPerHost <= 0 {
-		t.Fatalf("max idle connections per host = %d, want positive limit", transport.MaxIdleConnsPerHost)
-	}
-
 	t.Logf("direct media behavior: client.Timeout=%s, so valid response bodies keep the caller context budget", client.Timeout)
-	t.Logf("direct media behavior: phase bounds active: TLSHandshakeTimeout=%s ResponseHeaderTimeout=%s ExpectContinueTimeout=%s IdleConnTimeout=%s MaxIdleConns=%d MaxIdleConnsPerHost=%d", transport.TLSHandshakeTimeout, transport.ResponseHeaderTimeout, transport.ExpectContinueTimeout, transport.IdleConnTimeout, transport.MaxIdleConns, transport.MaxIdleConnsPerHost)
+	t.Logf("direct media behavior: default transport semantics preserved: ForceAttemptHTTP2=%t DialContextPresent=%t MaxIdleConnsPerHost=%d", transport.ForceAttemptHTTP2, transport.DialContext != nil, transport.MaxIdleConnsPerHost)
+	t.Logf("direct media behavior: phase bounds active: TLSHandshakeTimeout=%s ResponseHeaderTimeout=%s ExpectContinueTimeout=%s IdleConnTimeout=%s MaxIdleConns=%d", transport.TLSHandshakeTimeout, transport.ResponseHeaderTimeout, transport.ExpectContinueTimeout, transport.IdleConnTimeout, transport.MaxIdleConns)
 }
 
 func TestDownloadDirectBytesUsesDedicatedHTTPClient(t *testing.T) {

--- a/internal/wa/media_timeout_test.go
+++ b/internal/wa/media_timeout_test.go
@@ -2,11 +2,19 @@ package wa
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestNewDirectMediaHTTPClientHasTimeouts(t *testing.T) {
 	client := newDirectMediaHTTPClient()
@@ -31,7 +39,43 @@ func TestNewDirectMediaHTTPClientHasTimeouts(t *testing.T) {
 	}
 }
 
-func TestDownloadDirectBytesUsesBoundedHTTPClient(t *testing.T) {
+func TestDownloadDirectBytesUsesDedicatedHTTPClient(t *testing.T) {
+	oldClient := directMediaHTTPClient
+	called := false
+	directMediaHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			called = true
+			if got, want := req.URL.String(), "https://example.test/voice.ogg"; got != want {
+				t.Fatalf("request URL = %q, want %q", got, want)
+			}
+			if req.Header.Get("Origin") == "" || req.Header.Get("Referer") == "" {
+				t.Fatalf("missing WhatsApp media request headers")
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("media bytes")),
+				Request:    req,
+			}, nil
+		}),
+	}
+	defer func() {
+		directMediaHTTPClient = oldClient
+	}()
+
+	got, err := downloadDirectBytes(context.Background(), "https://example.test/voice.ogg")
+	if err != nil {
+		t.Fatalf("downloadDirectBytes: %v", err)
+	}
+	if !called {
+		t.Fatalf("dedicated direct media HTTP client was not used")
+	}
+	if string(got) != "media bytes" {
+		t.Fatalf("downloadDirectBytes = %q, want media bytes", string(got))
+	}
+}
+
+func TestDownloadDirectBytesFailsFastWhenServerStalls(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
 		case <-r.Context().Done():


### PR DESCRIPTION
## Summary

Bounds direct WhatsApp media downloads with an explicit HTTP client instead of `http.DefaultClient`.

The direct-media fallback already limits response body size and validates hashes/HMACs, but the transport path had no explicit response-header bound. A media endpoint that accepts a request but stalls before response headers could hold a direct media download until the caller context is canceled.

## What changed

- Add a package-scoped direct media HTTP client.
- Preserve `http.DefaultTransport` behavior by cloning the default transport.
- Preserve default HTTP/2 negotiation with `ForceAttemptHTTP2=true`.
- Add a 10s response-header timeout.
- Route `downloadDirectBytes` through the bounded client instead of `http.DefaultClient`.
- Preserve the existing caller/body download budget by intentionally leaving `http.Client.Timeout` unset.

## Security impact

This reduces denial-of-service risk in long-running sync/media workflows. A media server or network path that accepts a request but never returns headers should no longer pin the direct media download path indefinitely.

## Compatibility notes after review

The earlier version used `http.Client.Timeout: 30 * time.Second`. ClawSweeper correctly flagged that as too broad because `http.Client.Timeout` covers the full request, including reading a valid response body. This revision leaves `http.Client.Timeout` unset so valid response bodies keep the caller context budget.

The next review flagged that constructing a fresh `http.Transport` changed default transport behavior, including HTTP/2 negotiation. This revision now clones `http.DefaultTransport` and only adds `ResponseHeaderTimeout`, preserving the default dialer, TLS behavior, idle pool behavior, proxy behavior, and `ForceAttemptHTTP2=true`.

## Behavior proof

### Default transport semantics preserved and no total body timeout

```text
=== RUN   TestNewDirectMediaHTTPClientBoundsPhasesWithoutTotalBodyTimeout
    media_timeout_test.go:49: direct media behavior: client.Timeout=0s, so valid response bodies keep the caller context budget
    media_timeout_test.go:50: direct media behavior: default transport semantics preserved: ForceAttemptHTTP2=true DialContextPresent=true MaxIdleConnsPerHost=0
    media_timeout_test.go:51: direct media behavior: phase bounds active: TLSHandshakeTimeout=10s ResponseHeaderTimeout=10s ExpectContinueTimeout=1s IdleConnTimeout=1m30s MaxIdleConns=100
--- PASS: TestNewDirectMediaHTTPClientBoundsPhasesWithoutTotalBodyTimeout (0.00s)
PASS
ok      github.com/openclaw/wacli/internal/wa   0.004s
```

This proves the current patch preserves the default transport's HTTP/2 behavior while adding the response-header bound. `MaxIdleConnsPerHost=0` is the preserved default transport value, not a custom override.

### `downloadDirectBytes` uses the dedicated direct media client

```text
=== RUN   TestDownloadDirectBytesUsesDedicatedHTTPClient
    media_timeout_test.go:66: direct media behavior: dedicated directMediaHTTPClient handled request host=example.test path=/voice.ogg origin_header_present=true referer_header_present=true
    media_timeout_test.go:89: direct media behavior: downloadDirectBytes used dedicated client and returned 11 bytes
--- PASS: TestDownloadDirectBytesUsesDedicatedHTTPClient (0.00s)
PASS
ok      github.com/openclaw/wacli/internal/wa   0.004s
```

This proves `downloadDirectBytes` is routed through `directMediaHTTPClient`. If the implementation regresses back to `http.DefaultClient.Do(req)`, the injected transport is not called and this test fails.

### Pre-header stall is bounded

```text
=== RUN   TestDownloadDirectBytesFailsFastWhenServerStallsBeforeHeaders
    media_timeout_test.go:118: direct media behavior: pre-header stall failed in 50.768278ms with error "Get \"http://127.0.0.1:38689/voice.ogg\": net/http: timeout awaiting response headers"
--- PASS: TestDownloadDirectBytesFailsFastWhenServerStallsBeforeHeaders (0.05s)
PASS
ok      github.com/openclaw/wacli/internal/wa   0.055s
```

This proves a server that accepts the request but does not return headers is bounded by `ResponseHeaderTimeout`.

### Slow body still succeeds after headers

```text
=== RUN   TestDownloadDirectBytesAllowsSlowBodyAfterHeaders
    media_timeout_test.go:152: direct media behavior: headers arrived before the 50ms ResponseHeaderTimeout, then slow body completed in 151.207465ms and returned 9 bytes
--- PASS: TestDownloadDirectBytesAllowsSlowBodyAfterHeaders (0.15s)
PASS
ok      github.com/openclaw/wacli/internal/wa   0.156s
```

This directly addresses the earlier timeout-policy concern. `ResponseHeaderTimeout` bounds only the pre-header phase; it does not cap the response body after headers arrive.

## Live direct-media proof from synced store

The following was run locally from the PR branch against a real authenticated and synced `wacli` store. Private identifiers are redacted.

Store status before proof:

```text
STORE             /home/rev/.local/state/wacli
LOCKED            false
AUTHENTICATED     true
LINKED_JID        <REDACTED_LINKED_JID>
CONNECTED         false
CONNECTION_STATE  disconnected
FTS5              false
MESSAGES          5835
CHATS             33
CONTACTS          13
GROUPS            3
LAST_SYNC         2026-05-29T18:55:27Z
```

A downloadable media candidate was selected from the synced local DB with chat JID, message ID, and filename redacted:

```text
Found candidate media row:
chat=<REDACTED_CHAT_JID>
id=<REDACTED_MESSAGE_ID>
media_type=image
mime_type=image/jpeg
filename=<REDACTED>
file_length=53820
```

The real read-only direct-media CLI path was then executed using the selected chat and message ID:

```bash
/tmp/wacli-pr271 --read-only --json media download \
  --chat "<REDACTED_CHAT_JID>" \
  --id "<REDACTED_MESSAGE_ID>" \
  --output /tmp/wacli-pr271-proof-media.bin
```

The command completed successfully and wrote the downloaded media file:

```text
-rw------- 1 rev rev 53K May 29 17:42 /tmp/wacli-pr271-proof-media.bin
/tmp/wacli-pr271-proof-media.bin: JPEG image data, JFIF standard 1.01, aspect ratio, density 1x1, segment length 16, progressive, precision 8, 720x1280, components 3
```

This proves the changed direct-media path works against a real synced WhatsApp media item, not only against unit-test servers. No JIDs, message IDs, direct paths, media keys, hashes, contact names, or private filenames are included in this proof.

## Validation

Package validation:

```text
ok      github.com/openclaw/wacli/internal/wa   0.215s
```

Full repo validation:

```text
ok      github.com/openclaw/wacli/cmd/wacli     0.302s
ok      github.com/openclaw/wacli/internal/app  6.189s
ok      github.com/openclaw/wacli/internal/config       0.003s
ok      github.com/openclaw/wacli/internal/fsutil       0.003s
ok      github.com/openclaw/wacli/internal/linkpreview  0.007s
ok      github.com/openclaw/wacli/internal/lock 0.057s
ok      github.com/openclaw/wacli/internal/out  0.002s
ok      github.com/openclaw/wacli/internal/pathutil     0.004s
ok      github.com/openclaw/wacli/internal/resolve      0.004s
ok      github.com/openclaw/wacli/internal/sqliteutil   0.003s
ok      github.com/openclaw/wacli/internal/store        0.421s
?       github.com/openclaw/wacli/internal/store/storedb        [no test files]
ok      github.com/openclaw/wacli/internal/syscontacts  0.002s
ok      github.com/openclaw/wacli/internal/wa   0.220s
```

## Current GitHub Actions status

Fork-triggered workflow runs still require maintainer approval before they execute. Local behavior proof, live direct-media proof, and full local test validation are included above.

Current proof head: `eef1045e41725103cd195952ea5795c47f8f03f9`.