### PR TITLE
ci: pin and refresh hydration actions

### DIFF
--- a/.github/actions/setup-ci-env/action.yml
+++ b/.github/actions/setup-ci-env/action.yml
@@ -33,7 +33,7 @@ runs:
         node-version: ${{ inputs.node-version }}
 
     - name: Setup Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.1.0
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: true

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   NODE_VERSION: "24"
-  PNPM_VERSION: "10.33.3"
+  PNPM_VERSION: "10.34.4"
 
 jobs:
   hydrate:
@@ -39,20 +39,20 @@ jobs:
     runs-on: [self-hosted, crabbox, openclaw, wacli, "${{ inputs.crabbox_runner_label }}"]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -64,7 +64,6 @@ jobs:
           git fetch --no-tags --depth=50 origin "+refs/heads/main:refs/remotes/origin/main"
           pnpm install --frozen-lockfile
           node --version
-          pnpm --version
           pnpm --version
           go version
 


### PR DESCRIPTION
## Summary

- pin every third-party action in the Crabbox hydration workflow to an immutable commit SHA
- update `actions/setup-go` to v6.5.0 in both the shared CI setup action and hydration workflow
- update hydration to pnpm 10.34.4 and `pnpm/action-setup` v6.0.9
- remove the duplicate pnpm version probe

## Security and compatibility

This closes the floating-tag supply-chain gap in `.github/workflows/crabbox-hydrate.yml`. The selected versions remain on the repository's current major lines; checkout v7 and pnpm 11 are deliberately not included.

Upstream releases:

- https://github.com/actions/setup-go/releases/tag/v6.5.0
- https://github.com/pnpm/action-setup/releases/tag/v6.0.9

## Validation

- `actionlint -config-file .github/actionlint.yaml`
- `pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`
- `govulncheck ./...` — no vulnerabilities found
- Codex autoreview (`gpt-5.5`) on the final diff: no accepted/actionable findings
- public model identifier gate: PASS; no model-bearing surfaces in this change

No external live boundary applies to this workflow-only change; exact-head GitHub Actions is the runtime proof gate.
