### PR TITLE
fix(sync): drain media before one-shot exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Sync: finish queued media downloads before clean one-shot and bootstrap exits instead of canceling them at idle. (thanks @njt)
+
 ## 0.11.2 - 2026-07-02
 
 ### Added

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -18,7 +18,7 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-t
 - `--max-reconnect 0` keeps reconnecting indefinitely.
 - `--max-messages N` stops before storing more than `N` total messages locally.
 - `--max-db-size SIZE` stops when `wacli.db` plus SQLite sidecars reaches `SIZE` (`500MB`, `2GB`, etc.).
-- `--download-media` runs a bounded media downloader for sync events.
+- `--download-media` runs a bounded media downloader for sync events. Clean one-shot and bootstrap runs finish queued downloads before exiting; cancellation, errors, and storage-limit exits stop immediately.
 - `--refresh-contacts` imports contacts from the session store.
 - `--refresh-groups` fetches joined groups live and updates the local DB.
 - `--refresh-channels` fetches subscribed WhatsApp Channels live and updates local chat rows.

--- a/internal/app/heartbeat_test.go
+++ b/internal/app/heartbeat_test.go
@@ -33,6 +33,7 @@ func TestSyncWritesHeartbeatFileOnActivity(t *testing.T) {
 		nil,
 		nil,
 		&syncPresence{},
+		nil,
 	)
 	defer f.RemoveEventHandler(handlerID)
 
@@ -70,6 +71,7 @@ func TestSyncOnceDoesNotWriteHeartbeatFile(t *testing.T) {
 		nil,
 		nil,
 		&syncPresence{},
+		nil,
 	)
 	defer f.RemoveEventHandler(handlerID)
 
@@ -99,6 +101,7 @@ func TestSyncFollowDoesNotWriteHeartbeatOnKeepAliveTimeout(t *testing.T) {
 		nil,
 		nil,
 		&syncPresence{},
+		nil,
 	)
 	defer f.RemoveEventHandler(handlerID)
 
@@ -200,6 +203,7 @@ func TestSyncFollowDoesNotReconnectOnFreshKeepAliveTimeout(t *testing.T) {
 		nil,
 		nil,
 		&syncPresence{},
+		nil,
 	)
 	defer f.RemoveEventHandler(handlerID)
 
@@ -251,6 +255,7 @@ func TestSyncFollowEmitsStaleEvent(t *testing.T) {
 		nil,
 		nil,
 		&syncPresence{},
+		nil,
 	)
 	defer f.RemoveEventHandler(handlerID)
 

--- a/internal/app/media.go
+++ b/internal/app/media.go
@@ -21,6 +21,95 @@ type mediaJob struct {
 	msgID   string
 }
 
+type mediaQueue struct {
+	jobs      chan mediaJob
+	mu        sync.Mutex
+	pending   int
+	producers int
+	accepting bool
+	changed   chan struct{}
+}
+
+func newMediaQueue(buffer int) *mediaQueue {
+	return &mediaQueue{
+		jobs:      make(chan mediaJob, buffer),
+		accepting: true,
+		changed:   make(chan struct{}, 1),
+	}
+}
+
+func (q *mediaQueue) beginProducer() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if !q.accepting {
+		return false
+	}
+	q.producers++
+	q.notify()
+	return true
+}
+
+func (q *mediaQueue) endProducer() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.producers--
+	if q.producers < 0 {
+		panic("media queue producer count became negative")
+	}
+	q.notify()
+}
+
+func (q *mediaQueue) enqueue(ctx context.Context, job mediaJob) {
+	q.mu.Lock()
+	q.pending++
+	q.mu.Unlock()
+	q.notify()
+	select {
+	case q.jobs <- job:
+	case <-ctx.Done():
+		q.done()
+	}
+}
+
+func (q *mediaQueue) done() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.pending--
+	if q.pending < 0 {
+		panic("media queue pending count became negative")
+	}
+	q.notify()
+}
+
+func (q *mediaQueue) notify() {
+	select {
+	case q.changed <- struct{}{}:
+	default:
+	}
+}
+
+// waitIdle keeps media intake open while waiting, then atomically fences new
+// event producers once no callback or media job remains. This avoids a long
+// intake blackout during slow downloads without racing an in-flight handler.
+func (q *mediaQueue) waitIdle(ctx context.Context) bool {
+	for {
+		q.mu.Lock()
+		idle := q.pending == 0 && q.producers == 0
+		if idle {
+			q.accepting = false
+		}
+		q.mu.Unlock()
+		if idle {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-q.changed:
+		}
+	}
+}
+
 func (a *App) ResolveMediaOutputPath(info store.MediaDownloadInfo, requested string) (string, error) {
 	filename := mediaFilename(info)
 
@@ -74,15 +163,15 @@ func mediaFilename(info store.MediaDownloadInfo) string {
 	return name
 }
 
-func (a *App) runMediaWorkers(ctx context.Context, jobs <-chan mediaJob, workers int) (func(), error) {
+func (a *App) runMediaWorkers(ctx context.Context, queue *mediaQueue, workers int) (wait func(), cancel func(), err error) {
 	if workers <= 0 {
 		workers = 2
 	}
-	if jobs == nil {
-		return func() {}, nil
+	if queue == nil {
+		return func() {}, func() {}, nil
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancelWorkers := context.WithCancel(ctx)
 	var wg sync.WaitGroup
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
@@ -92,16 +181,11 @@ func (a *App) runMediaWorkers(ctx context.Context, jobs <-chan mediaJob, workers
 				select {
 				case <-ctx.Done():
 					return
-				case job, ok := <-jobs:
-					if !ok {
-						return
-					}
-					if strings.TrimSpace(job.chatJID) == "" || strings.TrimSpace(job.msgID) == "" {
-						continue
-					}
+				case job := <-queue.jobs:
 					// Recover per job so a panic fails one download
 					// instead of killing the worker permanently (#52).
 					func() {
+						defer queue.done()
 						defer func() {
 							if r := recover(); r != nil {
 								if a.eventsEnabled() {
@@ -117,6 +201,9 @@ func (a *App) runMediaWorkers(ctx context.Context, jobs <-chan mediaJob, workers
 								}
 							}
 						}()
+						if strings.TrimSpace(job.chatJID) == "" || strings.TrimSpace(job.msgID) == "" {
+							return
+						}
 						if err := a.downloadMediaJob(ctx, job); err != nil {
 							a.emitWarning(
 								"media_download_failed",
@@ -130,11 +217,7 @@ func (a *App) runMediaWorkers(ctx context.Context, jobs <-chan mediaJob, workers
 		}()
 	}
 
-	stop := func() {
-		cancel()
-		wg.Wait()
-	}
-	return stop, nil
+	return wg.Wait, cancelWorkers, nil
 }
 
 func (a *App) downloadMediaJob(ctx context.Context, job mediaJob) error {

--- a/internal/app/media_panic_test.go
+++ b/internal/app/media_panic_test.go
@@ -61,14 +61,18 @@ func TestMediaWorkerSurvivesPanic(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	jobs := make(chan mediaJob, 2)
-	stop, err := a.runMediaWorkers(ctx, jobs, 1)
+	queue := newMediaQueue(2)
+	wait, cancelWorkers, err := a.runMediaWorkers(ctx, queue, 1)
 	if err != nil {
 		t.Fatalf("runMediaWorkers: %v", err)
 	}
+	defer func() {
+		cancelWorkers()
+		wait()
+	}()
 
-	jobs <- mediaJob{chatJID: chat, msgID: "boom"}
-	jobs <- mediaJob{chatJID: chat, msgID: "ok"}
+	queue.enqueue(ctx, mediaJob{chatJID: chat, msgID: "boom"})
+	queue.enqueue(ctx, mediaJob{chatJID: chat, msgID: "ok"})
 
 	// Poll until the benign job is persisted. DownloadMediaToFile returning only
 	// proves the worker reached the second job; MarkMediaDownloaded can still be
@@ -97,5 +101,4 @@ func TestMediaWorkerSurvivesPanic(t *testing.T) {
 		t.Fatalf("expected LocalPath for benign job to be set after panic survival")
 	}
 
-	stop()
 }

--- a/internal/app/media_test.go
+++ b/internal/app/media_test.go
@@ -9,6 +9,39 @@ import (
 	"github.com/openclaw/wacli/internal/store"
 )
 
+func TestMediaQueueWaitIdleFencesActiveProducer(t *testing.T) {
+	queue := newMediaQueue(1)
+	if !queue.beginProducer() {
+		t.Fatal("expected producer admission before drain")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	drained := make(chan bool, 1)
+	go func() {
+		drained <- queue.waitIdle(ctx)
+	}()
+
+	select {
+	case <-drained:
+		t.Fatal("queue reported idle while an event producer was active")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	queue.endProducer()
+	select {
+	case ok := <-drained:
+		if !ok {
+			t.Fatal("queue drain was canceled")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("queue did not drain after producer finished")
+	}
+	if queue.beginProducer() {
+		t.Fatal("queue admitted a producer after the drain fence")
+	}
+}
+
 func TestDownloadMediaJobMarksDownloaded(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -115,21 +115,24 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 	disconnected := make(chan struct{}, 1)
 	staleReconnect := make(chan staleReconnectRequest, 1)
 
-	var stopMedia func()
-	var mediaJobs chan mediaJob
+	var waitMedia func(context.Context) bool
+	var mediaQ *mediaQueue
 	enqueueMedia := func(chatJID, msgID string) {}
 	if opts.DownloadMedia {
-		mediaJobs = make(chan mediaJob, 512)
-		enqueueMedia = newMediaEnqueuer(syncCtx, mediaJobs)
+		mediaQ = newMediaQueue(512)
+		enqueueMedia = newMediaEnqueuer(syncCtx, mediaQ)
 	}
 
 	if opts.DownloadMedia {
-		var err error
-		stopMedia, err = a.runMediaWorkers(syncCtx, mediaJobs, 4)
+		wait, cancelMedia, err := a.runMediaWorkers(syncCtx, mediaQ, 4)
 		if err != nil {
 			return SyncResult{}, err
 		}
-		defer stopMedia()
+		defer func() {
+			cancelMedia()
+			wait()
+		}()
+		waitMedia = mediaQ.waitIdle
 	}
 
 	var stopWebhook func()
@@ -143,7 +146,7 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 	}
 
 	ps := &syncPresence{}
-	handlerID := a.addSyncEventHandler(syncCtx, opts, &messagesStored, &lastEvent, disconnected, staleReconnect, enqueueMedia, enqueueWebhook, limits, ps)
+	handlerID := a.addSyncEventHandler(syncCtx, opts, &messagesStored, &lastEvent, disconnected, staleReconnect, enqueueMedia, enqueueWebhook, limits, ps, mediaQ)
 	defer a.wa.RemoveEventHandler(handlerID)
 
 	connectionEpoch.Store(nowUTC().UnixNano())
@@ -208,7 +211,15 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 	} else {
 		_, err = a.runSyncUntilIdle(syncCtx, opts.IdleExit, opts.MaxReconnect, &messagesStored, &lastEvent, disconnected)
 	}
-	if limitErr := limits.Err(); limitErr != nil {
+	limitErr := limits.Err()
+	// Successful one-shot modes must finish queued downloads before cleanup
+	// cancels the worker context. Follow mode keeps the queue open; error,
+	// cancellation, and storage-limit exits retain immediate cancellation.
+	if waitMedia != nil && opts.Mode != SyncModeFollow && err == nil && limitErr == nil && syncCtx.Err() == nil {
+		waitMedia(syncCtx)
+		limitErr = limits.Err()
+	}
+	if limitErr != nil {
 		return SyncResult{MessagesStored: messagesStored.Load()}, limitErr
 	}
 	if err != nil {

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -21,15 +21,12 @@ import (
 	"go.mau.fi/whatsmeow/types/events"
 )
 
-func newMediaEnqueuer(ctx context.Context, jobs chan<- mediaJob) func(chatJID, msgID string) {
+func newMediaEnqueuer(ctx context.Context, queue *mediaQueue) func(chatJID, msgID string) {
 	return func(chatJID, msgID string) {
 		if strings.TrimSpace(chatJID) == "" || strings.TrimSpace(msgID) == "" {
 			return
 		}
-		select {
-		case jobs <- mediaJob{chatJID: chatJID, msgID: msgID}:
-		case <-ctx.Done():
-		}
+		queue.enqueue(ctx, mediaJob{chatJID: chatJID, msgID: msgID})
 	}
 }
 
@@ -49,10 +46,16 @@ type syncPresence struct {
 	cleanupStarted bool
 }
 
-func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, messagesStored, lastEvent *atomic.Int64, disconnected chan<- struct{}, staleReconnect chan<- staleReconnectRequest, enqueueMedia func(string, string), enqueueWebhook func(wa.ParsedMessage), limits *syncStorageLimits, ps *syncPresence) uint32 {
+func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, messagesStored, lastEvent *atomic.Int64, disconnected chan<- struct{}, staleReconnect chan<- staleReconnectRequest, enqueueMedia func(string, string), enqueueWebhook func(wa.ParsedMessage), limits *syncStorageLimits, ps *syncPresence, mediaQ *mediaQueue) uint32 {
 	var panicCount atomic.Int64
 	var appStateRecoveries sync.Map
 	return a.wa.AddEventHandler(func(evt interface{}) {
+		if mediaQ != nil {
+			if !mediaQ.beginProducer() {
+				return
+			}
+			defer mediaQ.endProducer()
+		}
 		if opts.Mode == SyncModeFollow && syncActivityEvent(evt) {
 			a.writeHeartbeat()
 		}

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -136,6 +136,7 @@ func TestSyncEventHandlerClearsUnreadCountOnReadSelfReceipt(t *testing.T) {
 		nil,
 		nil,
 		&syncPresence{},
+		nil,
 	)
 	f.emit(&events.Receipt{
 		MessageSource: types.MessageSource{Chat: chat},
@@ -178,6 +179,7 @@ func TestSyncEventHandlerIgnoresRegularReadReceiptsForUnreadCount(t *testing.T) 
 		nil,
 		nil,
 		&syncPresence{},
+		nil,
 	)
 	f.emit(&events.Receipt{
 		MessageSource: types.MessageSource{Chat: chat},
@@ -1587,6 +1589,69 @@ func TestSyncMediaEnqueueUsesBoundedBackpressure(t *testing.T) {
 	}
 	if leaked := during - before; leaked > 20 {
 		t.Fatalf("expected bounded media enqueue goroutines, saw +%d (before=%d during=%d)", leaked, before, during)
+	}
+}
+
+// TestSyncOnceDrainsMediaBeforeExit guards the fix where once-mode idle-exit
+// used to cancel media downloads still queued or in flight. Each download takes
+// far longer than IdleExit, so without the graceful drain the sync would exit
+// and cancel most of them, leaving local_path empty.
+func TestSyncOnceDrainsMediaBeforeExit(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+	// Download work (12 jobs / 4 workers * 150ms ≈ 450ms) exceeds the 250ms idle
+	// poll inside runSyncUntilIdle, making premature worker cancellation deterministic.
+	f.downloadDelay = 150 * time.Millisecond
+
+	chat := types.JID{User: "123", Server: types.DefaultUserServer}
+	f.contacts[chat.ToNonAD()] = types.ContactInfo{Found: true, FullName: "Alice", PushName: "Alice"}
+
+	const n = 12
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	ids := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("media-%02d", i)
+		ids = append(ids, id)
+		f.connectEvents = append(f.connectEvents, &events.Message{
+			Info: types.MessageInfo{
+				MessageSource: types.MessageSource{Chat: chat, Sender: chat, IsFromMe: false},
+				ID:            id,
+				Timestamp:     base.Add(time.Duration(i) * time.Second),
+				PushName:      "Alice",
+			},
+			Message: &waProto.Message{
+				ImageMessage: &waProto.ImageMessage{
+					Mimetype:      proto.String("image/jpeg"),
+					DirectPath:    proto.String("/direct"),
+					MediaKey:      []byte{1, 2, 3},
+					FileSHA256:    []byte{4, 5, 6},
+					FileEncSHA256: []byte{7, 8, 9},
+					FileLength:    proto.Uint64(4),
+				},
+			},
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := a.Sync(ctx, SyncOptions{
+		Mode:          SyncModeOnce,
+		AllowQR:       false,
+		DownloadMedia: true,
+		IdleExit:      10 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	for _, id := range ids {
+		msg, err := a.db.GetMessage(chat.String(), id)
+		if err != nil {
+			t.Fatalf("GetMessage %s: %v", id, err)
+		}
+		if msg.LocalPath == "" {
+			t.Fatalf("expected media %s downloaded before exit, got empty local_path", id)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- keep bounded media intake active while one-shot/bootstrap sync drains accepted downloads
- track event producers plus queued/in-flight media jobs, then fence new work only at true idle
- preserve immediate cancellation, error, and storage-limit exits
- document the one-shot behavior and credit @njt for the original diagnosis in #291

## Root cause

`sync --once --download-media` canceled its media worker context immediately after idle exit. Downloads still queued or in flight were abandoned, leaving stored messages without `local_path`.

The first close-and-drain approach also exposed two races: closing intake before an active history handler finished could drop media jobs, while unregistering the handler during a long drain could drop newly arriving messages. The final design keeps intake live during the drain, accounts for active event producers, fences admission atomically only when both producer and job counts reach zero, and re-reads storage-limit state afterward.

## Proof

- Current-main regression reproduced: 4 of 12 downloads canceled with `context canceled`; test failed on `media-04`.
- `go test ./internal/app -run '^(TestMediaQueueWaitIdleFencesActiveProducer|TestSyncOnceDrainsMediaBeforeExit|TestSyncMediaEnqueueUsesBoundedBackpressure|TestMediaWorkerSurvivesPanic|TestSyncOnceIdleExit)$' -count=1`
- same focused slice with `go test -race`
- `pnpm docs:site && pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`
- structured Codex autoreview: clean, no accepted/actionable findings

## Live validation

- re-paired the existing named linked-device account; `doctor --connect` reports authenticated and connected
- `sync --once --idle-exit 5s --download-media` connected, reached idle, and exited successfully
- sent a real JPEG media fixture through WhatsApp, downloaded its server media envelope with the candidate, and matched all 53,164 bytes by SHA-256 against the source
- WhatsApp does not emit self-chat sends back as incoming companion events, so the exact accepted-job drain race remains covered by the deterministic regression and race tests above

Extracted from #291 without taking its backfill, retry, or schema changes. Commit preserves Nat Torkington's co-author credit.
