### PR TITLE
feat(groups): resolve LID to phone number in requests list output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Groups: add live admin commands for creating groups, setting descriptions, toggling announce-only and admin-only edits, and approving or rejecting join requests. (#265 - thanks @dovocoder)
+- Groups: include resolved phone numbers in pending join request output when LID mappings are available. (#273 - thanks @cielecki)
 - Profile: add commands to remove the profile picture, set About text, set the profile display name, fetch profile picture metadata, fetch a user's About text, and fetch WhatsApp Business profile details. (#267 - thanks @dovocoder)
 - Sync: add opt-in keepalive-failure stale detection for `sync --follow` (`1s` to `<2m20s`), including forced reconnect, a `stale` NDJSON event, a private store `HEARTBEAT`, and `doctor --json` `last_activity_at`. (#278 - thanks @thedavidweng)
 

--- a/cmd/wacli/groups_admin.go
+++ b/cmd/wacli/groups_admin.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	appcore "github.com/openclaw/wacli/internal/app"
 	"github.com/openclaw/wacli/internal/out"
@@ -227,6 +228,32 @@ func newGroupsRequestsCmd(flags *rootFlags) *cobra.Command {
 	return cmd
 }
 
+// requestListEntry is the JSON/text output shape for a single pending join request.
+type requestListEntry struct {
+	JID         string    `json:"JID"`
+	PhoneNumber string    `json:"phone_number,omitempty"`
+	RequestedAt time.Time `json:"RequestedAt"`
+}
+
+// resolveRequestEntries converts raw join-request participants to output entries,
+// resolving LID JIDs to phone numbers via the provided resolver function.
+func resolveRequestEntries(ctx context.Context, requests []types.GroupParticipantRequest, resolve func(context.Context, types.JID) types.JID) []requestListEntry {
+	entries := make([]requestListEntry, len(requests))
+	for i, req := range requests {
+		pn := resolve(ctx, req.JID)
+		phone := ""
+		if pn.Server == types.DefaultUserServer {
+			phone = "+" + pn.User
+		}
+		entries[i] = requestListEntry{
+			JID:         req.JID.String(),
+			PhoneNumber: phone,
+			RequestedAt: req.RequestedAt,
+		}
+	}
+	return entries
+}
+
 func newGroupsRequestsListCmd(flags *rootFlags) *cobra.Command {
 	var jidStr string
 	cmd := &cobra.Command{
@@ -259,11 +286,14 @@ func newGroupsRequestsListCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			entries := resolveRequestEntries(ctx, requests, a.WA().ResolveLIDToPN)
+
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, requests)
+				return out.WriteJSON(os.Stdout, entries)
 			}
-			for _, req := range requests {
-				fmt.Fprintf(os.Stdout, "%s\t%s\n", req.JID.String(), req.RequestedAt.Local().Format("2006-01-02 15:04:05"))
+			for _, e := range entries {
+				fmt.Fprintf(os.Stdout, "%s\t%s\t%s\n", e.JID, e.RequestedAt.Local().Format("2006-01-02 15:04:05"), e.PhoneNumber)
 			}
 			return nil
 		},

--- a/cmd/wacli/groups_admin_test.go
+++ b/cmd/wacli/groups_admin_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.mau.fi/whatsmeow/types"
@@ -101,4 +105,131 @@ func toggleTestCmd() *cobra.Command {
 	cmd.Flags().Bool("on", false, "")
 	cmd.Flags().Bool("off", false, "")
 	return cmd
+}
+
+func TestGroupsRequestsListRegistered(t *testing.T) {
+	cmd := newGroupsCmd(&rootFlags{})
+	got, _, err := cmd.Find([]string{"requests", "list"})
+	if err != nil || got == nil || got.Name() != "list" {
+		t.Fatalf("groups requests list not registered: got=%v err=%v", got, err)
+	}
+	if f := got.Flags().Lookup("jid"); f == nil {
+		t.Fatal("--jid flag missing from groups requests list")
+	}
+}
+
+func TestGroupsRequestsActionRegistered(t *testing.T) {
+	cmd := newGroupsCmd(&rootFlags{})
+	for _, sub := range []string{"approve", "reject"} {
+		got, _, err := cmd.Find([]string{"requests", sub})
+		if err != nil || got == nil || got.Name() != sub {
+			t.Fatalf("groups requests %s not registered: got=%v err=%v", sub, got, err)
+		}
+		if f := got.Flags().Lookup("jid"); f == nil {
+			t.Fatalf("--jid flag missing from groups requests %s", sub)
+		}
+		if f := got.Flags().Lookup("user"); f == nil {
+			t.Fatalf("--user flag missing from groups requests %s", sub)
+		}
+	}
+}
+
+func TestResolveRequestEntriesResolved(t *testing.T) {
+	lid, _ := types.ParseJID("12345@lid")
+	pn, _ := types.ParseJID("48600000001@s.whatsapp.net")
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	requests := []types.GroupParticipantRequest{{JID: lid, RequestedAt: ts}}
+	resolver := func(_ context.Context, j types.JID) types.JID { return pn }
+
+	entries := resolveRequestEntries(context.Background(), requests, resolver)
+
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	if entries[0].JID != lid.String() {
+		t.Errorf("JID = %q, want %q", entries[0].JID, lid.String())
+	}
+	if entries[0].PhoneNumber != "+48600000001" {
+		t.Errorf("PhoneNumber = %q, want %q", entries[0].PhoneNumber, "+48600000001")
+	}
+	if !entries[0].RequestedAt.Equal(ts) {
+		t.Errorf("RequestedAt = %v, want %v", entries[0].RequestedAt, ts)
+	}
+}
+
+func TestResolveRequestEntriesUnresolved(t *testing.T) {
+	lid, _ := types.ParseJID("99999@lid")
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	requests := []types.GroupParticipantRequest{{JID: lid, RequestedAt: ts}}
+	// resolver returns the LID unchanged (not in store)
+	resolver := func(_ context.Context, j types.JID) types.JID { return j }
+
+	entries := resolveRequestEntries(context.Background(), requests, resolver)
+
+	if entries[0].PhoneNumber != "" {
+		t.Errorf("PhoneNumber = %q, want empty for unresolved LID", entries[0].PhoneNumber)
+	}
+	if entries[0].JID != lid.String() {
+		t.Errorf("JID = %q, want %q", entries[0].JID, lid.String())
+	}
+}
+
+func TestRequestListEntryJSONCompatibility(t *testing.T) {
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	// resolved entry: all three keys present
+	e := requestListEntry{JID: "12345@lid", PhoneNumber: "+48600000001", RequestedAt: ts}
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"JID", "RequestedAt", "phone_number"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("JSON output missing key %q", key)
+		}
+	}
+
+	// unresolved entry: phone_number must be omitted (omitempty)
+	e2 := requestListEntry{JID: "12345@lid", RequestedAt: ts}
+	data2, _ := json.Marshal(e2)
+	var m2 map[string]any
+	_ = json.Unmarshal(data2, &m2)
+	if _, ok := m2["phone_number"]; ok {
+		t.Error("JSON should omit 'phone_number' when empty (omitempty)")
+	}
+}
+
+func TestRequestListEntryTableColumnOrder(t *testing.T) {
+	// Table output must preserve existing field order: JID, timestamp, phone_number
+	// (phone appended as third field so existing consumers reading field[1] as timestamp are unaffected)
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	lid, _ := types.ParseJID("12345@lid")
+	pn, _ := types.ParseJID("48600000001@s.whatsapp.net")
+
+	requests := []types.GroupParticipantRequest{{JID: lid, RequestedAt: ts}}
+	resolver := func(_ context.Context, j types.JID) types.JID { return pn }
+	entries := resolveRequestEntries(context.Background(), requests, resolver)
+
+	e := entries[0]
+	line := fmt.Sprintf("%s\t%s\t%s", e.JID, e.RequestedAt.Local().Format("2006-01-02 15:04:05"), e.PhoneNumber)
+	fields := strings.Split(line, "\t")
+	if len(fields) != 3 {
+		t.Fatalf("expected 3 tab-separated fields, got %d: %q", len(fields), line)
+	}
+	if fields[0] != lid.String() {
+		t.Errorf("field[0] (JID) = %q, want %q", fields[0], lid.String())
+	}
+	wantTS := ts.Local().Format("2006-01-02 15:04:05")
+	if fields[1] != wantTS {
+		t.Errorf("field[1] (timestamp) = %q, want %q", fields[1], wantTS)
+	}
+	if fields[2] != "+48600000001" {
+		t.Errorf("field[2] (phone) = %q, want %q", fields[2], "+48600000001")
+	}
 }


### PR DESCRIPTION
## Summary

- `groups requests list` previously returned opaque `@lid` JIDs; this PR adds a
  `phone_number` field by calling the already-available `ResolveLIDToPN` from the
  `WAClient` interface.
- **JSON output**: new `phone_number` key added, existing `JID` and `RequestedAt` keys
  preserved — backward-compatible.
- **Table output**: appends a phone column after the timestamp.

## Why

Callers that maintain a phone-number-based allowlist (e.g. an alumni roster) cannot
correlate pending join requests against the list without a separate LID-to-phone
resolution step. With this change, the resolved number is included directly in the
output when it is available in the local contact store.

## Changes

- `newGroupsRequestsListCmd` RunE: resolve each LID via `ResolveLIDToPN`, emit
  `requestListEntry` slice (preserves `JID` + `RequestedAt` keys, adds `phone_number`).
- `resolveRequestEntries` helper extracted for unit testing.
- `TestResolveRequestEntriesResolved` — resolved LID emits correct `phone_number`.
- `TestResolveRequestEntriesUnresolved` — unresolved LID emits no `phone_number` field.
- `TestRequestListEntryJSONCompatibility` — JSON keys `JID`, `RequestedAt`, `phone_number`
  present/absent as expected.

## Proof — live output (redacted)

```
{"JID": "XXXXXXXX@lid", "phone_number": "+4175471XXXX", "RequestedAt": "2026-06-03T19:06:23+02:00"}
{"JID": "XXXXXXXX@lid", "phone_number": "+44795764XXXX", "RequestedAt": "2026-06-06T15:55:14+02:00"}
{"JID": "XXXXXXXX@lid", "phone_number": "+4850015XXXX", "RequestedAt": "2026-06-05T18:56:34+02:00"}
... (25 total entries, 23 with phone resolved)
```

