### PR TITLE
fix(sync): presence handling for linked-device active status and phone push notifications

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -81,6 +81,7 @@ type WAClient interface {
 	DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error)
 
 	SendChatPresence(ctx context.Context, jid types.JID, state types.ChatPresence, media types.ChatPresenceMedia) error
+	SendPresence(ctx context.Context, presence types.Presence) error
 	ParseWebMessage(chatJID types.JID, webMsg *waWeb.WebMessageInfo) (*events.Message, error)
 	DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error)
 	SetManualHistorySyncDownload(enabled bool)

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -63,10 +63,12 @@ type fakeWA struct {
 	pinCalls                    []fakePinCall
 	muteCalls                   []fakeMuteCall
 	markReadCalls               []fakeMarkReadCall
+	manualHistorySyncCalls      []bool
+	appStateRecoveries          []string
+	appStateFetches             []fakeAppStateFetch
 
-	manualHistorySyncCalls []bool
-	appStateRecoveries     []string
-	appStateFetches        []fakeAppStateFetch
+	presenceCalls   []types.Presence
+	sendPresenceErr error
 }
 
 type fakeArchiveCall struct {
@@ -555,6 +557,13 @@ func (f *fakeWA) UploadNewsletter(ctx context.Context, data []byte, mediaType wh
 
 func (f *fakeWA) SendChatPresence(ctx context.Context, jid types.JID, state types.ChatPresence, media types.ChatPresenceMedia) error {
 	return nil
+}
+
+func (f *fakeWA) SendPresence(ctx context.Context, presence types.Presence) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.presenceCalls = append(f.presenceCalls, presence)
+	return f.sendPresenceErr
 }
 
 func (f *fakeWA) DecryptReaction(ctx context.Context, reaction *events.Message) (*waProto.ReactionMessage, error) {

--- a/internal/app/heartbeat_test.go
+++ b/internal/app/heartbeat_test.go
@@ -32,6 +32,7 @@ func TestSyncWritesHeartbeatFileOnActivity(t *testing.T) {
 		func(string, string) {},
 		nil,
 		nil,
+		&syncPresence{},
 	)
 	defer f.RemoveEventHandler(handlerID)
 
@@ -68,6 +69,7 @@ func TestSyncOnceDoesNotWriteHeartbeatFile(t *testing.T) {
 		func(string, string) {},
 		nil,
 		nil,
+		&syncPresence{},
 	)
 	defer f.RemoveEventHandler(handlerID)
 
@@ -96,6 +98,7 @@ func TestSyncFollowDoesNotWriteHeartbeatOnKeepAliveTimeout(t *testing.T) {
 		func(string, string) {},
 		nil,
 		nil,
+		&syncPresence{},
 	)
 	defer f.RemoveEventHandler(handlerID)
 
@@ -196,6 +199,7 @@ func TestSyncFollowDoesNotReconnectOnFreshKeepAliveTimeout(t *testing.T) {
 		func(string, string) {},
 		nil,
 		nil,
+		&syncPresence{},
 	)
 	defer f.RemoveEventHandler(handlerID)
 
@@ -246,6 +250,7 @@ func TestSyncFollowEmitsStaleEvent(t *testing.T) {
 		func(string, string) {},
 		nil,
 		nil,
+		&syncPresence{},
 	)
 	defer f.RemoveEventHandler(handlerID)
 

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -142,13 +142,25 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 		defer stopWebhook()
 	}
 
-	handlerID := a.addSyncEventHandler(syncCtx, opts, &messagesStored, &lastEvent, disconnected, staleReconnect, enqueueMedia, enqueueWebhook, limits)
+	ps := &syncPresence{}
+	handlerID := a.addSyncEventHandler(syncCtx, opts, &messagesStored, &lastEvent, disconnected, staleReconnect, enqueueMedia, enqueueWebhook, limits, ps)
 	defer a.wa.RemoveEventHandler(handlerID)
 
 	connectionEpoch.Store(nowUTC().UnixNano())
 	if err := a.connectForSync(syncCtx, opts); err != nil {
 		return SyncResult{}, err
 	}
+	// Ensure unavailable presence is sent on ALL post-connect exits
+	// (success, error, storage limit, reconnect failure), not just the
+	// success path. The websocket stays alive via DetachSocket, so the
+	// send can complete even after the sync context is cancelled.
+	defer func() {
+		ps.mu.Lock()
+		ps.cleanupStarted = true
+		ps.mu.Unlock()
+		a.wa.RemoveEventHandler(handlerID)
+		a.sendPresenceBounded(types.PresenceUnavailable)
+	}()
 	now = nowUTC().UnixNano()
 	lastEvent.Store(now)
 	if err := a.migrateHistoricalLIDs(syncCtx); err != nil {
@@ -224,6 +236,10 @@ func (a *App) connectForSync(ctx context.Context, opts SyncOptions) error {
 		OnQRCode:        opts.OnQRCode,
 		PairPhoneNumber: opts.PairPhoneNumber,
 		OnPairCode:      opts.OnPairCode,
+		// Only detach for already-authenticated sync, not for auth
+		// bootstrap (AllowQR / phone pairing) where caller
+		// cancellation must bound the QR/pairing flow.
+		DetachSocket: opts.AllowQR == false && opts.PairPhoneNumber == "",
 	}
 
 	attempts := 1

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -41,7 +41,15 @@ type staleReconnectRequest struct {
 	source      string
 }
 
-func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, messagesStored, lastEvent *atomic.Int64, disconnected chan<- struct{}, staleReconnect chan<- staleReconnectRequest, enqueueMedia func(string, string), enqueueWebhook func(wa.ParsedMessage), limits *syncStorageLimits) uint32 {
+// syncPresence serializes available presence sends with the final
+// unavailable cleanup so an in-flight Connected or PushNameSetting
+// callback cannot mark the device available after the cleanup send.
+type syncPresence struct {
+	mu             sync.Mutex
+	cleanupStarted bool
+}
+
+func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, messagesStored, lastEvent *atomic.Int64, disconnected chan<- struct{}, staleReconnect chan<- staleReconnectRequest, enqueueMedia func(string, string), enqueueWebhook func(wa.ParsedMessage), limits *syncStorageLimits, ps *syncPresence) uint32 {
 	var panicCount atomic.Int64
 	var appStateRecoveries sync.Map
 	return a.wa.AddEventHandler(func(evt interface{}) {
@@ -100,8 +108,19 @@ func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, message
 			a.handleChatStateEvent(ctx, v)
 		case *events.Connected:
 			a.emitOrPrint("connected", nil, "\nConnected.\n")
+			ps.mu.Lock()
+			if !ps.cleanupStarted {
+				a.sendPresenceBounded(types.PresenceAvailable)
+			}
+			ps.mu.Unlock()
 		case *events.KeepAliveTimeout:
 			a.handleKeepAliveTimeout(opts, v, staleReconnect)
+		case *events.PushNameSetting:
+			ps.mu.Lock()
+			if !ps.cleanupStarted {
+				a.sendPresenceBounded(types.PresenceAvailable)
+			}
+			ps.mu.Unlock()
 		case *events.Disconnected:
 			a.emitOrPrint("disconnected", nil, "\nDisconnected.\n")
 			select {
@@ -562,4 +581,28 @@ func (a *App) decryptEncryptedReaction(ctx context.Context, pm *wa.ParsedMessage
 			pm.ReactionToID = key.GetID()
 		}
 	}
+}
+
+// sendPresence sends a global presence update if the WhatsApp client is ready.
+// Errors are logged as warnings but never stop sync.
+func (a *App) sendPresence(ctx context.Context, presence types.Presence) {
+	if a.wa == nil {
+		return
+	}
+	if err := a.wa.SendPresence(ctx, presence); err != nil {
+		a.emitWarning(
+			"send_presence_failed",
+			fmt.Sprintf("warning: failed to send %s presence: %v", presence, err),
+			map[string]any{"presence": string(presence), "error": err.Error()},
+		)
+	}
+}
+
+// sendPresenceBounded sends a presence update with a 5-second timeout so a
+// stalled WhatsApp write cannot hold the event handler dispatch lock or
+// block shutdown from reaching the final unavailable cleanup send.
+func (a *App) sendPresenceBounded(presence types.Presence) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	a.sendPresence(ctx, presence)
 }

--- a/internal/app/sync_presence_test.go
+++ b/internal/app/sync_presence_test.go
@@ -1,0 +1,205 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openclaw/wacli/internal/out"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+// TestSyncSendsAvailablePresenceOnConnected ensures that when a sync session
+// connects, wacli broadcasts types.PresenceAvailable, and that it sends
+// types.PresenceUnavailable again when the session ends so the phone still
+// receives push notifications.
+func TestSyncSendsAvailablePresenceOnConnected(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	raw := captureStderr(t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := a.Sync(ctx, SyncOptions{
+			Mode:         SyncModeOnce,
+			AllowQR:      false,
+			IdleExit:     time.Millisecond,
+			WarnNoLimits: false,
+		})
+		if err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+	})
+
+	if !strings.Contains(raw, "\nConnected.\n") {
+		t.Fatalf("missing connected line in stderr:\n%s", raw)
+	}
+
+	assertPresenceCalls(t, f, types.PresenceAvailable, types.PresenceUnavailable)
+}
+
+// TestSyncSendsAvailablePresenceOnPushNameSetting ensures that once the
+// server tells us our pushname, wacli sends another presence update. This
+// mirrors the behavior of go-whatsapp-web-multidevice and is important because
+// whatsmeow's SendPresence requires a pushname to be set. When the sync
+// session ends, PresenceUnavailable is sent as well.
+func TestSyncSendsAvailablePresenceOnPushNameSetting(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	// Fake the server sending a pushname update after the initial connect.
+	f.connectEvents = []interface{}{&events.PushNameSetting{}}
+
+	raw := captureStderr(t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := a.Sync(ctx, SyncOptions{
+			Mode:         SyncModeOnce,
+			AllowQR:      false,
+			IdleExit:     time.Millisecond,
+			WarnNoLimits: false,
+		})
+		if err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+	})
+
+	if !strings.Contains(raw, "\nConnected.\n") {
+		t.Fatalf("missing connected line in stderr:\n%s", raw)
+	}
+
+	assertPresenceCalls(t, f, types.PresenceAvailable, types.PresenceAvailable, types.PresenceUnavailable)
+}
+
+// TestSyncPresenceFailureWarnsAndContinues verifies that a failed presence
+// update is logged as a warning and does not abort the sync loop.
+func TestSyncPresenceFailureWarnsAndContinues(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	f.sendPresenceErr = errors.New("presence offline")
+	a.wa = f
+
+	raw := captureStderr(t, func() {
+		// Enable NDJSON events so warnings surface on stderr as JSON events.
+		a.opts.Events = out.NewEventWriter(os.Stderr, true)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := a.Sync(ctx, SyncOptions{
+			Mode:         SyncModeOnce,
+			AllowQR:      false,
+			IdleExit:     time.Millisecond,
+			WarnNoLimits: false,
+		})
+		if err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+	})
+
+	waitForPresenceCalls(t, f, 2)
+
+	if !strings.Contains(raw, "send_presence_failed") {
+		t.Fatalf("missing send_presence_failed warning event in stderr:\n%s", raw)
+	}
+	if !strings.Contains(raw, "presence offline") {
+		t.Fatalf("missing original error text in warning event in stderr:\n%s", raw)
+	}
+}
+
+// TestSyncSendsAvailablePresenceOnConnectedIsSynchronous ensures the event
+// handler presence call happens within the sync lifetime without requiring a
+// follow-mode loop.
+func TestSyncSendsAvailablePresenceOnConnectedIsSynchronous(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	captureStderr(t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := a.Sync(ctx, SyncOptions{
+			Mode:         SyncModeOnce,
+			AllowQR:      false,
+			IdleExit:     time.Millisecond,
+			WarnNoLimits: false,
+		})
+		if err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+	})
+
+	waitForPresenceCalls(t, f, 2)
+}
+
+func assertPresenceCalls(t *testing.T, f *fakeWA, want ...types.Presence) {
+	t.Helper()
+	waitForPresenceCalls(t, f, len(want))
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.presenceCalls) != len(want) {
+		t.Fatalf("got %d presence calls, want %d", len(f.presenceCalls), len(want))
+	}
+	for i, got := range f.presenceCalls {
+		if got != want[i] {
+			t.Fatalf("presence call %d = %v, want %v", i, got, want[i])
+		}
+	}
+}
+
+func waitForPresenceCalls(t *testing.T, f *fakeWA, want int) {
+	t.Helper()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		f.mu.Lock()
+		n := len(f.presenceCalls)
+		f.mu.Unlock()
+		if n >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	f.mu.Lock()
+	n := len(f.presenceCalls)
+	f.mu.Unlock()
+	if n != want {
+		t.Fatalf("timed out waiting for presence calls: got %d, want %d", n, want)
+	}
+}
+
+// TestSyncSendsUnavailableOnErrorExit ensures the unavailable presence is
+// sent even when Sync returns early due to an AfterConnect error, not just
+// on the success path. This covers the P1 finding where storage-limit or
+// reconnect/error exits could leave the linked device marked available.
+func TestSyncSendsUnavailableOnErrorExit(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	captureStderr(t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := a.Sync(ctx, SyncOptions{
+			Mode:         SyncModeOnce,
+			AllowQR:      false,
+			IdleExit:     time.Millisecond,
+			WarnNoLimits: false,
+			AfterConnect: func(context.Context) error {
+				return errors.New("simulated after-connect failure")
+			},
+		})
+		if err == nil {
+			t.Fatalf("expected error from AfterConnect")
+		}
+	})
+
+	// The Connected event fires during Connect (before AfterConnect fails),
+	// so available is sent first. The defer then sends unavailable on the
+	// error exit — proving cleanup runs on all post-connect exits.
+	assertPresenceCalls(t, f, types.PresenceAvailable, types.PresenceUnavailable)
+}

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -135,6 +135,7 @@ func TestSyncEventHandlerClearsUnreadCountOnReadSelfReceipt(t *testing.T) {
 		func(string, string) {},
 		nil,
 		nil,
+		&syncPresence{},
 	)
 	f.emit(&events.Receipt{
 		MessageSource: types.MessageSource{Chat: chat},
@@ -176,6 +177,7 @@ func TestSyncEventHandlerIgnoresRegularReadReceiptsForUnreadCount(t *testing.T) 
 		func(string, string) {},
 		nil,
 		nil,
+		&syncPresence{},
 	)
 	f.emit(&events.Receipt{
 		MessageSource: types.MessageSource{Chat: chat},

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -110,6 +110,13 @@ type ConnectOptions struct {
 	OnQRCode        func(code string)
 	PairPhoneNumber string
 	OnPairCode      func(code string)
+	// DetachSocket, when true, connects the websocket with a detached
+	// context so it is not closed when the caller's context is cancelled.
+	// This allows graceful shutdown to send a final PresenceUnavailable
+	// stanza before the client is disconnected. Only sync uses this;
+	// other commands keep the default (false) so --timeout and signal
+	// cancellation still bound the connection.
+	DetachSocket bool
 }
 
 func (c *Client) Connect(ctx context.Context, opts ConnectOptions) error {
@@ -138,8 +145,44 @@ func (c *Client) Connect(ctx context.Context, opts ConnectOptions) error {
 		qrChan = ch
 	}
 
-	if err := cli.ConnectContext(ctx); err != nil {
+	// When DetachSocket is set (sync), connect with a detached context that
+	// has a 30-second dial timeout. The dial is bounded so a hanging connect
+	// cannot outlive SIGTERM indefinitely; after the dial succeeds the timer
+	// is stopped so the websocket stays open until Disconnect()/Close().
+	// Other commands keep the caller's context so --timeout and signal
+	// cancellation still bound the connection.
+	connCtx := ctx
+	var dialCancel context.CancelFunc
+	var dialTimer *time.Timer
+	var dialStop func() bool
+	if opts.DetachSocket {
+		// Use a detached context so the websocket survives signal
+		// cancellation, but also cancel the dial if the caller's
+		// context fires (--max-reconnect, SIGTERM) so an in-flight
+		// connect cannot outlive caller cancellation.
+		connCtx, dialCancel = context.WithCancel(context.Background())
+		dialTimer = time.AfterFunc(30*time.Second, dialCancel)
+		dialStop = context.AfterFunc(ctx, dialCancel)
+	}
+	if err := cli.ConnectContext(connCtx); err != nil {
+		if dialCancel != nil {
+			dialCancel()
+		}
+		if dialTimer != nil {
+			dialTimer.Stop()
+		}
+		if dialStop != nil {
+			dialStop()
+		}
 		return err
+	}
+	// Dial succeeded — stop the timer and unregister the caller
+	// cancellation hook so the websocket stays alive until Close().
+	if dialTimer != nil {
+		dialTimer.Stop()
+	}
+	if dialStop != nil {
+		dialStop()
 	}
 
 	if authed {
@@ -811,6 +854,17 @@ func sendInitialAvailablePresence(ctx context.Context, cli *whatsmeow.Client) {
 	}
 }
 
+// SendPresence updates the authenticated account's global presence status.
+func (c *Client) SendPresence(ctx context.Context, presence types.Presence) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	return cli.SendPresence(ctx, presence)
+}
+
 func (c *Client) Logout(ctx context.Context) error {
 	c.mu.Lock()
 	cli := c.client
@@ -920,7 +974,7 @@ func (c *Client) ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay ti
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		if err := c.Connect(ctx, ConnectOptions{AllowQR: false}); err == nil {
+		if err := c.Connect(ctx, ConnectOptions{AllowQR: false, DetachSocket: true}); err == nil {
 			return nil
 		}
 		select {


### PR DESCRIPTION
## Problem

A `wacli sync` linked device stays connected but never tells WhatsApp it is active, and when sync exits it fails to tell WhatsApp it is inactive. This causes two user-visible issues:

1. **Stale "last active" timestamp** — WhatsApp's Linked Devices screen shows the device as inactive even while `sync --follow` is running.
2. **Phone stops receiving push notifications** — after sync exits, the device stays marked "available" because the `<presence type="unavailable"/>` send fails every time.

### Root causes

**Missing available presence.** The upstream `main` added `sendInitialAvailablePresence` in `ConnectContext`, but it only runs once at initial connect and only when the pushname is already set. It misses reconnects and late-arriving pushname events.

**Unavailable presence fails on SIGTERM.** `wa.Client.Connect` passed the caller's (signal-cancellable) context to `cli.ConnectContext(ctx)`. When the signal handler cancels it (e.g., `timeout` sending SIGTERM), whatsmeow closes the websocket before `sync.go:207` can send the unavailable presence.

## Solution

### 1. Send available presence on connect and pushname

On `*events.Connected` and `*events.PushNameSetting`, call `sendPresence(ctx, types.PresenceAvailable)` synchronously (not in goroutines) so a delayed available send cannot run after the final unavailable cleanup send.

### 2. Send unavailable presence after sync exit

After a successful sync run, call `sendPresence(ctx, types.PresenceUnavailable)` so the phone resumes push notifications. The event handler is removed before this send so no late `Connected`/`PushNameSetting` event can fire an available presence after cleanup. The cleanup send uses a 5-second timeout context so a stalled WhatsApp write cannot block shutdown.

### 3. Detach websocket context for sync only with bounded dial

Add a `DetachSocket bool` field to `ConnectOptions`. When `true` (set by `connectForSync` and `ReconnectWithBackoff` — sync only), `ConnectContext` uses a detached context with a **30-second dial timeout** (`time.AfterFunc`). The dial is bounded so a hanging connect cannot outlive SIGTERM indefinitely; after the dial succeeds, the timer is stopped so the websocket stays open until `Disconnect()`/`Close()`. Other commands keep the default `false` so `--timeout` and signal cancellation still bound the connection.

The retry loop in `ReconnectWithBackoff` still uses the passed context for cancellation control — only the websocket lifetime is decoupled.

## Files changed

- `internal/wa/client.go` — adds `DetachSocket` field to `ConnectOptions`; uses a dial-timeout-bounded detached context for `ConnectContext` when `DetachSocket` is true; adds `(Client).SendPresence()` wrapper.
- `internal/app/app.go` — adds `SendPresence()` to the `WAClient` interface.
- `internal/app/sync_events.go` — on `*events.Connected` and `*events.PushNameSetting`, calls `sendPresence(ctx, types.PresenceAvailable)` synchronously; adds `App.sendPresence()` helper.
- `internal/app/sync.go` — after a successful sync run, removes the event handler, then sends unavailable presence with a 5-second timeout context; sets `DetachSocket: true` in `connectForSync`.
- `internal/app/fake_wa_test.go` — adds `SendPresence()` fake implementation and tracking fields.
- `internal/app/sync_presence_test.go` — regression tests for connected, push-name setting, failure-warning, synchronous behavior, and the final unavailable send.

## Tests

The full gate passes locally:

```bash
pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check
```

New regression tests:

```bash
go test ./internal/app -run TestSyncSendsAvailablePresence -count=1
go test ./internal/app -run TestSyncPresenceFailureWarnsAndContinues -count=1
go test ./internal/app -run TestSyncSendsAvailablePresenceOnConnectedIsSynchronous -count=1
```

> **Note on websocket-context test coverage:** the unavailable-send-on-SIGTERM fix lives in `wa.Client.Connect` (which calls `cli.ConnectContext`). The app-level tests use a fake WA client whose `SendPresence` always succeeds, so they verify the *call sequence* (available → unavailable) but cannot catch the real `cli.IsConnected()` failure path. A unit test for the detached-context fix would require refactoring `wa.Client` to accept an interface for the whatsmeow client. The fix was verified with a live WhatsApp account (see below).

## Live verification

Tested on a real linked-device account with a `timeout 30s` cron job:

**Before fix — every unavailable send failed:**
```
{"event":"signal","action":"shutdown","signal":"terminated"}
{"event":"stopping","messages_synced":19}
{"event":"warning","code":"send_presence_failed","error":"...context canceled"}
Messages stored: 19
```

**After fix — unavailable send succeeds on SIGTERM:**
```
{"event":"signal","action":"shutdown","signal":"terminated"}
{"event":"stopping","messages_synced":9}
Messages stored: 9
```

No `send_presence_failed` warning — the unavailable presence was sent successfully because the websocket stayed open (DetachSocket with bounded dial).

## Operational notes

No new flags or env vars. The compiled `dist/wacli` binary is already deployed.

For continuous sync via cron, a `timeout 30s wacli sync --idle-exit 10s` cron entry now works correctly: sync runs for ~30s, exits on SIGTERM, sends unavailable presence, and the phone receives push notifications for the remaining ~30s of each minute.

## Checklist

- [x] Code compiles / builds.
- [x] Tests pass (`pnpm test` and FTS path).
- [x] Lint / formatting checks pass.
- [x] `git diff --check` clean.
- [x] Commits squashed into one.
- [x] No release-owned CHANGELOG.md edits.
- [x] Live WhatsApp behavior proof included.
- [x] Available presence sends are synchronous (no goroutine race).
- [x] Event handler removed before unavailable cleanup send.
- [x] Unavailable cleanup send bounded with 5-second timeout.
- [x] `DetachSocket` is sync-only; other commands keep caller-cancellation.
- [x] Detached connect attempt bounded with 30-second dial timeout.
