### PR TITLE
fix(sync): send available presence on connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 - WhatsApp connectivity: update `whatsmeow` for the current WhatsApp protocol and fix `405 (Client Outdated)` failures. (#280)
-- Sync: send available presence on reconnect and when the server sends the pushname after the initial connect, so the linked device shows as active even when the pushname arrives late. (#282 - thanks @dovocoder)
+- Sync: send available presence on reconnect and when the server sends the pushname after the initial connect, and send unavailable presence after a successful sync so the phone continues to receive push notifications. (#282 - thanks @dovocoder)
 
 ## 0.11.1 - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - WhatsApp connectivity: update `whatsmeow` for the current WhatsApp protocol and fix `405 (Client Outdated)` failures. (#280)
+- Sync: send available presence on reconnect and when the server sends the pushname after the initial connect, so the linked device shows as active even when the pushname arrives late. (#282 - thanks @dovocoder)
 
 ## 0.11.1 - 2026-06-11
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -81,6 +81,7 @@ type WAClient interface {
 	DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error)
 
 	SendChatPresence(ctx context.Context, jid types.JID, state types.ChatPresence, media types.ChatPresenceMedia) error
+	SendPresence(ctx context.Context, presence types.Presence) error
 	ParseWebMessage(chatJID types.JID, webMsg *waWeb.WebMessageInfo) (*events.Message, error)
 	DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error)
 	SetManualHistorySyncDownload(enabled bool)

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -63,10 +63,12 @@ type fakeWA struct {
 	pinCalls                    []fakePinCall
 	muteCalls                   []fakeMuteCall
 	markReadCalls               []fakeMarkReadCall
+	manualHistorySyncCalls      []bool
+	appStateRecoveries          []string
+	appStateFetches             []fakeAppStateFetch
 
-	manualHistorySyncCalls []bool
-	appStateRecoveries     []string
-	appStateFetches        []fakeAppStateFetch
+	presenceCalls   []types.Presence
+	sendPresenceErr error
 }
 
 type fakeArchiveCall struct {
@@ -555,6 +557,13 @@ func (f *fakeWA) UploadNewsletter(ctx context.Context, data []byte, mediaType wh
 
 func (f *fakeWA) SendChatPresence(ctx context.Context, jid types.JID, state types.ChatPresence, media types.ChatPresenceMedia) error {
 	return nil
+}
+
+func (f *fakeWA) SendPresence(ctx context.Context, presence types.Presence) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.presenceCalls = append(f.presenceCalls, presence)
+	return f.sendPresenceErr
 }
 
 func (f *fakeWA) DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error) {

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -202,6 +202,9 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 	if err != nil {
 		return SyncResult{MessagesStored: messagesStored.Load()}, err
 	}
+	// Mark the linked device as inactive again after a successful sync so the
+	// phone continues to receive push notifications for new messages.
+	a.sendPresence(context.WithoutCancel(ctx), types.PresenceUnavailable)
 	return SyncResult{MessagesStored: messagesStored.Load()}, nil
 }
 

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -100,8 +100,11 @@ func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, message
 			a.handleChatStateEvent(ctx, v)
 		case *events.Connected:
 			a.emitOrPrint("connected", nil, "\nConnected.\n")
+			go a.sendPresence(context.WithoutCancel(ctx), types.PresenceAvailable)
 		case *events.KeepAliveTimeout:
 			a.handleKeepAliveTimeout(opts, v, staleReconnect)
+		case *events.PushNameSetting:
+			go a.sendPresence(context.WithoutCancel(ctx), types.PresenceAvailable)
 		case *events.Disconnected:
 			a.emitOrPrint("disconnected", nil, "\nDisconnected.\n")
 			select {
@@ -561,5 +564,20 @@ func (a *App) decryptEncryptedReaction(ctx context.Context, pm *wa.ParsedMessage
 		if key := reaction.GetKey(); key != nil {
 			pm.ReactionToID = key.GetID()
 		}
+	}
+}
+
+// sendPresence sends a global presence update if the WhatsApp client is ready.
+// Errors are logged as warnings but never stop sync.
+func (a *App) sendPresence(ctx context.Context, presence types.Presence) {
+	if a.wa == nil {
+		return
+	}
+	if err := a.wa.SendPresence(ctx, presence); err != nil {
+		a.emitWarning(
+			"send_presence_failed",
+			fmt.Sprintf("warning: failed to send %s presence: %v", presence, err),
+			map[string]any{"presence": string(presence), "error": err.Error()},
+		)
 	}
 }

--- a/internal/app/sync_presence_test.go
+++ b/internal/app/sync_presence_test.go
@@ -1,0 +1,176 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openclaw/wacli/internal/out"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+// TestSyncSendsAvailablePresenceOnConnected ensures that when a sync session
+// connects, wacli broadcasts types.PresenceAvailable. WhatsApp uses this node to
+// update the linked device's "last active" status; without it the connection is
+// alive but the app still shows a stale timestamp.
+func TestSyncSendsAvailablePresenceOnConnected(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	raw := captureStderr(t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := a.Sync(ctx, SyncOptions{
+			Mode:         SyncModeOnce,
+			AllowQR:      false,
+			IdleExit:     time.Millisecond,
+			WarnNoLimits: false,
+		})
+		if err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+	})
+
+	if !strings.Contains(raw, "\nConnected.\n") {
+		t.Fatalf("missing connected line in stderr:\n%s", raw)
+	}
+
+	waitForPresenceCalls(t, f, 1)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.presenceCalls) != 1 {
+		t.Fatalf("got %d presence calls, want 1", len(f.presenceCalls))
+	}
+	if f.presenceCalls[0] != types.PresenceAvailable {
+		t.Fatalf("presence call = %v, want Available", f.presenceCalls[0])
+	}
+}
+
+// TestSyncSendsAvailablePresenceOnPushNameSetting ensures that once the
+// server tells us our pushname, wacli sends another presence update. This
+// mirrors the behavior of go-whatsapp-web-multidevice and is important because
+// whatsmeow's SendPresence requires a pushname to be set.
+func TestSyncSendsAvailablePresenceOnPushNameSetting(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	// Fake the server sending a pushname update after the initial connect.
+	f.connectEvents = []interface{}{&events.PushNameSetting{}}
+
+	raw := captureStderr(t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := a.Sync(ctx, SyncOptions{
+			Mode:         SyncModeOnce,
+			AllowQR:      false,
+			IdleExit:     time.Millisecond,
+			WarnNoLimits: false,
+		})
+		if err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+	})
+
+	if !strings.Contains(raw, "\nConnected.\n") {
+		t.Fatalf("missing connected line in stderr:\n%s", raw)
+	}
+
+	waitForPresenceCalls(t, f, 2)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.presenceCalls) != 2 {
+		t.Fatalf("got %d presence calls, want 2", len(f.presenceCalls))
+	}
+	for i, p := range f.presenceCalls {
+		if p != types.PresenceAvailable {
+			t.Fatalf("presence call %d = %v, want Available", i, p)
+		}
+	}
+}
+
+// TestSyncPresenceFailureWarnsAndContinues verifies that a failed presence
+// update is logged as a warning and does not abort the sync loop.
+func TestSyncPresenceFailureWarnsAndContinues(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	f.sendPresenceErr = errors.New("presence offline")
+	a.wa = f
+
+	raw := captureStderr(t, func() {
+		// Enable NDJSON events so warnings surface on stderr as JSON events.
+		a.opts.Events = out.NewEventWriter(os.Stderr, true)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := a.Sync(ctx, SyncOptions{
+			Mode:         SyncModeOnce,
+			AllowQR:      false,
+			IdleExit:     time.Millisecond,
+			WarnNoLimits: false,
+		})
+		if err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+	})
+
+	waitForPresenceCalls(t, f, 1)
+
+	if !strings.Contains(raw, "send_presence_failed") {
+		t.Fatalf("missing send_presence_failed warning event in stderr:\n%s", raw)
+	}
+	if !strings.Contains(raw, "presence offline") {
+		t.Fatalf("missing original error text in warning event in stderr:\n%s", raw)
+	}
+}
+
+// TestSyncSendsAvailablePresenceOnConnectedIsSynchronous ensures the event
+// handler presence call happens within the sync lifetime without requiring a
+// follow-mode loop.
+func TestSyncSendsAvailablePresenceOnConnectedIsSynchronous(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	captureStderr(t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := a.Sync(ctx, SyncOptions{
+			Mode:         SyncModeOnce,
+			AllowQR:      false,
+			IdleExit:     time.Millisecond,
+			WarnNoLimits: false,
+		})
+		if err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+	})
+
+	waitForPresenceCalls(t, f, 1)
+}
+
+func waitForPresenceCalls(t *testing.T, f *fakeWA, want int) {
+	t.Helper()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		f.mu.Lock()
+		n := len(f.presenceCalls)
+		f.mu.Unlock()
+		if n >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	f.mu.Lock()
+	n := len(f.presenceCalls)
+	f.mu.Unlock()
+	if n != want {
+		t.Fatalf("timed out waiting for presence calls: got %d, want %d", n, want)
+	}
+}

--- a/internal/app/sync_presence_test.go
+++ b/internal/app/sync_presence_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 // TestSyncSendsAvailablePresenceOnConnected ensures that when a sync session
-// connects, wacli broadcasts types.PresenceAvailable. WhatsApp uses this node to
-// update the linked device's "last active" status; without it the connection is
-// alive but the app still shows a stale timestamp.
+// connects, wacli broadcasts types.PresenceAvailable, and that it sends
+// types.PresenceUnavailable again when the session ends so the phone still
+// receives push notifications.
 func TestSyncSendsAvailablePresenceOnConnected(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()
@@ -40,22 +40,14 @@ func TestSyncSendsAvailablePresenceOnConnected(t *testing.T) {
 		t.Fatalf("missing connected line in stderr:\n%s", raw)
 	}
 
-	waitForPresenceCalls(t, f, 1)
-
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if len(f.presenceCalls) != 1 {
-		t.Fatalf("got %d presence calls, want 1", len(f.presenceCalls))
-	}
-	if f.presenceCalls[0] != types.PresenceAvailable {
-		t.Fatalf("presence call = %v, want Available", f.presenceCalls[0])
-	}
+	assertPresenceCalls(t, f, types.PresenceAvailable, types.PresenceUnavailable)
 }
 
 // TestSyncSendsAvailablePresenceOnPushNameSetting ensures that once the
 // server tells us our pushname, wacli sends another presence update. This
 // mirrors the behavior of go-whatsapp-web-multidevice and is important because
-// whatsmeow's SendPresence requires a pushname to be set.
+// whatsmeow's SendPresence requires a pushname to be set. When the sync
+// session ends, PresenceUnavailable is sent as well.
 func TestSyncSendsAvailablePresenceOnPushNameSetting(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()
@@ -82,18 +74,7 @@ func TestSyncSendsAvailablePresenceOnPushNameSetting(t *testing.T) {
 		t.Fatalf("missing connected line in stderr:\n%s", raw)
 	}
 
-	waitForPresenceCalls(t, f, 2)
-
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if len(f.presenceCalls) != 2 {
-		t.Fatalf("got %d presence calls, want 2", len(f.presenceCalls))
-	}
-	for i, p := range f.presenceCalls {
-		if p != types.PresenceAvailable {
-			t.Fatalf("presence call %d = %v, want Available", i, p)
-		}
-	}
+	assertPresenceCalls(t, f, types.PresenceAvailable, types.PresenceAvailable, types.PresenceUnavailable)
 }
 
 // TestSyncPresenceFailureWarnsAndContinues verifies that a failed presence
@@ -120,7 +101,7 @@ func TestSyncPresenceFailureWarnsAndContinues(t *testing.T) {
 		}
 	})
 
-	waitForPresenceCalls(t, f, 1)
+	waitForPresenceCalls(t, f, 2)
 
 	if !strings.Contains(raw, "send_presence_failed") {
 		t.Fatalf("missing send_presence_failed warning event in stderr:\n%s", raw)
@@ -152,7 +133,23 @@ func TestSyncSendsAvailablePresenceOnConnectedIsSynchronous(t *testing.T) {
 		}
 	})
 
-	waitForPresenceCalls(t, f, 1)
+	waitForPresenceCalls(t, f, 2)
+}
+
+func assertPresenceCalls(t *testing.T, f *fakeWA, want ...types.Presence) {
+	t.Helper()
+	waitForPresenceCalls(t, f, len(want))
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.presenceCalls) != len(want) {
+		t.Fatalf("got %d presence calls, want %d", len(f.presenceCalls), len(want))
+	}
+	for i, got := range f.presenceCalls {
+		if got != want[i] {
+			t.Fatalf("presence call %d = %v, want %v", i, got, want[i])
+		}
+	}
 }
 
 func waitForPresenceCalls(t *testing.T, f *fakeWA, want int) {

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -811,6 +811,17 @@ func sendInitialAvailablePresence(ctx context.Context, cli *whatsmeow.Client) {
 	}
 }
 
+// SendPresence updates the authenticated account's global presence status.
+func (c *Client) SendPresence(ctx context.Context, presence types.Presence) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	return cli.SendPresence(ctx, presence)
+}
+
 func (c *Client) Logout(ctx context.Context) error {
 	c.mu.Lock()
 	cli := c.client


### PR DESCRIPTION
## Problem

WhatsApp requires an `<presence type="available"/>` stanza after a link to mark the device as active. Without it the connection stays alive, but the mobile app shows a stale "last active" timestamp.

The latest upstream `main` added `sendInitialAvailablePresence` in `internal/wa/client.go`, but it only runs once inside the initial `ConnectContext` call and only when the pushname is already set. It therefore misses two real-world cases:

- **Reconnects inside a running sync session** fire `*events.Connected` again, but `ConnectContext` is not re-entered, so no presence is re-sent.
- **Late-arriving pushname** is delivered as `*events.PushNameSetting` after connect. If the pushname was empty at connect time, the upstream path never sends presence.

## Solution

Keep the upstream early-connect attempt and add an event-loop path that covers the cases above.

### Files changed

- `internal/wa/client.go` — adds `(Client).SendPresence()`, a concurrency-safe wrapper around `whatsmeow.Client.SendPresence()`.
- `internal/app/app.go` — adds `SendPresence()` to the `WAClient` interface.
- `internal/app/sync_events.go` — on `*events.Connected` and `*events.PushNameSetting`, calls `go a.sendPresence(...)`.
- `internal/app/sync_events.go` — adds `App.sendPresence()` helper that logs failures as NDJSON warning events (`send_presence_failed`) and never aborts sync.
- `internal/app/fake_wa_test.go` — adds `SendPresence()` fake implementation and tracking fields so the new behavior is unit-testable.
- `internal/app/sync_presence_test.go` — adds regression tests for connected, push-name setting, and presence-error paths.

## Tests

The full gate was run locally and passes:

```bash
pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check
```

New regression tests:

```bash
go test ./internal/app -run TestSyncSendsAvailablePresence -count=1
go test ./internal/app -run TestSyncPresenceFailureWarnsAndContinues -count=1
```

## Real behavior proof

A live linked-device run confirms the new event-loop path sends `PresenceAvailable` through the wrapper. Redacted stderr/NDJSON log is attached in [this comment](https://github.com/openclaw/wacli/pull/282#issuecomment-4742536673).

## Deployment / rollout

No operational changes required. The compiled `dist/wacli` binary is already available at `~/.local/bin/wacli`.

## Checklist

- [x] Code compiles / builds.
- [x] Tests pass (`pnpm test` and FTS path).
- [x] Lint / formatting checks pass.
- [x] `git diff --check` clean.
- [x] Branch rebased onto latest `openclaw/wacli:main` (`464254a`).
- [x] Redacted live WhatsApp behavior proof added to PR comments.
