### PR TITLE
fix: preserve history during release-note fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           fi
           helper=scripts/extract-release-notes.mjs
           if [ ! -f "$helper" ]; then
-            git fetch --no-tags --depth=1 origin main
+            git fetch --no-tags origin main
             git show origin/main:scripts/extract-release-notes.mjs > /tmp/extract-release-notes.mjs
             helper=/tmp/extract-release-notes.mjs
           fi

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const workflow = fs.readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+
+test("historical release fallback preserves the full checkout", () => {
+  const fallback = workflow.match(/if \[ ! -f "\$helper" \]; then([\s\S]*?)\n\s+fi/);
+  assert.ok(fallback, "release-note fallback block is missing");
+  assert.match(fallback[1], /git fetch --no-tags origin main/);
+  assert.doesNotMatch(fallback[1], /--depth(?:=|\s)/);
+});


### PR DESCRIPTION
## Summary

- fetch the current release-note helper without converting a historical tag checkout into a shallow repository
- add a focused workflow regression test that forbids shallow fallback fetches

## Root cause

The historical re-release fallback used `git fetch --depth=1` after `actions/checkout` deliberately created a full-history checkout. Git marks the repository shallow after that fetch, so the following GoReleaser step can run without the complete history it expects.

This addresses the actionable review finding on https://github.com/openclaw/wacli/pull/287.

## Risk

Low. Release workflow and test only; normal tag releases that already contain the helper are unchanged. Historical reruns now fetch `main` with full history.

## Proof

Exact head: `a9c5362f`

- reproduction: full clone reports `false`; the old depth-1 fetch changes `git rev-parse --is-shallow-repository` to `true`; the fixed fetch keeps it `false`
- `pnpm -s test:docs` — 6/6 passed, including the new regression
- `actionlint -config-file .github/actionlint.yaml .github/workflows/release.yml`
- `pnpm docs:site && pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`
- `govulncheck ./...` — no vulnerabilities found
- Codex autoreview (`gpt-5.5`) — no accepted/actionable findings
- public model identifier gate: PASS; no model-bearing surfaces

No external live boundary applies to this workflow-only change; exact-head GitHub Actions is the hosted runtime proof gate.