### PR TITLE
fix: support gif media type in downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Media: download synced WhatsApp GIF playback videos by treating their stored `gif` label as video-encrypted media. (#274 - thanks @larskluge)
 - Sync: reconnect after WhatsApp replaces the linked-device stream instead of leaving `sync --follow` offline. (#266 - thanks @ngutman)
 - Sync: clear chat unread state from `ReceiptTypeReadSelf` receipts so linked-device reads still update when `regular_high` app-state sync is unhealthy. (#269 - thanks @p-jackson1)
 

--- a/internal/wa/media.go
+++ b/internal/wa/media.go
@@ -45,6 +45,10 @@ func MediaTypeFromString(mediaType string) (whatsmeow.MediaType, error) {
 		return whatsmeow.MediaImage, nil
 	case "video":
 		return whatsmeow.MediaVideo, nil
+	case "gif":
+		// WhatsApp gifs are video messages with a gif-playback hint;
+		// they are stored and encrypted as regular videos.
+		return whatsmeow.MediaVideo, nil
 	case "audio":
 		return whatsmeow.MediaAudio, nil
 	case "document":

--- a/internal/wa/media_test.go
+++ b/internal/wa/media_test.go
@@ -19,9 +19,20 @@ import (
 )
 
 func TestMediaTypeFromString(t *testing.T) {
-	for _, tc := range []string{"image", "video", "audio", "document", "sticker"} {
-		if _, err := MediaTypeFromString(tc); err != nil {
+	for tc, want := range map[string]whatsmeow.MediaType{
+		"image":    whatsmeow.MediaImage,
+		"video":    whatsmeow.MediaVideo,
+		"gif":      whatsmeow.MediaVideo,
+		"audio":    whatsmeow.MediaAudio,
+		"document": whatsmeow.MediaDocument,
+		"sticker":  whatsmeow.MediaImage,
+	} {
+		got, err := MediaTypeFromString(tc)
+		if err != nil {
 			t.Fatalf("expected %s to be supported: %v", tc, err)
+		}
+		if got != want {
+			t.Fatalf("MediaTypeFromString(%q) = %q, want %q", tc, got, want)
 		}
 	}
 	if _, err := MediaTypeFromString("nope"); err == nil {

--- a/internal/wa/media_test.go
+++ b/internal/wa/media_test.go
@@ -19,20 +19,23 @@ import (
 )
 
 func TestMediaTypeFromString(t *testing.T) {
-	for tc, want := range map[string]whatsmeow.MediaType{
-		"image":    whatsmeow.MediaImage,
-		"video":    whatsmeow.MediaVideo,
-		"gif":      whatsmeow.MediaVideo,
-		"audio":    whatsmeow.MediaAudio,
-		"document": whatsmeow.MediaDocument,
-		"sticker":  whatsmeow.MediaImage,
+	for _, tc := range []struct {
+		input string
+		want  whatsmeow.MediaType
+	}{
+		{input: "image", want: whatsmeow.MediaImage},
+		{input: "video", want: whatsmeow.MediaVideo},
+		{input: "gif", want: whatsmeow.MediaVideo},
+		{input: "audio", want: whatsmeow.MediaAudio},
+		{input: "document", want: whatsmeow.MediaDocument},
+		{input: "sticker", want: whatsmeow.MediaImage},
 	} {
-		got, err := MediaTypeFromString(tc)
+		got, err := MediaTypeFromString(tc.input)
 		if err != nil {
-			t.Fatalf("expected %s to be supported: %v", tc, err)
+			t.Fatalf("expected %s to be supported: %v", tc.input, err)
 		}
-		if got != want {
-			t.Fatalf("MediaTypeFromString(%q) = %q, want %q", tc, got, want)
+		if got != tc.want {
+			t.Fatalf("MediaTypeFromString(%q) = %q, want %q", tc.input, got, tc.want)
 		}
 	}
 	if _, err := MediaTypeFromString("nope"); err == nil {
@@ -57,9 +60,85 @@ func TestMediaDownloadLength(t *testing.T) {
 }
 
 func TestDownloadMediaDirectToFile(t *testing.T) {
-	plaintext := []byte("voice note bytes")
-	mediaKey := bytes.Repeat([]byte{7}, 32)
-	iv, cipherKey, macKey := directMediaKeys(mediaKey, whatsmeow.MediaAudio)
+	for _, tc := range []struct {
+		name       string
+		mediaType  string
+		keyType    whatsmeow.MediaType
+		path       string
+		wantMMS    string
+		targetName string
+		plaintext  []byte
+	}{
+		{
+			name:       "audio",
+			mediaType:  "audio",
+			keyType:    whatsmeow.MediaAudio,
+			path:       "/voice.ogg",
+			wantMMS:    "audio",
+			targetName: "voice.ogg",
+			plaintext:  []byte("voice note bytes"),
+		},
+		{
+			name:       "gif video",
+			mediaType:  "gif",
+			keyType:    whatsmeow.MediaVideo,
+			path:       "/clip.mp4",
+			wantMMS:    "video",
+			targetName: "clip.mp4",
+			plaintext:  []byte("gif playback video bytes"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mediaKey := bytes.Repeat([]byte{7}, 32)
+			encrypted, encHash, fileHash := encryptedMediaFixture(t, tc.plaintext, mediaKey, tc.keyType)
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Origin") == "" || r.Header.Get("Referer") == "" {
+					t.Fatalf("missing WhatsApp media headers")
+				}
+				if r.URL.Path != tc.path {
+					t.Fatalf("path = %q, want %s", r.URL.Path, tc.path)
+				}
+				if got, want := r.URL.Query().Get("hash"), base64.URLEncoding.EncodeToString(encHash); got != want {
+					t.Fatalf("hash query = %q, want %q", got, want)
+				}
+				if got := r.URL.Query().Get("mms-type"); got != tc.wantMMS {
+					t.Fatalf("mms-type query = %q, want %s", got, tc.wantMMS)
+				}
+				if !strings.Contains(r.URL.RawQuery, "__wa-mms=") {
+					t.Fatalf("raw query %q missing __wa-mms", r.URL.RawQuery)
+				}
+				_, _ = w.Write(encrypted)
+			}))
+			defer server.Close()
+			oldBaseURL := directMediaBaseURL
+			directMediaBaseURL = server.URL
+			defer func() {
+				directMediaBaseURL = oldBaseURL
+			}()
+
+			target := filepath.Join(t.TempDir(), tc.targetName)
+			n, err := DownloadMediaDirectToFile(context.Background(), tc.path, encHash, fileHash, mediaKey, uint64(len(tc.plaintext)), tc.mediaType, target)
+			if err != nil {
+				t.Fatalf("DownloadMediaDirectToFile: %v", err)
+			}
+			if n != int64(len(tc.plaintext)) {
+				t.Fatalf("downloaded bytes = %d, want %d", n, len(tc.plaintext))
+			}
+			got, err := os.ReadFile(target)
+			if err != nil {
+				t.Fatalf("ReadFile: %v", err)
+			}
+			if !bytes.Equal(got, tc.plaintext) {
+				t.Fatalf("output = %q, want %q", got, tc.plaintext)
+			}
+		})
+	}
+}
+
+func encryptedMediaFixture(t *testing.T, plaintext, mediaKey []byte, mediaType whatsmeow.MediaType) (encrypted, encHash, fileHash []byte) {
+	t.Helper()
+	iv, cipherKey, macKey := directMediaKeys(mediaKey, mediaType)
 	ciphertext, err := cbcutil.Encrypt(cipherKey, iv, append([]byte(nil), plaintext...))
 	if err != nil {
 		t.Fatalf("Encrypt: %v", err)
@@ -67,50 +146,10 @@ func TestDownloadMediaDirectToFile(t *testing.T) {
 	mac := hmac.New(sha256.New, macKey)
 	mac.Write(iv)
 	mac.Write(ciphertext)
-	encrypted := append(append([]byte(nil), ciphertext...), mac.Sum(nil)[:mediaHMACLength]...)
-	encHash := sha256.Sum256(encrypted)
-	fileHash := sha256.Sum256(plaintext)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Origin") == "" || r.Header.Get("Referer") == "" {
-			t.Fatalf("missing WhatsApp media headers")
-		}
-		if r.URL.Path != "/voice.ogg" {
-			t.Fatalf("path = %q, want /voice.ogg", r.URL.Path)
-		}
-		if got, want := r.URL.Query().Get("hash"), base64.URLEncoding.EncodeToString(encHash[:]); got != want {
-			t.Fatalf("hash query = %q, want %q", got, want)
-		}
-		if got := r.URL.Query().Get("mms-type"); got != "audio" {
-			t.Fatalf("mms-type query = %q, want audio", got)
-		}
-		if !strings.Contains(r.URL.RawQuery, "__wa-mms=") {
-			t.Fatalf("raw query %q missing __wa-mms", r.URL.RawQuery)
-		}
-		_, _ = w.Write(encrypted)
-	}))
-	defer server.Close()
-	oldBaseURL := directMediaBaseURL
-	directMediaBaseURL = server.URL
-	defer func() {
-		directMediaBaseURL = oldBaseURL
-	}()
-
-	target := filepath.Join(t.TempDir(), "voice.ogg")
-	n, err := DownloadMediaDirectToFile(context.Background(), "/voice.ogg", encHash[:], fileHash[:], mediaKey, uint64(len(plaintext)), "audio", target)
-	if err != nil {
-		t.Fatalf("DownloadMediaDirectToFile: %v", err)
-	}
-	if n != int64(len(plaintext)) {
-		t.Fatalf("downloaded bytes = %d, want %d", n, len(plaintext))
-	}
-	got, err := os.ReadFile(target)
-	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
-	}
-	if !bytes.Equal(got, plaintext) {
-		t.Fatalf("output = %q, want %q", got, plaintext)
-	}
+	encrypted = append(append([]byte(nil), ciphertext...), mac.Sum(nil)[:mediaHMACLength]...)
+	encSum := sha256.Sum256(encrypted)
+	fileSum := sha256.Sum256(plaintext)
+	return encrypted, encSum[:], fileSum[:]
 }
 
 func TestDownloadMediaDirectToFileRejectsMalformedDirectPath(t *testing.T) {


### PR DESCRIPTION
## Problem

`extractMedia` labels video messages carrying the gif-playback hint as media_type `"gif"`, but `MediaTypeFromString` has no case for it. As a result every gif fails media download — both via `wacli media download` and via the background workers of `sync --download-media` — with `unsupported media type: gif`, before any network request is made. `local_path` never gets set for these messages.

## Fix

Map `"gif"` to `whatsmeow.MediaVideo`: WhatsApp gifs are stored and encrypted as regular videos (the gif flag is only a playback hint). Same label-remap precedent as `"sticker"` → `MediaImage` in the same switch.

## Real behavior proof

Before/after run against a **real gif message** that the background downloader had skipped (`media download` in `--read-only` direct-download mode; same store, same message, run back to back; group JID and message id redacted):

```console
$ wacli-main --read-only --json media download --store <store> \
    --chat <redacted-group-jid> --id <redacted-msg-id> --output /tmp/gif-proof.mp4
{"success":false,"data":null,"error":"unsupported media type: gif"}
# exit 1

$ wacli-pr --read-only --json media download --store <store> \
    --chat <redacted-group-jid> --id <redacted-msg-id> --output /tmp/gif-proof.mp4
{"success":true,"data":{"bytes":1268887,"chat":"<redacted-group-jid>","downloaded":true,"id":"<redacted-msg-id>","media_type":"gif","mime_type":"video/mp4","path":"/tmp/gif-proof.mp4","read_only":true,"recorded":false},"error":null}
# exit 0

$ ffprobe -v error -show_entries format=format_name,duration,size:stream=codec_name,width,height \
    -of default=noprint_wrappers=1 gif-proof.mp4
codec_name=h264
width=576
height=1024
format_name=mov,mp4,m4a,3gp,3g2,mj2
duration=6.066667
size=1268887
```

- `wacli-main` = built from current `main` (be2d22f); `wacli-pr` = `main` + this PR (9116ff7). Only this PR's 2-file diff differs between the binaries.
- Downloaded size (1,268,887 bytes) matches the message's recorded `file_length` exactly, and the direct-download path verifies `file_sha256` internally before writing — so this is the original media, decrypted correctly with the video key type.
- Coverage context from the originating store: gif messages were 0/18 ever auto-downloaded while every other media type had normal coverage (image 2401/2830, video 757/821, audio 11/14, sticker 8/10, document 59/63) — consistent with a hard block on the `gif` label rather than network flakiness.

## Test

Extended `TestMediaTypeFromString` to assert the resolved `whatsmeow.MediaType` for every supported label, including `gif` → `MediaVideo`. The new assertion fails on `main` with `unsupported media type: gif` and passes with this change. Full suite (`go build ./... && go vet ./... && go test ./...`) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
