### PR TITLE
ci: refresh release toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           CGO_ENABLED: "1"
         run: |
           output_file=$(mktemp)
-          go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test -tags sqlite_fts5 ./... > "$output_file"
+          go run golang.org/x/tools/cmd/deadcode@v0.47.0 -test -tags sqlite_fts5 ./... > "$output_file"
           if [ -s "$output_file" ]; then
             cat "$output_file"
             exit 1
@@ -71,19 +71,19 @@ jobs:
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
-          version: v2.15.4
+          version: v2.16.0
           args: check --config .goreleaser.yaml
 
       - name: GoReleaser check (linux/windows)
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
-          version: v2.15.4
+          version: v2.16.0
           args: check --config .goreleaser-linux-windows.yaml
 
       - name: GoReleaser build (linux amd64/arm64)
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
-          version: v2.15.4
+          version: v2.16.0
           args: build --snapshot --clean --config .goreleaser-linux-windows.yaml --id wacli_linux_amd64 --id wacli_linux_arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
-          version: v2.15.4
+          version: v2.16.0
           args: release --clean --config /tmp/.goreleaser.yaml --release-notes /tmp/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -154,7 +154,7 @@ jobs:
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
-          version: v2.15.4
+          version: v2.16.0
           args: release --clean --skip=publish --config /tmp/.goreleaser-linux-windows.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- update the pinned GoReleaser binary from v2.15.4 to v2.16.0 in CI and release workflows
- update the CI-only deadcode tool from v0.45.0 to v0.47.0

## Risk

Low, CI/release tooling only. No runtime code, dependencies, artifact layout, or release action changed.

## Proof

- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `git diff --check`
- `govulncheck ./...`
- deadcode v0.47.0: clean
- actionlint: pass
- GoReleaser v2.16.0 config checks: pass for macOS and Linux/Windows configs
- GoReleaser v2.16.0 macOS universal snapshot build: pass
- Linux cross-build: delegated to exact-head Ubuntu CI, which supplies the required cross-compilers
- autoreview: no accepted/actionable findings

Upstream release: https://github.com/goreleaser/goreleaser/releases/tag/v2.16.0
