### PR TITLE
ci: add deadcode check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,13 @@ jobs:
       - name: deadcode
         env:
           CGO_ENABLED: "1"
-        run: go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test -tags sqlite_fts5 ./...
+        run: |
+          output_file=$(mktemp)
+          go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test -tags sqlite_fts5 ./... > "$output_file"
+          if [ -s "$output_file" ]; then
+            cat "$output_file"
+            exit 1
+          fi
 
       - name: pnpm test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
       - name: pnpm lint
         run: pnpm -s lint
 
+      - name: deadcode
+        env:
+          CGO_ENABLED: "1"
+        run: go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test -tags sqlite_fts5 ./...
+
       - name: pnpm test
         env:
           CGO_ENABLED: "1"

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -200,14 +199,4 @@ func closeApp(a *app.App, lk *lock.Lock) {
 	if lk != nil {
 		_ = lk.Release()
 	}
-}
-
-func wrapErr(err error, msg string) error {
-	if err == nil {
-		return nil
-	}
-	if errors.Is(err, context.Canceled) {
-		return err
-	}
-	return fmt.Errorf("%s: %w", msg, err)
 }

--- a/cmd/wacli/signal.go
+++ b/cmd/wacli/signal.go
@@ -10,13 +10,6 @@ import (
 	"github.com/openclaw/wacli/internal/out"
 )
 
-// signalContext returns a context that is cancelled on the first SIGINT/SIGTERM.
-// A second signal force-kills the process so that a stuck cleanup never leaves
-// the user unable to get their terminal back.
-func signalContext() (context.Context, context.CancelFunc) {
-	return signalContextWithEvents(nil)
-}
-
 func signalContextWithEvents(events *out.EventWriter) (context.Context, context.CancelFunc) {
 	sigCh := make(chan os.Signal, 2)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -236,7 +235,3 @@ func (d *DB) HasFTS() bool { return d.ftsEnabled }
 
 const DeletedMessageDisplayText = "This message was deleted"
 const DeletedForMeMessageDisplayText = "This message was deleted for me"
-
-func IsNotFound(err error) bool {
-	return errors.Is(err, sql.ErrNoRows)
-}

--- a/internal/syscontacts/other.go
+++ b/internal/syscontacts/other.go
@@ -2,8 +2,11 @@
 
 package syscontacts
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 func ReadSystem(ctx context.Context) ([]Contact, error) {
-	return nil, UnsupportedError()
+	return nil, fmt.Errorf("system contacts import is only supported on macOS; pass --input with JSON/NDJSON contacts to import from a file")
 }

--- a/internal/syscontacts/syscontacts.go
+++ b/internal/syscontacts/syscontacts.go
@@ -3,9 +3,7 @@ package syscontacts
 import (
 	"bufio"
 	"encoding/json"
-	"fmt"
 	"io"
-	"os"
 	"strings"
 	"unicode"
 )
@@ -22,15 +20,6 @@ func (c Contact) Name() string {
 		return strings.TrimSpace(c.FullName)
 	}
 	return strings.TrimSpace(strings.Join([]string{c.FirstName, c.LastName}, " "))
-}
-
-func ReadFile(path string) ([]Contact, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-	return Decode(f)
 }
 
 func Decode(r io.Reader) ([]Contact, error) {
@@ -98,8 +87,4 @@ func NormalizePhone(phone string) string {
 		out = strings.TrimPrefix(out, "00")
 	}
 	return out
-}
-
-func UnsupportedError() error {
-	return fmt.Errorf("system contacts import is only supported on macOS; pass --input with JSON/NDJSON contacts to import from a file")
 }

--- a/internal/wa/jid.go
+++ b/internal/wa/jid.go
@@ -22,10 +22,6 @@ func ParseUserOrJID(s string) (types.JID, error) {
 	return types.JID{User: phone, Server: types.DefaultUserServer}, nil
 }
 
-func IsGroupJID(jid types.JID) bool {
-	return jid.Server == types.GroupServer
-}
-
 func normalizePhoneRecipient(s string) (string, error) {
 	var phone strings.Builder
 	for i, ch := range s {


### PR DESCRIPTION
## Summary
- add an enforced Go deadcode CI gate pinned to `golang.org/x/tools/cmd/deadcode@v0.45.0`
- remove unreachable helpers reported by deadcode
- keep the non-darwin system-contacts error path compiling after autoreview caught the cross-platform reference

## Validation
- `git diff --check`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test -tags sqlite_fts5 ./...`
- `go test -count=1 ./...`
- `go test -count=1 -tags sqlite_fts5 ./...`
- `CGO_ENABLED=1 CGO_CFLAGS=-Wno-error=missing-braces go build -tags sqlite_fts5 ./cmd/wacli`
- `GOOS=linux CGO_ENABLED=0 go test -c ./internal/syscontacts`
- `autoreview --mode branch --base origin/main --no-web-search --thinking low` clean
