### PR TITLE
feat(media): backfill already-synced downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Media: add `media backfill` to download media for already-synced messages that have metadata but no local copy. (thanks @njt)
+
 ### Security
 
 - Store: replace dynamic schema-inspection SQL with fixed allowlisted queries. (thanks @dovocoder)

--- a/cmd/wacli/media.go
+++ b/cmd/wacli/media.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openclaw/wacli/internal/app"
 	"github.com/openclaw/wacli/internal/out"
 	"github.com/openclaw/wacli/internal/wa"
 	"github.com/spf13/cobra"
@@ -18,7 +19,100 @@ func newMediaCmd(flags *rootFlags) *cobra.Command {
 		Short: "Media download",
 	}
 	cmd.AddCommand(newMediaDownloadCmd(flags))
+	cmd.AddCommand(newMediaBackfillCmd(flags))
 	return cmd
+}
+
+func newMediaBackfillCmd(flags *rootFlags) *cobra.Command {
+	var chat string
+	var limit int
+	var workers int
+
+	cmd := &cobra.Command{
+		Use:   "backfill",
+		Short: "Download media for already-synced messages missing a local copy",
+		Long: "Fetch media for messages already stored in the local database that have\n" +
+			"downloadable metadata but no local file yet. Unlike `sync --download-media`,\n" +
+			"which only downloads media for messages arriving during the sync, this scans\n" +
+			"existing rows and downloads them over a single connection.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if limit < 0 {
+				return fmt.Errorf("--limit must be >= 0")
+			}
+			if workers < 0 {
+				return fmt.Errorf("--workers must be >= 0")
+			}
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+
+			ctx, cancel := mediaBackfillContext(cmd, flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+
+			res, err := a.BackfillMedia(ctx, app.BackfillMediaOptions{
+				ChatJID: chat,
+				Limit:   limit,
+				Workers: workers,
+			})
+			if err != nil {
+				return err
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{
+					"pending":    res.Pending,
+					"attempted":  res.Attempted,
+					"downloaded": res.Downloaded,
+					"skipped":    res.Skipped,
+					"failed":     res.Failed,
+				})
+			}
+			fmt.Fprintf(os.Stdout, "Pending: %d  Attempted: %d  Downloaded: %d  Skipped: %d  Failed: %d\n",
+				res.Pending, res.Attempted, res.Downloaded, res.Skipped, res.Failed)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&chat, "chat", "", "limit backfill to a single chat JID")
+	cmd.Flags().IntVar(&limit, "limit", 0, "maximum number of media files to download (0 = all)")
+	cmd.Flags().IntVar(&workers, "workers", 4, "number of concurrent downloads")
+	return cmd
+}
+
+func mediaBackfillContext(cmd *cobra.Command, flags *rootFlags) (context.Context, context.CancelFunc) {
+	ctx, stop := signalContextWithEvents(out.NewEventWriter(os.Stderr, flags.events))
+	if !mediaBackfillTimeoutEnabled(cmd, flags) {
+		return ctx, stop
+	}
+	timedCtx, cancel := withTimeout(ctx, flags)
+	return timedCtx, func() {
+		cancel()
+		stop()
+	}
+}
+
+func mediaBackfillTimeoutEnabled(cmd *cobra.Command, flags *rootFlags) bool {
+	if cmd == nil || flags == nil || flags.timeout <= 0 {
+		return false
+	}
+	if flag := cmd.Flags().Lookup("timeout"); flag != nil && flag.Changed {
+		return true
+	}
+	flag := cmd.InheritedFlags().Lookup("timeout")
+	return flag != nil && flag.Changed
 }
 
 func newMediaDownloadCmd(flags *rootFlags) *cobra.Command {

--- a/cmd/wacli/media_test.go
+++ b/cmd/wacli/media_test.go
@@ -3,7 +3,28 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
 )
+
+func TestMediaBackfillTimeoutIsOptIn(t *testing.T) {
+	flags := &rootFlags{timeout: 5 * time.Minute}
+	root := &cobra.Command{Use: "wacli"}
+	root.PersistentFlags().DurationVar(&flags.timeout, "timeout", flags.timeout, "command timeout")
+	cmd := newMediaBackfillCmd(flags)
+	root.AddCommand(cmd)
+
+	if mediaBackfillTimeoutEnabled(cmd, flags) {
+		t.Fatalf("default timeout unexpectedly enabled")
+	}
+	if err := root.PersistentFlags().Set("timeout", "1s"); err != nil {
+		t.Fatalf("set timeout: %v", err)
+	}
+	if !mediaBackfillTimeoutEnabled(cmd, flags) {
+		t.Fatalf("explicit timeout was not enabled")
+	}
+}
 
 func TestMediaDownloadReadOnlyRequiresOutput(t *testing.T) {
 	err := execute([]string{"--read-only", "media", "download", "--chat", "chat@s.whatsapp.net", "--id", "mid"})

--- a/docs/media.md
+++ b/docs/media.md
@@ -4,13 +4,18 @@ Read when: downloading media from a synced message.
 
 `wacli media` downloads media referenced by messages already stored in `wacli.db`.
 
-## Command
+## Commands
 
 ```bash
 wacli media download --chat JID --id MSG_ID [--output PATH]
+wacli media backfill [--chat JID] [--limit N] [--workers N]
 ```
 
-## Notes
+## download
+
+Downloads media for a single message.
+
+### Notes
 
 - The target message must already be synced.
 - Media downloads are capped at 100 MiB.
@@ -18,11 +23,39 @@ wacli media download --chat JID --id MSG_ID [--output PATH]
 - If `--output` is omitted, media is written under the store media directory.
 - `--read-only` is supported only with explicit `--output`; it writes the file without opening the WhatsApp session store or recording `local_path` / `downloaded_at`.
 
-## Examples
+### Examples
 
 ```bash
 wacli media download --chat 1234567890@s.whatsapp.net --id ABC123
 wacli media download --chat 1234567890@s.whatsapp.net --id ABC123 --output ./downloads
 wacli media download --chat 1234567890@s.whatsapp.net --id ABC123 --output ./photo.jpg
 wacli --read-only media download --chat 1234567890@s.whatsapp.net --id ABC123 --output /tmp/photo.jpg
+```
+
+## backfill
+
+Downloads media for every already-synced message that has downloadable metadata
+but no local copy yet, over a single connection.
+
+`sync --download-media` only downloads media for messages that *arrive during*
+the sync session. Media for messages synced earlier is never fetched by sync;
+`media backfill` closes that gap by scanning existing rows.
+
+### Notes
+
+- Files are written under the store media directory (same layout as `download`).
+- `--chat` scopes the backfill to a single chat JID.
+- `--limit` caps how many files to download (0 = all); newest messages first.
+- `--workers` sets the number of concurrent downloads (default 4).
+- Runs until completion or interruption by default; explicitly set global `--timeout` to cap a run.
+- Requires a writable store; not available in `--read-only` mode.
+- Reports counts: pending (total matching), attempted, downloaded, skipped, failed.
+
+### Examples
+
+```bash
+wacli media backfill                                   # download all pending media
+wacli media backfill --limit 50                        # download the 50 newest pending
+wacli media backfill --chat 1234567890@s.whatsapp.net  # one chat only
+wacli media backfill --json                            # machine-readable counts
 ```

--- a/internal/app/media.go
+++ b/internal/app/media.go
@@ -204,7 +204,7 @@ func (a *App) runMediaWorkers(ctx context.Context, queue *mediaQueue, workers in
 						if strings.TrimSpace(job.chatJID) == "" || strings.TrimSpace(job.msgID) == "" {
 							return
 						}
-						if err := a.downloadMediaJob(ctx, job); err != nil {
+						if _, err := a.downloadMediaJob(ctx, job); err != nil {
 							a.emitWarning(
 								"media_download_failed",
 								fmt.Sprintf("media download failed for %s/%s: %v", job.chatJID, job.msgID, err),
@@ -220,33 +220,40 @@ func (a *App) runMediaWorkers(ctx context.Context, queue *mediaQueue, workers in
 	return wg.Wait, cancelWorkers, nil
 }
 
-func (a *App) downloadMediaJob(ctx context.Context, job mediaJob) error {
+// downloadMediaJob fetches the media for a single message to disk and records
+// the local path. It returns downloaded=true only when a file was actually
+// fetched; a job that is already downloaded or lacks the metadata needed to
+// download is skipped with downloaded=false and a nil error.
+func (a *App) downloadMediaJob(ctx context.Context, job mediaJob) (downloaded bool, err error) {
 	info, err := a.db.GetMediaDownloadInfo(job.chatJID, job.msgID)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return nil
+			return false, nil
 		}
-		return err
+		return false, err
 	}
 	if strings.TrimSpace(info.LocalPath) != "" {
-		return nil
+		return false, nil
 	}
 	if strings.TrimSpace(info.MediaType) == "" || strings.TrimSpace(info.DirectPath) == "" || len(info.MediaKey) == 0 {
-		return nil
+		return false, nil
 	}
 
 	targetPath, err := a.ResolveMediaOutputPath(info, "")
 	if err != nil {
-		return err
+		return false, err
 	}
 	if err := fsutil.EnsurePrivateDir(filepath.Dir(targetPath)); err != nil {
-		return err
+		return false, err
 	}
 
 	if _, err := a.wa.DownloadMediaToFile(ctx, info.DirectPath, info.FileEncSHA256, info.FileSHA256, info.MediaKey, info.FileLength, info.MediaType, "", targetPath); err != nil {
-		return err
+		return false, err
 	}
 
 	now := nowUTC()
-	return a.db.MarkMediaDownloaded(info.ChatJID, info.MsgID, targetPath, now)
+	if err := a.db.MarkMediaDownloaded(info.ChatJID, info.MsgID, targetPath, now); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/internal/app/media_backfill.go
+++ b/internal/app/media_backfill.go
@@ -1,0 +1,177 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/openclaw/wacli/internal/store"
+)
+
+// BackfillMediaOptions controls a one-shot backfill of media already recorded in
+// the local database but not yet downloaded to disk.
+type BackfillMediaOptions struct {
+	// ChatJID, when non-empty, scopes the backfill to a single chat.
+	ChatJID string
+	// Limit caps how many pending downloads to attempt (<= 0 means all).
+	Limit int
+	// Workers is the number of concurrent downloads (defaults to 4).
+	Workers int
+}
+
+// BackfillMediaResult summarises a backfill run.
+type BackfillMediaResult struct {
+	// Pending is the total number of downloadable-but-not-downloaded messages
+	// matching the filter, before Limit is applied.
+	Pending int
+	// Attempted is how many downloads were tried (bounded by Limit).
+	Attempted int
+	// Downloaded is how many files were successfully fetched.
+	Downloaded int
+	// Skipped is how many jobs were already downloaded or lacked metadata by the
+	// time the worker reached them.
+	Skipped int
+	// Failed is how many downloads returned an error.
+	Failed int
+}
+
+// BackfillMedia downloads media for messages already stored in the local
+// database that have downloadable metadata but no local copy yet. Unlike
+// `sync --download-media`, which only fetches media for messages arriving during
+// the sync session, this scans existing rows and fetches them over a single
+// connection. The caller must have an authenticated, connected client.
+func (a *App) BackfillMedia(ctx context.Context, opts BackfillMediaOptions) (BackfillMediaResult, error) {
+	if err := ctx.Err(); err != nil {
+		return BackfillMediaResult{}, err
+	}
+	if opts.Limit < 0 {
+		return BackfillMediaResult{}, fmt.Errorf("limit must be >= 0")
+	}
+	if opts.Workers < 0 {
+		return BackfillMediaResult{}, fmt.Errorf("workers must be >= 0")
+	}
+	opts.ChatJID = strings.TrimSpace(opts.ChatJID)
+
+	workers := opts.Workers
+	if workers <= 0 {
+		workers = 4
+	}
+
+	pendingTotal, err := a.db.CountPendingMediaDownloads(ctx, opts.ChatJID)
+	if err != nil {
+		return BackfillMediaResult{}, fmt.Errorf("count pending media: %w", err)
+	}
+	result := BackfillMediaResult{Pending: pendingTotal}
+	if pendingTotal == 0 {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		return result, nil
+	}
+
+	jobs, err := a.db.ListPendingMediaDownloads(ctx, opts.ChatJID, opts.Limit)
+	if err != nil {
+		return result, fmt.Errorf("list pending media: %w", err)
+	}
+	if len(jobs) == 0 {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		return result, nil
+	}
+	if workers > len(jobs) {
+		workers = len(jobs)
+	}
+
+	a.emitEvent("media_backfill_start", map[string]any{
+		"pending":  pendingTotal,
+		"selected": len(jobs),
+		"chat_jid": opts.ChatJID,
+	})
+
+	var attempted, downloaded, skipped, failed atomic.Int64
+	jobCh := make(chan store.PendingMediaDownload)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for pj := range jobCh {
+				if ctx.Err() != nil {
+					return
+				}
+				attempted.Add(1)
+				job := mediaJob{chatJID: pj.ChatJID, msgID: pj.MsgID}
+				// Recover per job so one panic fails a single download
+				// instead of killing the worker (mirrors runMediaWorkers, #52).
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							failed.Add(1)
+							if a.eventsEnabled() {
+								a.emitEvent("media_worker_panic", map[string]any{
+									"chat_jid": job.chatJID,
+									"msg_id":   job.msgID,
+									"panic":    fmt.Sprint(r),
+									"stack":    string(debug.Stack()),
+								})
+							} else {
+								fmt.Fprintf(os.Stderr, "media worker panic (recovered) for %s/%s: %v\n%s\n",
+									job.chatJID, job.msgID, r, debug.Stack())
+							}
+						}
+					}()
+					ok, err := a.downloadMediaJob(ctx, job)
+					switch {
+					case err != nil:
+						failed.Add(1)
+						a.emitWarning(
+							"media_download_failed",
+							fmt.Sprintf("media download failed for %s/%s: %v", job.chatJID, job.msgID, err),
+							map[string]any{"chat_jid": job.chatJID, "msg_id": job.msgID, "error": err.Error()},
+						)
+					case ok:
+						downloaded.Add(1)
+					default:
+						skipped.Add(1)
+					}
+				}()
+			}
+		}()
+	}
+
+	feed := func() {
+		defer close(jobCh)
+		for _, job := range jobs {
+			if ctx.Err() != nil {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case jobCh <- job:
+			}
+		}
+	}
+	feed()
+	wg.Wait()
+
+	result.Attempted = int(attempted.Load())
+	result.Downloaded = int(downloaded.Load())
+	result.Skipped = int(skipped.Load())
+	result.Failed = int(failed.Load())
+
+	a.emitEvent("media_backfill_done", map[string]any{
+		"pending":    result.Pending,
+		"attempted":  result.Attempted,
+		"downloaded": result.Downloaded,
+		"skipped":    result.Skipped,
+		"failed":     result.Failed,
+	})
+
+	return result, ctx.Err()
+}

--- a/internal/app/media_backfill_test.go
+++ b/internal/app/media_backfill_test.go
@@ -1,0 +1,157 @@
+package app
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/openclaw/wacli/internal/store"
+)
+
+func insertMediaMessage(t *testing.T, a *App, chat, id string, ts time.Time) {
+	t.Helper()
+	if err := a.db.UpsertMessage(store.UpsertMessageParams{
+		ChatJID:       chat,
+		MsgID:         id,
+		SenderJID:     chat,
+		SenderName:    "Alice",
+		Timestamp:     ts,
+		MediaType:     "image",
+		Filename:      id + ".jpg",
+		MimeType:      "image/jpeg",
+		DirectPath:    "/direct/" + id,
+		MediaKey:      []byte{1, 2, 3},
+		FileSHA256:    []byte{4, 5},
+		FileEncSHA256: []byte{6, 7},
+		FileLength:    123,
+	}); err != nil {
+		t.Fatalf("UpsertMessage %s: %v", id, err)
+	}
+}
+
+func TestBackfillMediaDownloadsPending(t *testing.T) {
+	a := newTestApp(t)
+	a.wa = newFakeWA()
+
+	chat := "123@s.whatsapp.net"
+	if err := a.db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	base := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+	insertMediaMessage(t, a, chat, "m1", base)
+	insertMediaMessage(t, a, chat, "m2", base.Add(time.Second))
+	insertMediaMessage(t, a, chat, "m3", base.Add(2*time.Second))
+
+	// A text-only message must be ignored.
+	if err := a.db.UpsertMessage(store.UpsertMessageParams{
+		ChatJID: chat, MsgID: "text", SenderJID: chat, Timestamp: base, Text: "hi",
+	}); err != nil {
+		t.Fatalf("UpsertMessage text: %v", err)
+	}
+
+	res, err := a.BackfillMedia(context.Background(), BackfillMediaOptions{})
+	if err != nil {
+		t.Fatalf("BackfillMedia: %v", err)
+	}
+	if res.Pending != 3 || res.Attempted != 3 || res.Downloaded != 3 || res.Failed != 0 || res.Skipped != 0 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+
+	for _, id := range []string{"m1", "m2", "m3"} {
+		info, err := a.db.GetMediaDownloadInfo(chat, id)
+		if err != nil {
+			t.Fatalf("GetMediaDownloadInfo %s: %v", id, err)
+		}
+		if info.LocalPath == "" {
+			t.Fatalf("expected LocalPath set for %s", id)
+		}
+		if _, err := os.Stat(info.LocalPath); err != nil {
+			t.Fatalf("expected file for %s: %v", id, err)
+		}
+	}
+
+	// A second run has nothing left to do.
+	res2, err := a.BackfillMedia(context.Background(), BackfillMediaOptions{})
+	if err != nil {
+		t.Fatalf("BackfillMedia rerun: %v", err)
+	}
+	if res2.Pending != 0 || res2.Attempted != 0 || res2.Downloaded != 0 {
+		t.Fatalf("expected nothing pending on rerun, got %+v", res2)
+	}
+}
+
+func TestBackfillMediaLimitAndChatFilter(t *testing.T) {
+	a := newTestApp(t)
+	a.wa = newFakeWA()
+
+	chatA := "111@s.whatsapp.net"
+	chatB := "222@s.whatsapp.net"
+	for _, c := range []string{chatA, chatB} {
+		if err := a.db.UpsertChat(c, "dm", "x", time.Now()); err != nil {
+			t.Fatalf("UpsertChat %s: %v", c, err)
+		}
+	}
+	base := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+	insertMediaMessage(t, a, chatA, "a1", base)
+	insertMediaMessage(t, a, chatA, "a2", base)
+	insertMediaMessage(t, a, chatB, "b1", base) // newest row among equal timestamps
+
+	// Limit caps attempts but reports the full pending total. Newest-first,
+	// rowid-stable ordering means the single attempt is b1.
+	res, err := a.BackfillMedia(context.Background(), BackfillMediaOptions{Limit: 1})
+	if err != nil {
+		t.Fatalf("BackfillMedia: %v", err)
+	}
+	if res.Pending != 3 || res.Attempted != 1 || res.Downloaded != 1 {
+		t.Fatalf("limit result unexpected: %+v", res)
+	}
+	if n, err := a.db.CountPendingMediaDownloads(context.Background(), chatB); err != nil || n != 0 {
+		t.Fatalf("expected chatB drained by limit run, got %d (err %v)", n, err)
+	}
+
+	// Chat filter scopes the remaining work to one chat only.
+	res, err = a.BackfillMedia(context.Background(), BackfillMediaOptions{ChatJID: chatA})
+	if err != nil {
+		t.Fatalf("BackfillMedia chatA: %v", err)
+	}
+	if res.Pending != 2 || res.Attempted != 2 || res.Downloaded != 2 {
+		t.Fatalf("chat filter result unexpected: %+v", res)
+	}
+	// Everything is now downloaded.
+	if n, err := a.db.CountPendingMediaDownloads(context.Background(), ""); err != nil || n != 0 {
+		t.Fatalf("expected 0 pending overall, got %d (err %v)", n, err)
+	}
+}
+
+func TestBackfillMediaCanceledBeforeDispatch(t *testing.T) {
+	a := newTestApp(t)
+	a.wa = newFakeWA()
+
+	chat := "123@s.whatsapp.net"
+	if err := a.db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	insertMediaMessage(t, a, chat, "m1", time.Now())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	res, err := a.BackfillMedia(ctx, BackfillMediaOptions{})
+	if err != context.Canceled {
+		t.Fatalf("BackfillMedia error = %v, want context.Canceled", err)
+	}
+	if res != (BackfillMediaResult{}) {
+		t.Fatalf("unexpected canceled result: %+v", res)
+	}
+}
+
+func TestBackfillMediaRejectsNegativeOptions(t *testing.T) {
+	a := newTestApp(t)
+
+	if _, err := a.BackfillMedia(context.Background(), BackfillMediaOptions{Limit: -1}); err == nil {
+		t.Fatalf("expected negative limit error")
+	}
+	if _, err := a.BackfillMedia(context.Background(), BackfillMediaOptions{Workers: -1}); err == nil {
+		t.Fatalf("expected negative workers error")
+	}
+}

--- a/internal/app/media_test.go
+++ b/internal/app/media_test.go
@@ -72,8 +72,12 @@ func TestDownloadMediaJobMarksDownloaded(t *testing.T) {
 		t.Fatalf("UpsertMessage: %v", err)
 	}
 
-	if err := a.downloadMediaJob(context.Background(), mediaJob{chatJID: chat, msgID: "mid"}); err != nil {
+	downloaded, err := a.downloadMediaJob(context.Background(), mediaJob{chatJID: chat, msgID: "mid"})
+	if err != nil {
 		t.Fatalf("downloadMediaJob: %v", err)
+	}
+	if !downloaded {
+		t.Fatalf("expected downloaded=true")
 	}
 
 	info, err := a.db.GetMediaDownloadInfo(chat, "mid")

--- a/internal/store/media.go
+++ b/internal/store/media.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"time"
 
 	"github.com/openclaw/wacli/internal/store/storedb"
@@ -29,6 +30,42 @@ func (d *DB) GetMediaDownloadInfo(chatJID, msgID string) (MediaDownloadInfo, err
 		info.FileLength = uint64(row.FileLength)
 	}
 	return info, nil
+}
+
+// PendingMediaDownload identifies a message whose media has downloadable
+// metadata (direct_path + media_key) but has not yet been fetched to disk.
+type PendingMediaDownload struct {
+	ChatJID string
+	MsgID   string
+}
+
+// CountPendingMediaDownloads returns how many stored messages have downloadable
+// media that has not been fetched yet. Pass a non-empty chatJID to scope the
+// count to a single chat.
+func (d *DB) CountPendingMediaDownloads(ctx context.Context, chatJID string) (int, error) {
+	n, err := d.q.CountPendingMediaDownloads(ctx, chatJID)
+	if err != nil {
+		return 0, err
+	}
+	return int(n), nil
+}
+
+// ListPendingMediaDownloads returns messages with downloadable but not-yet-fetched
+// media, newest first. Pass a non-empty chatJID to scope to a single chat, and a
+// positive limit to cap the number of rows (limit <= 0 means no limit).
+func (d *DB) ListPendingMediaDownloads(ctx context.Context, chatJID string, limit int) ([]PendingMediaDownload, error) {
+	rows, err := d.q.ListPendingMediaDownloads(ctx, storedb.ListPendingMediaDownloadsParams{
+		ChatJid:    chatJID,
+		LimitCount: int64(limit),
+	})
+	if err != nil {
+		return nil, err
+	}
+	pending := make([]PendingMediaDownload, 0, len(rows))
+	for _, row := range rows {
+		pending = append(pending, PendingMediaDownload{ChatJID: row.ChatJid, MsgID: row.MsgID})
+	}
+	return pending, nil
 }
 
 func (d *DB) MarkMediaDownloaded(chatJID, msgID, localPath string, downloadedAt time.Time) error {

--- a/internal/store/media_test.go
+++ b/internal/store/media_test.go
@@ -1,0 +1,20 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestPendingMediaQueriesHonorCanceledContext(t *testing.T) {
+	db := openTestDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := db.CountPendingMediaDownloads(ctx, ""); !errors.Is(err, context.Canceled) {
+		t.Fatalf("CountPendingMediaDownloads error = %v, want context.Canceled", err)
+	}
+	if _, err := db.ListPendingMediaDownloads(ctx, "", 0); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ListPendingMediaDownloads error = %v, want context.Canceled", err)
+	}
+}

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -374,6 +374,30 @@ WHERE m.chat_jid = ? AND m.msg_id = ?;
 -- name: MarkMediaDownloaded :exec
 UPDATE messages SET local_path = ?, downloaded_at = ? WHERE chat_jid = ? AND msg_id = ?;
 
+-- name: CountPendingMediaDownloads :one
+SELECT COUNT(*)
+FROM messages m
+WHERE COALESCE(m.media_type,'') != ''
+  AND COALESCE(m.direct_path,'') != ''
+  AND m.media_key IS NOT NULL AND length(m.media_key) > 0
+  AND COALESCE(m.local_path,'') = ''
+  AND m.revoked = 0
+  AND m.deleted_for_me = 0
+  AND (sqlc.arg(chat_jid) = '' OR m.chat_jid = sqlc.arg(chat_jid));
+
+-- name: ListPendingMediaDownloads :many
+SELECT m.chat_jid, m.msg_id
+FROM messages m
+WHERE COALESCE(m.media_type,'') != ''
+  AND COALESCE(m.direct_path,'') != ''
+  AND m.media_key IS NOT NULL AND length(m.media_key) > 0
+  AND COALESCE(m.local_path,'') = ''
+  AND m.revoked = 0
+  AND m.deleted_for_me = 0
+  AND (sqlc.arg(chat_jid) = '' OR m.chat_jid = sqlc.arg(chat_jid))
+ORDER BY m.ts DESC, m.rowid DESC
+LIMIT CASE WHEN sqlc.arg(limit_count) <= 0 THEN -1 ELSE sqlc.arg(limit_count) END;
+
 -- name: UpsertPoll :exec
 INSERT INTO polls (chat_jid, msg_id, sender_jid, question, options_json, selectable_count, created_ts)
 VALUES (?, ?, ?, ?, ?, ?, ?)

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -94,6 +94,25 @@ func (q *Queries) CountMessages(ctx context.Context) (int64, error) {
 	return count, err
 }
 
+const countPendingMediaDownloads = `-- name: CountPendingMediaDownloads :one
+SELECT COUNT(*)
+FROM messages m
+WHERE COALESCE(m.media_type,'') != ''
+  AND COALESCE(m.direct_path,'') != ''
+  AND m.media_key IS NOT NULL AND length(m.media_key) > 0
+  AND COALESCE(m.local_path,'') = ''
+  AND m.revoked = 0
+  AND m.deleted_for_me = 0
+  AND (?1 = '' OR m.chat_jid = ?1)
+`
+
+func (q *Queries) CountPendingMediaDownloads(ctx context.Context, chatJid interface{}) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countPendingMediaDownloads, chatJid)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countSystemNames = `-- name: CountSystemNames :one
 SELECT COUNT(1) FROM contacts WHERE system_name IS NOT NULL AND system_name != ''
 `
@@ -719,6 +738,53 @@ func (q *Queries) ListLeftGroups(ctx context.Context) ([]ListLeftGroupsRow, erro
 			&i.LeftAt,
 			&i.UpdatedAt,
 		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listPendingMediaDownloads = `-- name: ListPendingMediaDownloads :many
+SELECT m.chat_jid, m.msg_id
+FROM messages m
+WHERE COALESCE(m.media_type,'') != ''
+  AND COALESCE(m.direct_path,'') != ''
+  AND m.media_key IS NOT NULL AND length(m.media_key) > 0
+  AND COALESCE(m.local_path,'') = ''
+  AND m.revoked = 0
+  AND m.deleted_for_me = 0
+  AND (?1 = '' OR m.chat_jid = ?1)
+ORDER BY m.ts DESC, m.rowid DESC
+LIMIT CASE WHEN ?2 <= 0 THEN -1 ELSE ?2 END
+`
+
+type ListPendingMediaDownloadsParams struct {
+	ChatJid    interface{}
+	LimitCount interface{}
+}
+
+type ListPendingMediaDownloadsRow struct {
+	ChatJid string
+	MsgID   string
+}
+
+func (q *Queries) ListPendingMediaDownloads(ctx context.Context, arg ListPendingMediaDownloadsParams) ([]ListPendingMediaDownloadsRow, error) {
+	rows, err := q.db.QueryContext(ctx, listPendingMediaDownloads, arg.ChatJid, arg.LimitCount)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListPendingMediaDownloadsRow
+	for rows.Next() {
+		var i ListPendingMediaDownloadsRow
+		if err := rows.Scan(&i.ChatJid, &i.MsgID); err != nil {
 			return nil, err
 		}
 		items = append(items, i)


### PR DESCRIPTION
## Summary

Add `wacli media backfill` for media metadata already present in the local store but missing a local file. The command supports optional chat filtering, newest-first limits, bounded worker concurrency, human/JSON result counts, interruption, and an explicit opt-in timeout.

This maintainer rewrite narrows the original combined PR to backfill only:

- the one-shot drain bug already landed separately in #295
- the media-retry protocol and schema migration are excluded for separate review
- contributor credit is preserved in the commit and changelog

## Maintainer hardening

- cancellation reaches pending-media count/list queries and workers
- pre-canceled contexts cannot dispatch downloads
- unlimited backfill has no implicit five-minute deadline; explicit `--timeout` still works
- worker count is bounded by selected jobs
- newest-first ties use stable row order
- negative limits and worker counts are rejected
- sqlc output regenerated from the checked-in query

## Verification

Exact head: `33a1ecc`

- structured autoreview: clean after fixing cancellation and default-timeout findings
- `go test -race ./...`
- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm docs:site`
- `git diff --check`

Source-blind live validation on the exact built patch:

- sent the public repository README to the linked account's self-chat
- `media backfill --limit 1 --workers 1 --json` reported pending `2044`, attempted `1`, downloaded `1`, skipped `0`, failed `0`
- the downloaded fixture had a persisted local path
- downloaded bytes matched the sent fixture exactly by SHA-256
- negative-limit validation failed before store access
