### PR TITLE
feat(presence): delegate typing/paused through the send socket when the store is locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Groups: add live admin commands for creating groups, setting descriptions, toggling announce-only and admin-only edits, and approving or rejecting join requests. (#265 - thanks @dovocoder)
 - Groups: include resolved phone numbers in pending join request output when LID mappings are available. (#273 - thanks @cielecki)
+- Presence: delegate typing and paused indicators through the sync daemon send socket when the store lock is held. (#272 - thanks @kidshaker)
 - Profile: add commands to remove the profile picture, set About text, set the profile display name, fetch profile picture metadata, fetch a user's About text, and fetch WhatsApp Business profile details. (#267 - thanks @dovocoder)
 - Sync: add opt-in keepalive-failure stale detection for `sync --follow` (`1s` to `<2m20s`), including forced reconnect, a `stale` NDJSON event, a private store `HEARTBEAT`, and `doctor --json` `last_activity_at`. (#278 - thanks @thedavidweng)
 

--- a/cmd/wacli/presence.go
+++ b/cmd/wacli/presence.go
@@ -137,3 +137,14 @@ func presenceMediaFromString(media string) (types.ChatPresenceMedia, error) {
 		return "", fmt.Errorf("unsupported --media %q (supported: audio)", media)
 	}
 }
+
+func presenceStateFromString(state string) (types.ChatPresence, error) {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case string(types.ChatPresenceComposing):
+		return types.ChatPresenceComposing, nil
+	case string(types.ChatPresencePaused):
+		return types.ChatPresencePaused, nil
+	default:
+		return "", fmt.Errorf("unsupported presence state %q", state)
+	}
+}

--- a/cmd/wacli/presence.go
+++ b/cmd/wacli/presence.go
@@ -67,6 +67,18 @@ func runPresence(flags *rootFlags, to string, state types.ChatPresence, media st
 
 	a, lk, err := newApp(ctx, flags, true, false)
 	if err != nil {
+		resp, delegated, delegateErr := tryDelegateSend(ctx, flags, err, sendDelegateRequest{
+			Kind:          "presence",
+			To:            to,
+			PresenceState: string(state),
+			PresenceMedia: media,
+		})
+		if delegated {
+			if delegateErr != nil {
+				return delegateErr
+			}
+			return writePresenceOutput(flags, state, resp)
+		}
 		return err
 	}
 	defer closeApp(a, lk)
@@ -100,6 +112,18 @@ func runPresence(flags *rootFlags, to string, state types.ChatPresence, media st
 		})
 	}
 	fmt.Fprintf(os.Stdout, "Presence '%s' sent to %s\n", state, toJID.String())
+	return nil
+}
+
+func writePresenceOutput(flags *rootFlags, state types.ChatPresence, resp sendDelegateResponse) error {
+	if flags.asJSON {
+		return out.WriteJSON(os.Stdout, map[string]any{
+			"sent":  true,
+			"to":    resp.To,
+			"state": string(state),
+		})
+	}
+	fmt.Fprintf(os.Stdout, "Presence '%s' sent to %s\n", state, resp.To)
 	return nil
 }
 

--- a/cmd/wacli/presence.go
+++ b/cmd/wacli/presence.go
@@ -100,7 +100,9 @@ func runPresence(flags *rootFlags, to string, state types.ChatPresence, media st
 		return err
 	}
 
-	if err := a.WA().SendChatPresence(ctx, toJID, state, chatMedia); err != nil {
+	if err := sendPresenceWithRetry(ctx, reconnectForSend(a), func(ctx context.Context) error {
+		return a.WA().SendChatPresence(ctx, toJID, state, chatMedia)
+	}); err != nil {
 		return err
 	}
 
@@ -147,4 +149,11 @@ func presenceStateFromString(state string) (types.ChatPresence, error) {
 	default:
 		return "", fmt.Errorf("unsupported presence state %q", state)
 	}
+}
+
+func sendPresenceWithRetry(ctx context.Context, reconnect func(context.Context) error, send func(context.Context) error) error {
+	_, err := runSendOperation(ctx, reconnect, func(ctx context.Context) (struct{}, error) {
+		return struct{}{}, send(ctx)
+	})
+	return err
 }

--- a/cmd/wacli/presence_test.go
+++ b/cmd/wacli/presence_test.go
@@ -1,8 +1,18 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/openclaw/wacli/internal/lock"
 	"go.mau.fi/whatsmeow/types"
 )
 
@@ -36,4 +46,296 @@ func TestPresenceMediaFromString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPresenceStateFromString(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    types.ChatPresence
+		wantErr bool
+	}{
+		{name: "composing", input: "composing", want: types.ChatPresenceComposing},
+		{name: "paused", input: "paused", want: types.ChatPresencePaused},
+		{name: "trimmed case", input: " Paused ", want: types.ChatPresencePaused},
+		{name: "unknown", input: "available", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := presenceStateFromString(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("presenceStateFromString(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+const (
+	presenceDelegateHelperEnv     = "WACLI_PRESENCE_DELEGATE_HELPER"
+	presenceDelegateHelperArgsEnv = "WACLI_PRESENCE_DELEGATE_ARGS"
+)
+
+func TestPresenceDelegateHelper(t *testing.T) {
+	if os.Getenv(presenceDelegateHelperEnv) != "1" {
+		t.Skip("helper process only")
+	}
+	var args []string
+	if err := json.Unmarshal([]byte(os.Getenv(presenceDelegateHelperArgsEnv)), &args); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "decode helper args: %v\n", err)
+		os.Exit(2)
+	}
+	if err := execute(args); err != nil {
+		os.Exit(1)
+	}
+}
+
+func TestPresenceDelegatesThroughSendSocketWhenStoreLocked(t *testing.T) {
+	tests := []struct {
+		name      string
+		command   string
+		media     string
+		wantState string
+		wantMedia string
+	}{
+		{name: "typing", command: "typing", media: "audio", wantState: string(types.ChatPresenceComposing), wantMedia: "audio"},
+		{name: "paused", command: "paused", wantState: string(types.ChatPresencePaused)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storeDir := shortPresenceDelegateStoreDir(t)
+			lk, err := lock.Acquire(storeDir)
+			if err != nil {
+				t.Fatalf("lock store: %v", err)
+			}
+			defer lk.Release()
+
+			server := startPresenceDelegateTestSocket(t, storeDir, func(req sendDelegateRequest) sendDelegateResponse {
+				return sendDelegateResponse{OK: true, Sent: true, To: "15551234567@s.whatsapp.net"}
+			})
+			defer server.stop()
+
+			args := []string{"--store", storeDir, "--json", "--timeout", "750ms", "presence", tt.command, "--to", "+1 (555) 123-4567"}
+			if tt.media != "" {
+				args = append(args, "--media", tt.media)
+			}
+			stdout, stderr, err := runPresenceDelegateHelper(t, args)
+			if err != nil {
+				t.Fatalf("presence command failed: %v stdout=%q stderr=%q", err, stdout, stderr)
+			}
+
+			req := server.nextRequest(t)
+			if req.Version != sendDelegateVersion {
+				t.Fatalf("delegate version = %d, want %d", req.Version, sendDelegateVersion)
+			}
+			if req.Kind != "presence" {
+				t.Fatalf("delegate kind = %q, want presence", req.Kind)
+			}
+			if req.To != "+1 (555) 123-4567" {
+				t.Fatalf("delegate to = %q", req.To)
+			}
+			if req.PresenceState != tt.wantState {
+				t.Fatalf("delegate presence state = %q, want %q", req.PresenceState, tt.wantState)
+			}
+			if req.PresenceMedia != tt.wantMedia {
+				t.Fatalf("delegate presence media = %q, want %q", req.PresenceMedia, tt.wantMedia)
+			}
+			if req.TimeoutMS != 750 {
+				t.Fatalf("delegate timeout_ms = %d, want 750", req.TimeoutMS)
+			}
+			if strings.Contains(stderr, "store is locked") || strings.Contains(stderr, "not authenticated") || strings.Contains(stderr, "not connected") {
+				t.Fatalf("delegated command tried the direct store/client path: stderr=%q", stderr)
+			}
+
+			jsonLine := strings.SplitN(strings.TrimSpace(stdout), "\n", 2)[0]
+			var payload struct {
+				Success bool `json:"success"`
+				Data    struct {
+					Sent  bool   `json:"sent"`
+					To    string `json:"to"`
+					State string `json:"state"`
+				} `json:"data"`
+				Error *string `json:"error"`
+			}
+			if err := json.Unmarshal([]byte(jsonLine), &payload); err != nil {
+				t.Fatalf("decode stdout JSON %q: %v", stdout, err)
+			}
+			if !payload.Success || payload.Error != nil || !payload.Data.Sent || payload.Data.To != "15551234567@s.whatsapp.net" || payload.Data.State != tt.wantState {
+				t.Fatalf("stdout payload = %+v", payload)
+			}
+		})
+	}
+}
+
+func TestPresenceLockedStoreReturnsLockErrorWithoutDelegateSocket(t *testing.T) {
+	storeDir := shortPresenceDelegateStoreDir(t)
+	lk, err := lock.Acquire(storeDir)
+	if err != nil {
+		t.Fatalf("lock store: %v", err)
+	}
+	defer lk.Release()
+
+	stdout, stderr, err := runPresenceDelegateHelper(t, []string{"--store", storeDir, "--timeout", "750ms", "presence", "typing", "--to", "+15551234567"})
+	if err == nil {
+		t.Fatalf("presence command unexpectedly succeeded: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "store is locked") {
+		t.Fatalf("stderr = %q, want original lock error", stderr)
+	}
+	if strings.Contains(stderr, "send delegate unavailable") {
+		t.Fatalf("stderr leaked delegate fallback error: %q", stderr)
+	}
+}
+
+func TestPresenceDelegatePropagatesDaemonErrorWhenStoreLocked(t *testing.T) {
+	storeDir := shortPresenceDelegateStoreDir(t)
+	lk, err := lock.Acquire(storeDir)
+	if err != nil {
+		t.Fatalf("lock store: %v", err)
+	}
+	defer lk.Release()
+
+	server := startPresenceDelegateTestSocket(t, storeDir, func(req sendDelegateRequest) sendDelegateResponse {
+		return sendDelegateResponse{OK: false, Error: "daemon rejected presence"}
+	})
+	defer server.stop()
+
+	stdout, stderr, err := runPresenceDelegateHelper(t, []string{"--store", storeDir, "--timeout", "750ms", "presence", "paused", "--to", "+15551234567"})
+	if err == nil {
+		t.Fatalf("presence command unexpectedly succeeded: stdout=%q stderr=%q", stdout, stderr)
+	}
+	_ = server.nextRequest(t)
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "daemon rejected presence") {
+		t.Fatalf("stderr = %q, want daemon error", stderr)
+	}
+	if strings.Contains(stderr, "store is locked") {
+		t.Fatalf("stderr returned lock error instead of daemon error: %q", stderr)
+	}
+}
+
+func TestExecuteDelegatedSendRoutesPresenceValidation(t *testing.T) {
+	_, err := executeDelegatedSend(contextWithTestTimeout(t), nil, sendDelegateRequest{
+		Version:       sendDelegateVersion,
+		Kind:          "presence",
+		To:            "+15551234567",
+		PresenceState: "available",
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported presence state") {
+		t.Fatalf("executeDelegatedSend error = %v, want presence state validation", err)
+	}
+}
+
+type presenceDelegateTestServer struct {
+	requests chan presenceDelegateTestRequest
+	stop     func()
+}
+
+type presenceDelegateTestRequest struct {
+	req sendDelegateRequest
+	err error
+}
+
+func startPresenceDelegateTestSocket(t *testing.T, storeDir string, respond func(sendDelegateRequest) sendDelegateResponse) *presenceDelegateTestServer {
+	t.Helper()
+	ln, err := net.Listen("unix", sendDelegateSocketPath(storeDir))
+	if err != nil {
+		t.Fatalf("listen delegate socket: %v", err)
+	}
+	if err := os.Chmod(sendDelegateSocketPath(storeDir), 0o600); err != nil {
+		_ = ln.Close()
+		t.Fatalf("chmod delegate socket: %v", err)
+	}
+	requests := make(chan presenceDelegateTestRequest, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+
+		var req sendDelegateRequest
+		if err := json.NewDecoder(conn).Decode(&req); err != nil {
+			requests <- presenceDelegateTestRequest{err: err}
+			return
+		}
+		requests <- presenceDelegateTestRequest{req: req}
+		_ = json.NewEncoder(conn).Encode(respond(req))
+	}()
+
+	return &presenceDelegateTestServer{
+		requests: requests,
+		stop: func() {
+			_ = ln.Close()
+			<-done
+			_ = os.Remove(sendDelegateSocketPath(storeDir))
+		},
+	}
+}
+
+func (s *presenceDelegateTestServer) nextRequest(t *testing.T) sendDelegateRequest {
+	t.Helper()
+	select {
+	case got := <-s.requests:
+		if got.err != nil {
+			t.Fatalf("decode delegate request: %v", got.err)
+		}
+		return got.req
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for delegate request")
+		return sendDelegateRequest{}
+	}
+}
+
+func runPresenceDelegateHelper(t *testing.T, args []string) (string, string, error) {
+	t.Helper()
+	rawArgs, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal helper args: %v", err)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestPresenceDelegateHelper$")
+	cmd.Env = append(os.Environ(),
+		presenceDelegateHelperEnv+"=1",
+		presenceDelegateHelperArgsEnv+"="+string(rawArgs),
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	return stdout.String(), stderr.String(), err
+}
+
+func shortPresenceDelegateStoreDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "wacli-presence-*")
+	if err != nil {
+		t.Fatalf("temp store dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func contextWithTestTimeout(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	t.Cleanup(cancel)
+	return ctx
 }

--- a/cmd/wacli/presence_test.go
+++ b/cmd/wacli/presence_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -100,6 +102,8 @@ func TestPresenceDelegateHelper(t *testing.T) {
 }
 
 func TestPresenceDelegatesThroughSendSocketWhenStoreLocked(t *testing.T) {
+	skipPresenceDelegateSocketTestOnUnsupportedOS(t)
+
 	tests := []struct {
 		name      string
 		command   string
@@ -201,6 +205,8 @@ func TestPresenceLockedStoreReturnsLockErrorWithoutDelegateSocket(t *testing.T) 
 }
 
 func TestPresenceDelegatePropagatesDaemonErrorWhenStoreLocked(t *testing.T) {
+	skipPresenceDelegateSocketTestOnUnsupportedOS(t)
+
 	storeDir := shortPresenceDelegateStoreDir(t)
 	lk, err := lock.Acquire(storeDir)
 	if err != nil {
@@ -238,6 +244,30 @@ func TestExecuteDelegatedSendRoutesPresenceValidation(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "unsupported presence state") {
 		t.Fatalf("executeDelegatedSend error = %v, want presence state validation", err)
+	}
+}
+
+func TestSendPresenceWithRetryReconnectsOnNotConnected(t *testing.T) {
+	var sends int
+	var reconnects int
+	err := sendPresenceWithRetry(contextWithTestTimeout(t), func(context.Context) error {
+		reconnects++
+		return nil
+	}, func(context.Context) error {
+		sends++
+		if sends == 1 {
+			return errors.New("not connected")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("sendPresenceWithRetry: %v", err)
+	}
+	if sends != 2 {
+		t.Fatalf("send attempts = %d, want 2", sends)
+	}
+	if reconnects != 1 {
+		t.Fatalf("reconnects = %d, want 1", reconnects)
 	}
 }
 
@@ -325,12 +355,25 @@ func runPresenceDelegateHelper(t *testing.T, args []string) (string, string, err
 
 func shortPresenceDelegateStoreDir(t *testing.T) string {
 	t.Helper()
-	dir, err := os.MkdirTemp("/tmp", "wacli-presence-*")
+	base := os.TempDir()
+	if runtime.GOOS == "darwin" {
+		// Darwin has a short sockaddr_un path limit; the default TMPDIR under
+		// /var/folders is often too long for .send.sock integration tests.
+		base = "/tmp"
+	}
+	dir, err := os.MkdirTemp(base, "wacli-presence-*")
 	if err != nil {
 		t.Fatalf("temp store dir: %v", err)
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 	return dir
+}
+
+func skipPresenceDelegateSocketTestOnUnsupportedOS(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix send delegate socket integration is not available on Windows")
+	}
 }
 
 func contextWithTestTimeout(t *testing.T) context.Context {

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -221,6 +221,10 @@ func executeDelegatedSend(parent context.Context, a *app.App, req sendDelegateRe
 }
 
 func executeDelegatedPresence(ctx context.Context, a *app.App, req sendDelegateRequest) (sendDelegateResponse, error) {
+	state, err := presenceStateFromString(req.PresenceState)
+	if err != nil {
+		return sendDelegateResponse{}, err
+	}
 	toJID, err := wa.ParseUserOrJID(req.To)
 	if err != nil {
 		return sendDelegateResponse{}, err
@@ -230,7 +234,7 @@ func executeDelegatedPresence(ctx context.Context, a *app.App, req sendDelegateR
 	if err != nil {
 		return sendDelegateResponse{}, err
 	}
-	if err := a.WA().SendChatPresence(ctx, toJID, types.ChatPresence(req.PresenceState), chatMedia); err != nil {
+	if err := a.WA().SendChatPresence(ctx, toJID, state, chatMedia); err != nil {
 		return sendDelegateResponse{}, err
 	}
 	return sendDelegateResponse{OK: true, Sent: true, To: toJID.String()}, nil

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openclaw/wacli/internal/app"
 	"github.com/openclaw/wacli/internal/lock"
 	"github.com/openclaw/wacli/internal/out"
+	"github.com/openclaw/wacli/internal/wa"
 	"go.mau.fi/whatsmeow/types"
 )
 
@@ -52,6 +53,8 @@ type sendDelegateRequest struct {
 	Question             string   `json:"question,omitempty"`
 	Options              []string `json:"options,omitempty"`
 	Selectable           int      `json:"selectable,omitempty"`
+	PresenceState        string   `json:"presence_state,omitempty"`
+	PresenceMedia        string   `json:"presence_media,omitempty"`
 	PostSendWaitMS       int64    `json:"post_send_wait_ms,omitempty"`
 	TimeoutMS            int64    `json:"timeout_ms,omitempty"`
 }
@@ -210,9 +213,27 @@ func executeDelegatedSend(parent context.Context, a *app.App, req sendDelegateRe
 		return executeDelegatedPollVote(ctx, a, req)
 	case "button_list_select":
 		return executeDelegatedButtonListSelect(ctx, a, req)
+	case "presence":
+		return executeDelegatedPresence(ctx, a, req)
 	default:
 		return sendDelegateResponse{}, fmt.Errorf("unsupported send kind %q", req.Kind)
 	}
+}
+
+func executeDelegatedPresence(ctx context.Context, a *app.App, req sendDelegateRequest) (sendDelegateResponse, error) {
+	toJID, err := wa.ParseUserOrJID(req.To)
+	if err != nil {
+		return sendDelegateResponse{}, err
+	}
+	toJID = warmupDelegatedRecipient(ctx, a, toJID)
+	chatMedia, err := presenceMediaFromString(req.PresenceMedia)
+	if err != nil {
+		return sendDelegateResponse{}, err
+	}
+	if err := a.WA().SendChatPresence(ctx, toJID, types.ChatPresence(req.PresenceState), chatMedia); err != nil {
+		return sendDelegateResponse{}, err
+	}
+	return sendDelegateResponse{OK: true, Sent: true, To: toJID.String()}, nil
 }
 
 func executeDelegatedText(ctx context.Context, a *app.App, req sendDelegateRequest) (sendDelegateResponse, error) {

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -234,7 +234,9 @@ func executeDelegatedPresence(ctx context.Context, a *app.App, req sendDelegateR
 	if err != nil {
 		return sendDelegateResponse{}, err
 	}
-	if err := a.WA().SendChatPresence(ctx, toJID, state, chatMedia); err != nil {
+	if err := sendPresenceWithRetry(ctx, reconnectForSend(a), func(ctx context.Context) error {
+		return a.WA().SendChatPresence(ctx, toJID, state, chatMedia)
+	}); err != nil {
 		return sendDelegateResponse{}, err
 	}
 	return sendDelegateResponse{OK: true, Sent: true, To: toJID.String()}, nil

--- a/cmd/wacli/send_ipc_test.go
+++ b/cmd/wacli/send_ipc_test.go
@@ -86,6 +86,39 @@ func TestSendDelegateRequestPreservesEphemeralInJSON(t *testing.T) {
 	}
 }
 
+func TestSendDelegateRequestPreservesPresenceInJSON(t *testing.T) {
+	raw, err := json.Marshal(sendDelegateRequest{
+		Version:       sendDelegateVersion,
+		Kind:          "presence",
+		To:            "+33600000000",
+		PresenceState: "composing",
+		PresenceMedia: "audio",
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"presence_state":"composing"`) {
+		t.Fatalf("encoded request missing presence state: %s", raw)
+	}
+	if !strings.Contains(string(raw), `"presence_media":"audio"`) {
+		t.Fatalf("encoded request missing presence media: %s", raw)
+	}
+
+	var got sendDelegateRequest
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Kind != "presence" {
+		t.Fatalf("Kind = %q, want presence", got.Kind)
+	}
+	if got.PresenceState != "composing" {
+		t.Fatalf("PresenceState = %q, want composing", got.PresenceState)
+	}
+	if got.PresenceMedia != "audio" {
+		t.Fatalf("PresenceMedia = %q, want audio", got.PresenceMedia)
+	}
+}
+
 func TestRemoveStaleSendDelegateSocketRefusesRegularFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), sendDelegateSocketName)
 	if err := fsutil.WritePrivateFile(path, []byte("not a socket")); err != nil {


### PR DESCRIPTION
## Problem

`wacli presence typing|paused` fails with a store-lock error whenever a `sync --follow` daemon is running. The presence command opens its own client and tries to take the exclusive store lock, but the daemon holds that lock continuously, so presence always errors with `store is locked`.

The `send` family of commands already solves this: when the lock is held they delegate the operation to the running daemon through the `.send.sock` Unix socket. Chat presence was never wired into that path, so the WhatsApp "typing…" indicator can't be sent while the sync daemon runs.

## Change

Extends the existing send-delegation mechanism to chat presence, mirroring the `react` path exactly:

- `send_ipc.go`: adds `presence_state` / `presence_media` fields to `sendDelegateRequest`, a `case "presence"` in `executeDelegatedSend`, and an `executeDelegatedPresence` handler that calls `a.WA().SendChatPresence(...)` on the daemon side.
- `presence.go`: when `newApp` fails on a held lock, `runPresence` now calls `tryDelegateSend` (same pattern as `send react`) instead of returning the lock error.
- `send_ipc_test.go`: JSON round-trip test for the new presence fields.

No behavior change when no daemon socket is present: `tryDelegateSend` only triggers when the error is a lock error **and** the socket exists, otherwise the original error is returned unchanged.

## Testing

- `go build ./...` ✓
- `go vet ./cmd/wacli/` ✓
- `go test ./cmd/wacli/` ✓ (existing suite + new test)

Closes #239