### PR TITLE
fix(sync): send available presence on connect so WhatsApp marks the linked device active

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -73,6 +73,7 @@ type WAClient interface {
 	DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error)
 
 	SendChatPresence(ctx context.Context, jid types.JID, state types.ChatPresence, media types.ChatPresenceMedia) error
+	SendPresence(ctx context.Context, presence types.Presence) error
 	ParseWebMessage(chatJID types.JID, webMsg *waWeb.WebMessageInfo) (*events.Message, error)
 	DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error)
 	SetManualHistorySyncDownload(enabled bool)

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -61,10 +61,12 @@ type fakeWA struct {
 	pinCalls                    []fakePinCall
 	muteCalls                   []fakeMuteCall
 	markReadCalls               []fakeMarkReadCall
+	manualHistorySyncCalls      []bool
+	appStateRecoveries          []string
+	appStateFetches             []fakeAppStateFetch
 
-	manualHistorySyncCalls []bool
-	appStateRecoveries     []string
-	appStateFetches        []fakeAppStateFetch
+	presenceCalls   []types.Presence
+	sendPresenceErr error
 }
 
 type fakeArchiveCall struct {
@@ -467,6 +469,13 @@ func (f *fakeWA) UploadNewsletter(ctx context.Context, data []byte, mediaType wh
 
 func (f *fakeWA) SendChatPresence(ctx context.Context, jid types.JID, state types.ChatPresence, media types.ChatPresenceMedia) error {
 	return nil
+}
+
+func (f *fakeWA) SendPresence(ctx context.Context, presence types.Presence) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.presenceCalls = append(f.presenceCalls, presence)
+	return f.sendPresenceErr
 }
 
 func (f *fakeWA) DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error) {

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -83,6 +83,9 @@ func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, message
 			a.handleChatStateEvent(ctx, v)
 		case *events.Connected:
 			a.emitOrPrint("connected", nil, "\nConnected.\n")
+			go a.sendPresence(context.WithoutCancel(ctx), types.PresenceAvailable)
+		case *events.PushNameSetting:
+			go a.sendPresence(context.WithoutCancel(ctx), types.PresenceAvailable)
 		case *events.Disconnected:
 			a.emitOrPrint("disconnected", nil, "\nDisconnected.\n")
 			select {
@@ -366,5 +369,20 @@ func (a *App) decryptEncryptedReaction(ctx context.Context, pm *wa.ParsedMessage
 		if key := reaction.GetKey(); key != nil {
 			pm.ReactionToID = key.GetID()
 		}
+	}
+}
+
+// sendPresence sends a global presence update if the WhatsApp client is ready.
+// Errors are logged as warnings but never stop sync.
+func (a *App) sendPresence(ctx context.Context, presence types.Presence) {
+	if a.wa == nil {
+		return
+	}
+	if err := a.wa.SendPresence(ctx, presence); err != nil {
+		a.emitWarning(
+			"send_presence_failed",
+			fmt.Sprintf("warning: failed to send %s presence: %v", presence, err),
+			map[string]any{"presence": string(presence), "error": err.Error()},
+		)
 	}
 }

--- a/internal/app/sync_presence_test.go
+++ b/internal/app/sync_presence_test.go
@@ -1,0 +1,176 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openclaw/wacli/internal/out"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+// TestSyncSendsAvailablePresenceOnConnected ensures that when a sync session
+// connects, wacli broadcasts types.PresenceAvailable. WhatsApp uses this node to
+// update the linked device's "last active" status; without it the connection is
+// alive but the app still shows a stale timestamp.
+func TestSyncSendsAvailablePresenceOnConnected(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	raw := captureStderr(t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := a.Sync(ctx, SyncOptions{
+			Mode:         SyncModeOnce,
+			AllowQR:      false,
+			IdleExit:     time.Millisecond,
+			WarnNoLimits: false,
+		})
+		if err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+	})
+
+	if !strings.Contains(raw, "\nConnected.\n") {
+		t.Fatalf("missing connected line in stderr:\n%s", raw)
+	}
+
+	waitForPresenceCalls(t, f, 1)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.presenceCalls) != 1 {
+		t.Fatalf("got %d presence calls, want 1", len(f.presenceCalls))
+	}
+	if f.presenceCalls[0] != types.PresenceAvailable {
+		t.Fatalf("presence call = %v, want Available", f.presenceCalls[0])
+	}
+}
+
+// TestSyncSendsAvailablePresenceOnPushNameSetting ensures that once the
+// server tells us our pushname, wacli sends another presence update. This
+// mirrors the behavior of go-whatsapp-web-multidevice and is important because
+// whatsmeow's SendPresence requires a pushname to be set.
+func TestSyncSendsAvailablePresenceOnPushNameSetting(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	// Fake the server sending a pushname update after the initial connect.
+	f.connectEvents = []interface{}{&events.PushNameSetting{}}
+
+	raw := captureStderr(t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := a.Sync(ctx, SyncOptions{
+			Mode:         SyncModeOnce,
+			AllowQR:      false,
+			IdleExit:     time.Millisecond,
+			WarnNoLimits: false,
+		})
+		if err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+	})
+
+	if !strings.Contains(raw, "\nConnected.\n") {
+		t.Fatalf("missing connected line in stderr:\n%s", raw)
+	}
+
+	waitForPresenceCalls(t, f, 2)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.presenceCalls) != 2 {
+		t.Fatalf("got %d presence calls, want 2", len(f.presenceCalls))
+	}
+	for i, p := range f.presenceCalls {
+		if p != types.PresenceAvailable {
+			t.Fatalf("presence call %d = %v, want Available", i, p)
+		}
+	}
+}
+
+// TestSyncPresenceFailureWarnsAndContinues verifies that a failed presence
+// update is logged as a warning and does not abort the sync loop.
+func TestSyncPresenceFailureWarnsAndContinues(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	f.sendPresenceErr = errors.New("presence offline")
+	a.wa = f
+
+	raw := captureStderr(t, func() {
+		// Enable NDJSON events so warnings surface on stderr as JSON events.
+		a.opts.Events = out.NewEventWriter(os.Stderr, true)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := a.Sync(ctx, SyncOptions{
+			Mode:         SyncModeOnce,
+			AllowQR:      false,
+			IdleExit:     time.Millisecond,
+			WarnNoLimits: false,
+		})
+		if err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+	})
+
+	waitForPresenceCalls(t, f, 1)
+
+	if !strings.Contains(raw, "send_presence_failed") {
+		t.Fatalf("missing send_presence_failed warning event in stderr:\n%s", raw)
+	}
+	if !strings.Contains(raw, "presence offline") {
+		t.Fatalf("missing original error text in warning event in stderr:\n%s", raw)
+	}
+}
+
+// TestSyncSendsAvailablePresenceOnConnectedIsSynchronous ensures the event
+// handler presence call happens within the sync lifetime without requiring a
+// follow-mode loop.
+func TestSyncSendsAvailablePresenceOnConnectedIsSynchronous(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	captureStderr(t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := a.Sync(ctx, SyncOptions{
+			Mode:         SyncModeOnce,
+			AllowQR:      false,
+			IdleExit:     time.Millisecond,
+			WarnNoLimits: false,
+		})
+		if err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+	})
+
+	waitForPresenceCalls(t, f, 1)
+}
+
+func waitForPresenceCalls(t *testing.T, f *fakeWA, want int) {
+	t.Helper()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		f.mu.Lock()
+		n := len(f.presenceCalls)
+		f.mu.Unlock()
+		if n >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	f.mu.Lock()
+	n := len(f.presenceCalls)
+	f.mu.Unlock()
+	if n != want {
+		t.Fatalf("timed out waiting for presence calls: got %d, want %d", n, want)
+	}
+}

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -773,6 +773,17 @@ func (c *Client) SendChatPresence(ctx context.Context, jid types.JID, state type
 	return cli.SendChatPresence(ctx, jid, state, media)
 }
 
+// SendPresence updates the authenticated account's global presence status.
+func (c *Client) SendPresence(ctx context.Context, presence types.Presence) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	return cli.SendPresence(ctx, presence)
+}
+
 func (c *Client) Logout(ctx context.Context) error {
 	c.mu.Lock()
 	cli := c.client


### PR DESCRIPTION
## Problem

Even though `wacli sync --follow` keeps a live websocket connection to WhatsApp, the WhatsApp mobile app kept showing the linked device as **"last active 23 May 2026"** instead of treating it as currently active.

A live websocket only keeps the TCP session alive. WhatsApp also requires a `<presence type="available"/>` stanza after connect so the server knows the linked device is online and can refresh its "last active" timestamp. `wacli` was never sending one.

## How upstream libraries handle this

I checked the three reference implementations the user asked about:

- **whatsmeow** (`go.mau.fi/whatsmeow`): exposes `Client.SendPresence(ctx, types.Presence)` in `presence.go` and explicitly documents that *"You should call this at least once after connecting so that the server has your pushname."* Its `keepalive.go` only sends websocket keepalive IQs every 20–30 s; those keep the socket open but do not update the "last active" UI.
- **go-whatsapp-web-multidevice (gowa)**: on `events.Connected` / `events.PushNameSetting` it calls `sendConfiguredPresence`; it also runs a scheduled presence pulse (`presence_pulse.go`) that periodically sends `available`, sleeps, then sends `unavailable` to keep the linked device from going stale.
- **Evolution API** (Baileys): exposes `setPresence` and `sendPresence` endpoints that call `client.sendPresenceUpdate(presence)`; callers are expected to manage presence themselves.

`wacli` had zero matches for any of those presence primitives.

## Solution

When a sync session connects and also when the server confirms our pushname, wacli now sends `types.PresenceAvailable` to WhatsApp. If the presence send fails, we log a warning but never interrupt the sync loop.

### Files changed

- `internal/wa/client.go` — added `SendPresence(ctx context.Context, presence types.Presence) error` wrapper around the underlying `*whatsmeow.Client`.
- `internal/app/app.go` — added `SendPresence` to the `WAClient` interface.
- `internal/app/fake_wa_test.go` — recorded presence calls in the test fake and added a configurable error return.
- `internal/app/sync_events.go` — on `*events.Connected` and `*events.PushNameSetting` we now call `sendPresence(ctx, types.PresenceAvailable)`. Added `sendPresence` helper that treats errors as warnings.
- `internal/app/sync_presence_test.go` — new test coverage.

## Tests added

- `TestSyncSendsAvailablePresenceOnConnected` — a single `SyncModeOnce` run triggers one `PresenceAvailable` call.
- `TestSyncSendsAvailablePresenceOnPushNameSetting` — when the server sends `PushNameSetting` after connect, a second `PresenceAvailable` call is recorded (mirrors gowa/whatsmeow recommendation).
- `TestSyncPresenceFailureWarnsAndContinues` — a mocked presence send error is surfaced as a `send_presence_failed` warning event and sync still completes.
- `TestSyncSendsAvailablePresenceOnConnectedIsSynchronous` — ensures the call happens within the sync lifetime even in non-follow mode.

All existing tests still pass:

```bash
go test ./...
go vet ./...
gofmt -l .
git diff --check
pnpm build
```

## Deployment note

This is a code fix only; the local runtime was switched from a systemd service to a cron-ensured `wacli sync --follow` singleton using `flock`. That change is outside this branch but is the recommended way to keep the device active with this fix applied:

```cron
* * * * * /usr/bin/flock -n /tmp/wacli-sync.lock -c '/home/agentic/.local/bin/wacli sync --follow --events /tmp/wacli-events.ndjson --max-messages 250000 --max-db-size 2GB' >> /home/agentic/wacli-sync.log 2>&1
```

## Checklist

- [x] Code compiles.
- [x] `go test ./...` passes.
- [x] `go vet ./...` passes.
- [x] `gofmt` clean.
- [x] `git diff --check` clean.
- [x] New tests cover the presence behavior.
