### PR TITLE
fix(store): harden SQLite schema inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Security
 
+- Store: replace dynamic schema-inspection SQL with fixed allowlisted queries. (thanks @dovocoder)
+
 ### Fixed
 
 - Sync: finish queued media downloads before clean one-shot and bootstrap exits instead of canceling them at idle. (thanks @njt)

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -596,12 +596,14 @@ func (d *DB) tableExists(table string) (bool, error) {
 }
 
 func (d *DB) tableHasColumn(table, column string) (bool, error) {
-	// table is always a hardcoded identifier at call sites; validate to prevent
-	// accidental misuse with user-controlled input (#58).
-	if table == "" {
-		return false, fmt.Errorf("tableHasColumn: table name is required")
+	query, err := tableInfoPragma(table)
+	if err != nil {
+		return false, fmt.Errorf("tableHasColumn table: %w", err)
 	}
-	rows, err := d.sql.Query("PRAGMA table_info(" + table + ")")
+	if !isSQLiteIdentifier(column) {
+		return false, fmt.Errorf("tableHasColumn column: invalid SQLite identifier %q", column)
+	}
+	rows, err := d.sql.Query(query)
 	if err != nil {
 		return false, err
 	}
@@ -624,4 +626,40 @@ func (d *DB) tableHasColumn(table, column string) (bool, error) {
 		}
 	}
 	return false, rows.Err()
+}
+
+func tableInfoPragma(table string) (string, error) {
+	switch table {
+	case "chats":
+		return `PRAGMA table_info("chats")`, nil
+	case "contacts":
+		return `PRAGMA table_info("contacts")`, nil
+	case "groups":
+		return `PRAGMA table_info("groups")`, nil
+	case "messages":
+		return `PRAGMA table_info("messages")`, nil
+	case "messages_fts":
+		return `PRAGMA table_info("messages_fts")`, nil
+	case "status_messages":
+		return `PRAGMA table_info("status_messages")`, nil
+	default:
+		return "", fmt.Errorf("unsupported table %q", table)
+	}
+}
+
+func isSQLiteIdentifier(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') {
+			continue
+		}
+		if i > 0 && '0' <= c && c <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
 }

--- a/internal/store/schema_test.go
+++ b/internal/store/schema_test.go
@@ -111,6 +111,33 @@ func TestOpenCreatesExpectedSchema(t *testing.T) {
 	}
 }
 
+func TestTableHasColumnRejectsUnsafeIdentifier(t *testing.T) {
+	db := openTestDB(t)
+
+	if _, err := db.tableHasColumn(`messages); DROP TABLE messages; --`, "msg_id"); err == nil {
+		t.Fatalf("expected unsafe table identifier to be rejected")
+	}
+	if _, err := db.tableHasColumn("messages", `msg_id); DROP TABLE messages; --`); err == nil {
+		t.Fatalf("expected unsafe column identifier to be rejected")
+	}
+
+	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM messages"); got != 0 {
+		t.Fatalf("messages table was unexpectedly modified, row count = %d", got)
+	}
+}
+
+func TestTableHasColumnAllowsSchemaIdentifiers(t *testing.T) {
+	db := openTestDB(t)
+
+	hasColumn, err := db.tableHasColumn("messages", "display_text")
+	if err != nil {
+		t.Fatalf("tableHasColumn: %v", err)
+	}
+	if !hasColumn {
+		t.Fatalf("expected messages.display_text to exist")
+	}
+}
+
 func TestOpenMigratesLegacyUnreadCounts(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wacli.db")


### PR DESCRIPTION
## Summary

- replace dynamic `PRAGMA table_info(...)` construction with fixed allowlisted schema queries
- reject unknown tables and invalid column identifiers before querying SQLite
- add regression coverage for malicious identifiers and normal schema lookup
- add the maintainer changelog entry and preserve contributor credit

This maintainer rewrite intentionally narrows the original 67-file analyzer-driven refactor to the one concrete, high-confidence finding on current `main`. The wider cleanup crossed send, sync, store, and WhatsApp runtime paths without enough benefit to justify that regression surface as one landing unit.

Refs #293.

## Verification

Exact head: `1b427aa7431eafc539c16641c2c2b6a637fdfb67`

- structured autoreview: clean; no accepted/actionable findings
- `go test -race ./...`
- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `git diff --check main...HEAD`

Source-blind runtime validation against the built exact head:

- existing linked-account store opened without migration/schema errors
- `doctor --connect` reported authenticated and connected
- redacted `messages list --limit 1` and `--limit 2` output shapes matched current `main`
- `sync --once --idle-exit 5s` connected and exited successfully
- an unknown account was rejected rather than reporting authenticated success
