### PR TITLE
ci: publish curated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,14 +33,37 @@ jobs:
           go-version-file: go.mod
 
       - name: Stash GoReleaser config
-        run: cp .goreleaser.yaml /tmp/.goreleaser.yaml
+        run: |
+          cp .goreleaser.yaml /tmp/.goreleaser.yaml
+          if ! grep -q '^release:' /tmp/.goreleaser.yaml; then
+            printf '\nrelease:\n  mode: replace\n' >> /tmp/.goreleaser.yaml
+          fi
+
+      - name: Generate release notes from changelog
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            release_tag="$INPUT_TAG"
+          else
+            release_tag="$REF_NAME"
+          fi
+          helper=scripts/extract-release-notes.mjs
+          if [ ! -f "$helper" ]; then
+            git fetch --no-tags --depth=1 origin main
+            git show origin/main:scripts/extract-release-notes.mjs > /tmp/extract-release-notes.mjs
+            helper=/tmp/extract-release-notes.mjs
+          fi
+          node "$helper" --tag "$release_tag" --output /tmp/release-notes.md
 
       - name: GoReleaser (macOS universal)
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: v2.15.4
-          args: release --clean --config /tmp/.goreleaser.yaml
+          args: release --clean --config /tmp/.goreleaser.yaml --release-notes /tmp/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,6 +40,9 @@ archives:
 checksum:
   name_template: checksums.txt
 
+release:
+  mode: replace
+
 changelog:
   sort: asc
   filters:

--- a/docs/release.md
+++ b/docs/release.md
@@ -8,12 +8,13 @@ Read when: cutting a release, debugging release artifacts, or updating the Homeb
 
 To cut a release:
 
-1. Tag and push:
+1. Replace the target `Unreleased` heading in `CHANGELOG.md` with the release date. The workflow refuses to publish while the matching version section is still `Unreleased`.
+2. Tag and push:
    - `git tag vX.Y.Z`
    - `git push origin vX.Y.Z`
-2. Wait for the GitHub Actions “release” workflow to publish the release artifacts.
+3. Wait for the GitHub Actions “release” workflow to publish the release artifacts and use that version's complete `CHANGELOG.md` section as the GitHub Release body.
 
-To re-release an existing tag, run the workflow manually and pass the tag (e.g. `v0.1.0`).
+To re-release an existing tag, run the workflow manually and pass the tag (e.g. `v0.1.0`). The workflow replaces stale release notes with the tagged changelog section.
 
 Expected macOS artifact names (used by the tap updater):
 

--- a/scripts/extract-release-notes.mjs
+++ b/scripts/extract-release-notes.mjs
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export function extractReleaseNotes(changelog, tag) {
+  const version = String(tag).trim().replace(/^v/, "");
+  if (!version) throw new Error("release tag is required");
+
+  const lines = changelog.replace(/\r\n/g, "\n").split("\n");
+  const headingPrefix = `## ${version} - `;
+  const start = lines.findIndex((line) => line.startsWith(headingPrefix));
+  if (start < 0) throw new Error(`missing changelog section for ${version}`);
+  if (lines[start].slice(headingPrefix.length).trim() === "Unreleased") {
+    throw new Error(`changelog section for ${version} is still Unreleased`);
+  }
+
+  let end = lines.findIndex((line, index) => index > start && line.startsWith("## "));
+  if (end < 0) end = lines.length;
+  const body = lines.slice(start + 1, end).join("\n").trim();
+  if (!body) throw new Error(`changelog section for ${version} is empty`);
+  return `## Changelog\n\n${body}\n`;
+}
+
+function parseArgs(argv) {
+  const options = { changelog: "CHANGELOG.md" };
+  for (let i = 0; i < argv.length; i += 1) {
+    const name = argv[i];
+    if (!["--tag", "--changelog", "--output"].includes(name) || !argv[i + 1]) {
+      throw new Error(`invalid argument: ${name}`);
+    }
+    options[name.slice(2)] = argv[i + 1];
+    i += 1;
+  }
+  if (!options.tag) throw new Error("--tag is required");
+  if (!options.output) throw new Error("--output is required");
+  return options;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const changelog = fs.readFileSync(options.changelog, "utf8");
+  fs.writeFileSync(options.output, extractReleaseNotes(changelog, options.tag));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/extract-release-notes.test.mjs
+++ b/scripts/extract-release-notes.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { extractReleaseNotes } from "./extract-release-notes.mjs";
+
+test("extractReleaseNotes returns only the dated target section", () => {
+  const changelog = `# Changelog
+
+## 1.2.4 - Unreleased
+
+### Fixed
+
+- Next fix.
+
+## 1.2.3 - 2026-07-01
+
+### Fixed
+
+- Released fix.
+
+## 1.2.2 - 2026-06-01
+
+- Older fix.
+`;
+
+  assert.equal(extractReleaseNotes(changelog, "v1.2.3"), "## Changelog\n\n### Fixed\n\n- Released fix.\n");
+});
+
+test("extractReleaseNotes rejects an unreleased target section", () => {
+  assert.throws(
+    () => extractReleaseNotes("## 1.2.3 - Unreleased\n\n- Pending.\n", "v1.2.3"),
+    /still Unreleased/,
+  );
+});
+
+test("extractReleaseNotes rejects a missing target section", () => {
+  assert.throws(() => extractReleaseNotes("# Changelog\n", "v1.2.3"), /missing changelog section/);
+});


### PR DESCRIPTION
## Summary

- generate GitHub Release notes from the matching dated `CHANGELOG.md` section
- fail release publication when that section is missing, empty, or still `Unreleased`
- replace stale notes on manual re-runs, including historical tags that predate the helper
- document the release-note gate and add focused extraction tests

## Risk

Low, release workflow only. No runtime or artifact-layout changes. A malformed or unfinished changelog now intentionally stops publication before GoReleaser.

## Proof

- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `git diff --check`
- `govulncheck ./...`
- `actionlint .github/workflows/release.yml`
- `goreleaser check --config .goreleaser.yaml`
- historical v0.11.1 config overlay validated with GoReleaser
- v0.11.1 notes extracted from its full changelog section
- v0.11.2 `Unreleased` section rejected as expected
- autoreview: no accepted/actionable findings

GoReleaser reference: https://goreleaser.com/customization/publish/scm/
