### PR TITLE
feat(media): recover expired downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Media: add `media backfill` to download media for already-synced messages that have metadata but no local copy. (thanks @njt)
+- Media: add `media retry` to recover CDN-expired media from the primary device. (thanks @njt)
 
 ### Security
 

--- a/cmd/wacli/media.go
+++ b/cmd/wacli/media.go
@@ -20,7 +20,106 @@ func newMediaCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.AddCommand(newMediaDownloadCmd(flags))
 	cmd.AddCommand(newMediaBackfillCmd(flags))
+	cmd.AddCommand(newMediaRetryCmd(flags))
 	return cmd
+}
+
+func newMediaRetryCmd(flags *rootFlags) *cobra.Command {
+	var chat string
+	var limit int
+	var batch int
+	var wait time.Duration
+	var before string
+
+	cmd := &cobra.Command{
+		Use:   "retry",
+		Short: "Recover expired media by asking the phone to re-upload it",
+		Long: "For media that expired off WhatsApp's CDN, ask the primary device (phone)\n" +
+			"to re-upload it via the media-retry protocol, then download it. Receipts are\n" +
+			"sent in batches with a second attempt for non-responders; media the phone no\n" +
+			"longer holds is marked so it is not retried again. Only works while the phone\n" +
+			"is online and still has the media.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if limit < 0 {
+				return fmt.Errorf("--limit must be >= 0")
+			}
+			if batch <= 0 {
+				return fmt.Errorf("--batch must be > 0")
+			}
+			if wait <= 0 {
+				return fmt.Errorf("--wait must be > 0")
+			}
+			beforeUnix, err := parseMediaRetryBefore(before)
+			if err != nil {
+				return err
+			}
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+			ctx, cancel := mediaBulkContext(cmd, flags)
+			defer cancel()
+
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			if err := a.Connect(ctx, false, nil); err != nil {
+				return err
+			}
+
+			res, err := a.RetryMedia(ctx, app.RetryMediaOptions{
+				ChatJID:    strings.TrimSpace(chat),
+				BeforeUnix: beforeUnix,
+				BeforeSet:  strings.TrimSpace(before) != "",
+				Limit:      limit,
+				BatchSize:  batch,
+				Wait:       wait,
+			})
+			if err != nil {
+				return err
+			}
+
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, res)
+			}
+			fmt.Fprintf(os.Stdout, "Requested: %d  Recovered: %d  Not on phone: %d  No response: %d  Failed: %d\n",
+				res.Requested, res.Recovered, res.NotOnPhone, res.NoResponse, res.Failed)
+			for _, o := range res.Outcomes {
+				line := fmt.Sprintf("  %-13s %s/%s", o.Status, o.ChatJID, o.MsgID)
+				if o.Status == "recovered" {
+					line += fmt.Sprintf("  (%d bytes) %s", o.Bytes, o.Path)
+				} else if o.Detail != "" {
+					line += "  " + o.Detail
+				}
+				fmt.Fprintln(os.Stdout, line)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&chat, "chat", "", "limit retry to a single chat JID")
+	cmd.Flags().IntVar(&limit, "limit", 0, "maximum number of messages to retry (0 = all pending)")
+	cmd.Flags().IntVar(&batch, "batch", 32, "number of retry receipts to send per batch")
+	cmd.Flags().DurationVar(&wait, "wait", 30*time.Second, "how long to wait for the phone per attempt")
+	cmd.Flags().StringVar(&before, "before", "", "only retry media older than this date (YYYY-MM-DD)")
+	return cmd
+}
+
+func parseMediaRetryBefore(value string) (int64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, nil
+	}
+	parsed, err := time.Parse("2006-01-02", value)
+	if err != nil {
+		return 0, fmt.Errorf("--before must be YYYY-MM-DD: %w", err)
+	}
+	return parsed.Unix(), nil
 }
 
 func newMediaBackfillCmd(flags *rootFlags) *cobra.Command {
@@ -46,7 +145,7 @@ func newMediaBackfillCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			ctx, cancel := mediaBackfillContext(cmd, flags)
+			ctx, cancel := mediaBulkContext(cmd, flags)
 			defer cancel()
 
 			a, lk, err := newApp(ctx, flags, true, false)
@@ -92,9 +191,9 @@ func newMediaBackfillCmd(flags *rootFlags) *cobra.Command {
 	return cmd
 }
 
-func mediaBackfillContext(cmd *cobra.Command, flags *rootFlags) (context.Context, context.CancelFunc) {
+func mediaBulkContext(cmd *cobra.Command, flags *rootFlags) (context.Context, context.CancelFunc) {
 	ctx, stop := signalContextWithEvents(out.NewEventWriter(os.Stderr, flags.events))
-	if !mediaBackfillTimeoutEnabled(cmd, flags) {
+	if !mediaBulkTimeoutEnabled(cmd, flags) {
 		return ctx, stop
 	}
 	timedCtx, cancel := withTimeout(ctx, flags)
@@ -104,7 +203,7 @@ func mediaBackfillContext(cmd *cobra.Command, flags *rootFlags) (context.Context
 	}
 }
 
-func mediaBackfillTimeoutEnabled(cmd *cobra.Command, flags *rootFlags) bool {
+func mediaBulkTimeoutEnabled(cmd *cobra.Command, flags *rootFlags) bool {
 	if cmd == nil || flags == nil || flags.timeout <= 0 {
 		return false
 	}

--- a/cmd/wacli/media_test.go
+++ b/cmd/wacli/media_test.go
@@ -8,21 +8,56 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func TestMediaBackfillTimeoutIsOptIn(t *testing.T) {
+func TestMediaBulkTimeoutIsOptIn(t *testing.T) {
 	flags := &rootFlags{timeout: 5 * time.Minute}
 	root := &cobra.Command{Use: "wacli"}
 	root.PersistentFlags().DurationVar(&flags.timeout, "timeout", flags.timeout, "command timeout")
 	cmd := newMediaBackfillCmd(flags)
 	root.AddCommand(cmd)
 
-	if mediaBackfillTimeoutEnabled(cmd, flags) {
+	if mediaBulkTimeoutEnabled(cmd, flags) {
 		t.Fatalf("default timeout unexpectedly enabled")
 	}
 	if err := root.PersistentFlags().Set("timeout", "1s"); err != nil {
 		t.Fatalf("set timeout: %v", err)
 	}
-	if !mediaBackfillTimeoutEnabled(cmd, flags) {
+	if !mediaBulkTimeoutEnabled(cmd, flags) {
 		t.Fatalf("explicit timeout was not enabled")
+	}
+}
+
+func TestParseMediaRetryBefore(t *testing.T) {
+	got, err := parseMediaRetryBefore(" 2026-01-02 ")
+	if err != nil {
+		t.Fatalf("parseMediaRetryBefore: %v", err)
+	}
+	want := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC).Unix()
+	if got != want {
+		t.Fatalf("timestamp = %d, want %d", got, want)
+	}
+	if _, err := parseMediaRetryBefore("02-01-2026"); err == nil {
+		t.Fatalf("expected invalid date error")
+	}
+}
+
+func TestMediaRetryRejectsInvalidOptionsBeforeStoreAccess(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "limit", args: []string{"--limit", "-1"}, want: "--limit must be >= 0"},
+		{name: "batch", args: []string{"--batch", "0"}, want: "--batch must be > 0"},
+		{name: "wait", args: []string{"--wait", "0"}, want: "--wait must be > 0"},
+		{name: "before", args: []string{"--before", "01-02-2026"}, want: "--before must be YYYY-MM-DD"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			args := append([]string{"--account", "does-not-exist", "media", "retry"}, tc.args...)
+			err := execute(args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("execute error = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -9,6 +9,7 @@ Read when: downloading media from a synced message.
 ```bash
 wacli media download --chat JID --id MSG_ID [--output PATH]
 wacli media backfill [--chat JID] [--limit N] [--workers N]
+wacli media retry [--chat JID] [--before YYYY-MM-DD] [--limit N] [--batch N] [--wait DUR]
 ```
 
 ## download
@@ -58,4 +59,38 @@ wacli media backfill                                   # download all pending me
 wacli media backfill --limit 50                        # download the 50 newest pending
 wacli media backfill --chat 1234567890@s.whatsapp.net  # one chat only
 wacli media backfill --json                            # machine-readable counts
+```
+
+## retry
+
+Recovers media that expired off WhatsApp's CDN. `media download` and `media
+backfill` fetch directly from WhatsApp's servers, which only keep media for a
+limited time — older media returns HTTP 403. `media retry` instead asks the
+primary device (your phone) to re-upload the media via WhatsApp's media-retry
+protocol (the same mechanism WhatsApp Web uses), then downloads it.
+
+Recovery only works while the phone is online and still holds the media. Media
+the phone no longer has is marked unavailable only after the stored CDN path is
+also confirmed expired, so later runs can skip genuinely unavailable rows.
+
+### Notes
+
+- Requires a writable store and an online phone; not available in `--read-only` mode.
+- Run `media backfill` first; retry is intended for media whose direct CDN download failed.
+- Retry receipts are sent in batches (`--batch`, default 32) with a second
+  attempt for non-responders; `--wait` (default 30s) bounds each attempt.
+- `--chat` scopes to one chat; `--before YYYY-MM-DD` scopes to media older than a date.
+- `--limit` caps how many messages to retry (0 = all pending); newest first.
+- Runs until completion or interruption by default; explicitly set global `--timeout` to cap a run.
+- Reports counts: requested, recovered, not_on_phone (gone), no_response, failed.
+- `no_response` means the phone did not answer in time (often transient) — those
+  stay pending and can be retried later; only `not_on_phone` is marked gone.
+
+### Examples
+
+```bash
+wacli media retry                                    # try to recover all pending media
+wacli media retry --chat 1234567890@s.whatsapp.net   # one chat only
+wacli media retry --before 2026-01-01                # only media older than a date
+wacli media retry --limit 50 --wait 45s --json       # bounded run, machine-readable
 ```

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -79,6 +79,7 @@ type WAClient interface {
 	Upload(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error)
 	UploadNewsletter(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error)
 	DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error)
+	SendMediaRetryReceipt(ctx context.Context, info *types.MessageInfo, mediaKey []byte) error
 
 	SendChatPresence(ctx context.Context, jid types.JID, state types.ChatPresence, media types.ChatPresenceMedia) error
 	SendPresence(ctx context.Context, presence types.Presence) error

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -37,6 +37,10 @@ type fakeWA struct {
 	connectCalls  int
 	connectDelay  time.Duration
 	downloadDelay time.Duration
+	downloadErr   error
+
+	onMediaRetry       func(info *types.MessageInfo, mediaKey []byte) interface{}
+	mediaRetryReceipts []string
 
 	contacts map[types.JID]types.ContactInfo
 	groups   map[types.JID]*types.GroupInfo
@@ -644,6 +648,9 @@ func (f *fakeWA) DownloadMediaToFile(ctx context.Context, directPath string, enc
 			return 0, ctx.Err()
 		}
 	}
+	if f.downloadErr != nil {
+		return 0, f.downloadErr
+	}
 	if err := os.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
 		return 0, err
 	}
@@ -655,6 +662,19 @@ func (f *fakeWA) DownloadMediaToFile(ctx context.Context, directPath string, enc
 		return 0, err
 	}
 	return st.Size(), nil
+}
+
+func (f *fakeWA) SendMediaRetryReceipt(ctx context.Context, info *types.MessageInfo, mediaKey []byte) error {
+	f.mu.Lock()
+	f.mediaRetryReceipts = append(f.mediaRetryReceipts, string(info.ID))
+	hook := f.onMediaRetry
+	f.mu.Unlock()
+	if hook != nil {
+		if evt := hook(info, mediaKey); evt != nil {
+			f.emit(evt)
+		}
+	}
+	return nil
 }
 
 func (f *fakeWA) RequestHistorySyncOnDemand(ctx context.Context, lastKnown types.MessageInfo, count int) (types.MessageID, error) {

--- a/internal/app/media_retry.go
+++ b/internal/app/media_retry.go
@@ -1,0 +1,391 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openclaw/wacli/internal/fsutil"
+	"github.com/openclaw/wacli/internal/store"
+	"github.com/openclaw/wacli/internal/wa"
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+// MediaRetryOutcome is the per-message result of a media-retry attempt.
+type MediaRetryOutcome struct {
+	ChatJID string `json:"chat_jid"`
+	MsgID   string `json:"msg_id"`
+	Status  string `json:"status"` // recovered | not_on_phone | no_response | error
+	Path    string `json:"path,omitempty"`
+	Bytes   int64  `json:"bytes,omitempty"`
+	Detail  string `json:"detail,omitempty"`
+}
+
+// MediaRetryResult summarises a media-retry run.
+type MediaRetryResult struct {
+	Requested  int                 `json:"requested"`
+	Recovered  int                 `json:"recovered"`
+	NotOnPhone int                 `json:"not_on_phone"`
+	NoResponse int                 `json:"no_response"`
+	Failed     int                 `json:"failed"`
+	Outcomes   []MediaRetryOutcome `json:"outcomes"`
+}
+
+// RetryMediaOptions controls a media-retry run.
+type RetryMediaOptions struct {
+	ChatJID    string        // scope to a single chat (optional)
+	BeforeUnix int64         // only retry media older than this unix time (optional)
+	BeforeSet  bool          // distinguish an explicit Unix epoch filter from no filter
+	Limit      int           // cap total messages to retry (0 = all pending)
+	BatchSize  int           // receipts in flight per batch (default 32)
+	Wait       time.Duration // how long to wait for the phone per attempt (default 30s)
+}
+
+type retryNotif struct {
+	directPath string
+	code       int
+	err        error
+}
+
+type mediaRetryKey struct {
+	chatJID string
+	msgID   string
+}
+
+// RetryMedia recovers media that expired off WhatsApp's CDN by asking the phone
+// to re-upload it. It sends media-retry receipts in batches, waits for the
+// phone's notifications (with one second attempt for non-responders), downloads
+// whatever the phone re-served, and marks genuinely-gone media so future runs
+// skip it. Recovery only works while the phone is online and still holds the
+// media. Requires an authenticated, connected client.
+func (a *App) RetryMedia(ctx context.Context, opts RetryMediaOptions) (MediaRetryResult, error) {
+	if err := ctx.Err(); err != nil {
+		return MediaRetryResult{}, err
+	}
+	if opts.Limit < 0 {
+		return MediaRetryResult{}, fmt.Errorf("limit must be >= 0")
+	}
+	if opts.BatchSize < 0 {
+		return MediaRetryResult{}, fmt.Errorf("batch size must be >= 0")
+	}
+	if opts.Wait < 0 {
+		return MediaRetryResult{}, fmt.Errorf("wait must be >= 0")
+	}
+	opts.ChatJID = strings.TrimSpace(opts.ChatJID)
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = 32
+	}
+	if opts.Wait <= 0 {
+		opts.Wait = 30 * time.Second
+	}
+
+	var pending []store.PendingMediaDownload
+	var err error
+	if opts.BeforeSet || opts.BeforeUnix != 0 {
+		pending, err = a.db.ListPendingMediaBefore(ctx, opts.ChatJID, opts.BeforeUnix, opts.Limit)
+	} else {
+		pending, err = a.db.ListPendingMediaDownloads(ctx, opts.ChatJID, opts.Limit)
+	}
+	if err != nil {
+		return MediaRetryResult{}, fmt.Errorf("list pending media: %w", err)
+	}
+	result := MediaRetryResult{Requested: len(pending)}
+	if len(pending) == 0 {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		return result, nil
+	}
+
+	// Shared notification map, keyed by chat and message ID as echoed by the
+	// phone. Message IDs are only unique within a chat.
+	// Guarded by mu because the event handler runs on whatsmeow's dispatch
+	// goroutine.
+	var mu sync.Mutex
+	infos := make(map[mediaRetryKey]store.MediaDownloadInfo, len(pending))
+	notifs := make(map[mediaRetryKey]retryNotif, len(pending))
+
+	handlerID := a.wa.AddEventHandler(func(evt interface{}) {
+		mr, ok := evt.(*events.MediaRetry)
+		if !ok {
+			return
+		}
+		key := mediaRetryKey{chatJID: canonicalJIDString(a.canonicalStoreJID(ctx, mr.ChatID)), msgID: string(mr.MessageID)}
+		mu.Lock()
+		defer mu.Unlock()
+		info, tracked := infos[key]
+		if !tracked {
+			return
+		}
+		if _, seen := notifs[key]; seen {
+			return
+		}
+		dp, code, derr := wa.DecryptMediaRetry(mr, info.MediaKey)
+		notifs[key] = retryNotif{directPath: dp, code: code, err: derr}
+	})
+	defer a.wa.RemoveEventHandler(handlerID)
+
+	// Load message info + build retry receipts, dropping rows we cannot address.
+	type ready struct {
+		info store.MediaDownloadInfo
+		mi   *types.MessageInfo
+	}
+	prepared := make(map[mediaRetryKey]ready, len(pending))
+	orderedKeys := make([]mediaRetryKey, 0, len(pending))
+	groupAddressingModes := make(map[types.JID]types.AddressingMode)
+	for _, p := range pending {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		info, err := a.db.GetMediaDownloadInfo(p.ChatJID, p.MsgID)
+		if err != nil {
+			result.Failed++
+			result.Outcomes = append(result.Outcomes, MediaRetryOutcome{ChatJID: p.ChatJID, MsgID: p.MsgID, Status: "error", Detail: fmt.Sprintf("load info: %v", err)})
+			continue
+		}
+		msg, err := a.db.GetMessage(p.ChatJID, p.MsgID)
+		if err != nil {
+			result.Failed++
+			result.Outcomes = append(result.Outcomes, MediaRetryOutcome{ChatJID: p.ChatJID, MsgID: p.MsgID, Status: "error", Detail: fmt.Sprintf("load message: %v", err)})
+			continue
+		}
+		chat, err := types.ParseJID(p.ChatJID)
+		if err != nil {
+			result.Failed++
+			result.Outcomes = append(result.Outcomes, MediaRetryOutcome{ChatJID: p.ChatJID, MsgID: p.MsgID, Status: "error", Detail: fmt.Sprintf("parse chat jid: %v", err)})
+			continue
+		}
+		sender, senderErr := types.ParseJID(msg.SenderJID)
+		isGroupLike := chat.Server == types.GroupServer || chat.IsBroadcastList()
+		if isGroupLike && (senderErr != nil || sender.IsEmpty()) && msg.FromMe {
+			sender, senderErr = types.ParseJID(a.wa.LinkedJID())
+		}
+		if isGroupLike && (senderErr != nil || sender.IsEmpty()) {
+			result.Failed++
+			result.Outcomes = append(result.Outcomes, MediaRetryOutcome{ChatJID: p.ChatJID, MsgID: p.MsgID, Status: "error", Detail: "group or broadcast media is missing its sender JID"})
+			continue
+		}
+		addressingMode := types.AddressingModePN
+		if chat.Server == types.GroupServer {
+			var ok bool
+			addressingMode, ok = groupAddressingModes[chat]
+			if !ok {
+				groupInfo, groupErr := a.wa.GetGroupInfo(ctx, chat)
+				if groupErr != nil {
+					result.Failed++
+					result.Outcomes = append(result.Outcomes, MediaRetryOutcome{ChatJID: p.ChatJID, MsgID: p.MsgID, Status: "error", Detail: fmt.Sprintf("load group addressing mode: %v", groupErr)})
+					continue
+				}
+				if groupInfo == nil {
+					result.Failed++
+					result.Outcomes = append(result.Outcomes, MediaRetryOutcome{ChatJID: p.ChatJID, MsgID: p.MsgID, Status: "error", Detail: "load group addressing mode: no group info returned"})
+					continue
+				}
+				addressingMode = groupInfo.AddressingMode
+				if addressingMode == "" {
+					addressingMode = types.AddressingModePN
+				}
+				groupAddressingModes[chat] = addressingMode
+			}
+		}
+		key := mediaRetryKey{chatJID: chat.String(), msgID: p.MsgID}
+		prepared[key] = ready{info: info, mi: &types.MessageInfo{
+			ID: p.MsgID,
+			MessageSource: types.MessageSource{
+				Chat:           chat,
+				Sender:         sender,
+				IsFromMe:       msg.FromMe,
+				IsGroup:        isGroupLike,
+				AddressingMode: addressingMode,
+			},
+		}}
+		mu.Lock()
+		infos[key] = info
+		mu.Unlock()
+		orderedKeys = append(orderedKeys, key)
+	}
+
+	sendReceipt := func(key mediaRetryKey) bool {
+		r := prepared[key]
+		if err := a.wa.SendMediaRetryReceipt(ctx, r.mi, r.info.MediaKey); err != nil {
+			mu.Lock()
+			notifs[key] = retryNotif{err: err}
+			mu.Unlock()
+			return false
+		}
+		return true
+	}
+	responded := func(keys []mediaRetryKey) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, key := range keys {
+			if _, ok := notifs[key]; !ok {
+				return false
+			}
+		}
+		return true
+	}
+	waitForBatch := func(keys []mediaRetryKey) {
+		timer := time.NewTimer(opts.Wait)
+		defer timer.Stop()
+		tick := time.NewTicker(250 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			if responded(keys) {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+				return
+			case <-tick.C:
+			}
+		}
+	}
+	missing := func(keys []mediaRetryKey) []mediaRetryKey {
+		mu.Lock()
+		defer mu.Unlock()
+		var out []mediaRetryKey
+		for _, key := range keys {
+			if _, ok := notifs[key]; !ok {
+				out = append(out, key)
+			}
+		}
+		return out
+	}
+
+	// Process in batches so we never have more than BatchSize receipts in flight.
+	for start := 0; start < len(orderedKeys); start += opts.BatchSize {
+		if ctx.Err() != nil {
+			break
+		}
+		end := start + opts.BatchSize
+		if end > len(orderedKeys) {
+			end = len(orderedKeys)
+		}
+		batch := orderedKeys[start:end]
+
+		for _, key := range batch {
+			sendReceipt(key)
+		}
+		waitForBatch(batch)
+		// One second attempt for non-responders (often just timing).
+		if retryIDs := missing(batch); len(retryIDs) > 0 && ctx.Err() == nil {
+			for _, key := range retryIDs {
+				sendReceipt(key)
+			}
+			waitForBatch(retryIDs)
+		}
+
+		for _, key := range batch {
+			if err := ctx.Err(); err != nil {
+				return result, err
+			}
+			mu.Lock()
+			n, got := notifs[key]
+			info := infos[key]
+			mu.Unlock()
+			result.Outcomes = append(result.Outcomes, a.classifyRetry(ctx, info, key.msgID, n, got, &result))
+		}
+		a.emitEvent("media_retry_progress", map[string]any{
+			"done":         end,
+			"total":        len(orderedKeys),
+			"recovered":    result.Recovered,
+			"not_on_phone": result.NotOnPhone,
+			"no_response":  result.NoResponse,
+			"failed":       result.Failed,
+		})
+	}
+	return result, ctx.Err()
+}
+
+// classifyRetry turns a single message's notification into an outcome, updating
+// the aggregate counters and performing the download when the phone re-served
+// the media.
+func (a *App) classifyRetry(ctx context.Context, info store.MediaDownloadInfo, id string, n retryNotif, got bool, result *MediaRetryResult) MediaRetryOutcome {
+	out := MediaRetryOutcome{ChatJID: info.ChatJID, MsgID: id}
+	switch {
+	case !got:
+		out.Status = "no_response"
+		result.NoResponse++
+	case n.err != nil:
+		out.Status = "error"
+		out.Detail = n.err.Error()
+		result.Failed++
+	case n.code == wa.MediaRetryNotFound:
+		// A phone may no longer hold media that is still available from the CDN.
+		// Try the stored path before permanently excluding this row from backfill.
+		path, bytes, directErr := a.downloadMediaWithDirectPath(ctx, info, info.DirectPath)
+		switch {
+		case directErr == nil:
+			out.Status = "recovered"
+			out.Path = path
+			out.Bytes = bytes
+			result.Recovered++
+		case !isExpiredMediaDownload(directErr):
+			out.Status = "error"
+			out.Detail = fmt.Sprintf("phone has no copy; direct download: %v", directErr)
+			result.Failed++
+		default:
+			if markErr := a.db.MarkMediaUnavailable(ctx, info.ChatJID, id, nowUTC()); markErr != nil {
+				out.Status = "error"
+				out.Detail = fmt.Sprintf("phone has no copy; mark unavailable: %v", markErr)
+				result.Failed++
+			} else {
+				out.Status = "not_on_phone"
+				result.NotOnPhone++
+			}
+		}
+	case n.code != wa.MediaRetrySuccess || strings.TrimSpace(n.directPath) == "":
+		out.Status = "error"
+		out.Detail = fmt.Sprintf("retry result code %d", n.code)
+		result.Failed++
+	default:
+		path, bytes, derr := a.downloadMediaWithDirectPath(ctx, info, n.directPath)
+		if derr != nil {
+			out.Status = "error"
+			out.Detail = fmt.Sprintf("download: %v", derr)
+			result.Failed++
+		} else {
+			out.Status = "recovered"
+			out.Path = path
+			out.Bytes = bytes
+			result.Recovered++
+		}
+	}
+	return out
+}
+
+func isExpiredMediaDownload(err error) bool {
+	return errors.Is(err, whatsmeow.ErrMediaDownloadFailedWith403) ||
+		errors.Is(err, whatsmeow.ErrMediaDownloadFailedWith404) ||
+		errors.Is(err, whatsmeow.ErrMediaDownloadFailedWith410)
+}
+
+// downloadMediaWithDirectPath downloads media using a caller-supplied direct
+// path (e.g. a fresh one from a media-retry notification) rather than the one
+// stored in the DB, then records the local path.
+func (a *App) downloadMediaWithDirectPath(ctx context.Context, info store.MediaDownloadInfo, directPath string) (string, int64, error) {
+	targetPath, err := a.ResolveMediaOutputPath(info, "")
+	if err != nil {
+		return "", 0, err
+	}
+	if err := fsutil.EnsurePrivateDir(filepath.Dir(targetPath)); err != nil {
+		return "", 0, err
+	}
+	n, err := a.wa.DownloadMediaToFile(ctx, directPath, info.FileEncSHA256, info.FileSHA256, info.MediaKey, info.FileLength, info.MediaType, "", targetPath)
+	if err != nil {
+		return "", 0, err
+	}
+	if err := a.db.MarkMediaDownloaded(info.ChatJID, info.MsgID, targetPath, nowUTC()); err != nil {
+		return "", 0, err
+	}
+	return targetPath, n, nil
+}

--- a/internal/app/media_retry_test.go
+++ b/internal/app/media_retry_test.go
@@ -1,0 +1,352 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/openclaw/wacli/internal/store"
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+func notOnPhoneHook(info *types.MessageInfo, _ []byte) interface{} {
+	return &events.MediaRetry{MessageID: types.MessageID(info.ID), ChatID: info.Chat, Error: &events.MediaRetryError{Code: 2}}
+}
+
+func TestRetryMediaMarksNotOnPhone(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+	f.onMediaRetry = notOnPhoneHook
+	f.downloadErr = whatsmeow.ErrMediaDownloadFailedWith403
+
+	chat := "123@s.whatsapp.net"
+	if err := a.db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	base := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+	for _, id := range []string{"m1", "m2", "m3"} {
+		insertMediaMessage(t, a, chat, id, base)
+	}
+
+	res, err := a.RetryMedia(context.Background(), RetryMediaOptions{Wait: 2 * time.Second})
+	if err != nil {
+		t.Fatalf("RetryMedia: %v", err)
+	}
+	if res.Requested != 3 || res.NotOnPhone != 3 || res.Recovered != 0 || res.NoResponse != 0 || res.Failed != 0 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	// Marked-gone media must drop out of the pending set.
+	if n, err := a.db.CountPendingMediaDownloads(context.Background(), ""); err != nil || n != 0 {
+		t.Fatalf("expected 0 pending after marking gone, got %d (err %v)", n, err)
+	}
+	// A second run finds nothing to do.
+	res2, err := a.RetryMedia(context.Background(), RetryMediaOptions{Wait: 2 * time.Second})
+	if err != nil {
+		t.Fatalf("RetryMedia rerun: %v", err)
+	}
+	if res2.Requested != 0 {
+		t.Fatalf("expected nothing pending on rerun, got %+v", res2)
+	}
+}
+
+func TestRetryMediaNoResponseDoesNotMarkGone(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+	f.onMediaRetry = nil // phone never answers
+
+	chat := "123@s.whatsapp.net"
+	if err := a.db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	insertMediaMessage(t, a, chat, "m1", time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC))
+
+	res, err := a.RetryMedia(context.Background(), RetryMediaOptions{Wait: 150 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("RetryMedia: %v", err)
+	}
+	if res.NoResponse != 1 || res.NotOnPhone != 0 || res.Recovered != 0 {
+		t.Fatalf("expected 1 no_response, got %+v", res)
+	}
+	// A non-responder must stay pending (not marked gone) so it can be retried.
+	if n, err := a.db.CountPendingMediaDownloads(context.Background(), ""); err != nil || n != 1 {
+		t.Fatalf("expected 1 still pending, got %d (err %v)", n, err)
+	}
+	// A non-responder gets a second attempt within the run.
+	if len(f.mediaRetryReceipts) != 2 {
+		t.Fatalf("expected 2 receipts (initial + second attempt), got %d", len(f.mediaRetryReceipts))
+	}
+}
+
+func TestRetryMediaBatches(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+	f.onMediaRetry = notOnPhoneHook
+	f.downloadErr = whatsmeow.ErrMediaDownloadFailedWith403
+
+	chat := "123@s.whatsapp.net"
+	if err := a.db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	base := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+	for i, id := range []string{"m1", "m2", "m3", "m4", "m5"} {
+		insertMediaMessage(t, a, chat, id, base.Add(time.Duration(i)*time.Second))
+	}
+
+	res, err := a.RetryMedia(context.Background(), RetryMediaOptions{BatchSize: 2, Wait: 2 * time.Second})
+	if err != nil {
+		t.Fatalf("RetryMedia: %v", err)
+	}
+	if res.Requested != 5 || res.NotOnPhone != 5 {
+		t.Fatalf("expected all 5 marked not_on_phone across batches, got %+v", res)
+	}
+	// Each message answered on the first attempt, so exactly one receipt each.
+	if len(f.mediaRetryReceipts) != 5 {
+		t.Fatalf("expected 5 receipts, got %d", len(f.mediaRetryReceipts))
+	}
+}
+
+func TestRetryMediaScopesDuplicateMessageIDsByChat(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+	f.onMediaRetry = notOnPhoneHook
+	f.downloadErr = whatsmeow.ErrMediaDownloadFailedWith403
+
+	for _, chat := range []string{"111@s.whatsapp.net", "222@s.whatsapp.net"} {
+		if err := a.db.UpsertChat(chat, "dm", "Chat", time.Now()); err != nil {
+			t.Fatalf("UpsertChat: %v", err)
+		}
+		insertMediaMessage(t, a, chat, "same-id", time.Now())
+	}
+
+	res, err := a.RetryMedia(context.Background(), RetryMediaOptions{Wait: time.Second})
+	if err != nil {
+		t.Fatalf("RetryMedia: %v", err)
+	}
+	if res.Requested != 2 || res.NotOnPhone != 2 || res.NoResponse != 0 || res.Failed != 0 {
+		t.Fatalf("unexpected duplicate-ID result: %+v", res)
+	}
+}
+
+func TestRetryMediaUsesCDNFallbackBeforeMarkingUnavailable(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+	f.onMediaRetry = notOnPhoneHook
+
+	chat := "123@s.whatsapp.net"
+	if err := a.db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	insertMediaMessage(t, a, chat, "m1", time.Now())
+
+	res, err := a.RetryMedia(context.Background(), RetryMediaOptions{Wait: time.Second})
+	if err != nil {
+		t.Fatalf("RetryMedia: %v", err)
+	}
+	if res.Recovered != 1 || res.NotOnPhone != 0 || res.Failed != 0 {
+		t.Fatalf("unexpected fallback result: %+v", res)
+	}
+	info, err := a.db.GetMediaDownloadInfo(chat, "m1")
+	if err != nil {
+		t.Fatalf("GetMediaDownloadInfo: %v", err)
+	}
+	if info.LocalPath == "" {
+		t.Fatalf("expected CDN fallback to record local path")
+	}
+}
+
+func TestRetryMediaDoesNotMarkUnavailableOnTransientCDNFailure(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+	f.onMediaRetry = notOnPhoneHook
+	f.downloadErr = errors.New("temporary CDN failure")
+
+	chat := "123@s.whatsapp.net"
+	if err := a.db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	insertMediaMessage(t, a, chat, "m1", time.Now())
+
+	res, err := a.RetryMedia(context.Background(), RetryMediaOptions{Wait: time.Second})
+	if err != nil {
+		t.Fatalf("RetryMedia: %v", err)
+	}
+	if res.Failed != 1 || res.NotOnPhone != 0 {
+		t.Fatalf("unexpected transient-failure result: %+v", res)
+	}
+	if n, err := a.db.CountPendingMediaDownloads(context.Background(), ""); err != nil || n != 1 {
+		t.Fatalf("expected row to remain pending, got %d (err %v)", n, err)
+	}
+}
+
+func TestRetryMediaBeforeFilter(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+	f.onMediaRetry = notOnPhoneHook
+	f.downloadErr = whatsmeow.ErrMediaDownloadFailedWith403
+
+	chat := "123@s.whatsapp.net"
+	if err := a.db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	base := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+	insertMediaMessage(t, a, chat, "old", base)
+	insertMediaMessage(t, a, chat, "new", base.Add(2*time.Hour))
+
+	res, err := a.RetryMedia(context.Background(), RetryMediaOptions{BeforeUnix: base.Add(time.Hour).Unix(), BeforeSet: true, Wait: time.Second})
+	if err != nil {
+		t.Fatalf("RetryMedia: %v", err)
+	}
+	if res.Requested != 1 || res.NotOnPhone != 1 {
+		t.Fatalf("unexpected before-filter result: %+v", res)
+	}
+	if n, err := a.db.CountPendingMediaDownloads(context.Background(), ""); err != nil || n != 1 {
+		t.Fatalf("expected newer row to remain pending, got %d (err %v)", n, err)
+	}
+}
+
+func TestRetryMediaExplicitEpochBeforeFilterDoesNotRetryEverything(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := "123@s.whatsapp.net"
+	if err := a.db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	insertMediaMessage(t, a, chat, "m1", time.Now())
+
+	res, err := a.RetryMedia(context.Background(), RetryMediaOptions{BeforeUnix: 0, BeforeSet: true, Wait: time.Second})
+	if err != nil {
+		t.Fatalf("RetryMedia: %v", err)
+	}
+	if res.Requested != 0 || len(f.mediaRetryReceipts) != 0 {
+		t.Fatalf("explicit epoch filter retried media: result=%+v receipts=%d", res, len(f.mediaRetryReceipts))
+	}
+}
+
+func TestRetryMediaMatchesLIDNotificationToCanonicalChat(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+	f.downloadErr = whatsmeow.ErrMediaDownloadFailedWith403
+	pn := types.NewJID("123", types.DefaultUserServer)
+	lid := types.NewJID("999", types.HiddenUserServer)
+	f.lids[lid] = pn
+	f.onMediaRetry = func(info *types.MessageInfo, _ []byte) interface{} {
+		return &events.MediaRetry{MessageID: types.MessageID(info.ID), ChatID: lid, Error: &events.MediaRetryError{Code: 2}}
+	}
+
+	if err := a.db.UpsertChat(pn.String(), "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	insertMediaMessage(t, a, pn.String(), "m1", time.Now())
+
+	res, err := a.RetryMedia(context.Background(), RetryMediaOptions{Wait: time.Second})
+	if err != nil {
+		t.Fatalf("RetryMedia: %v", err)
+	}
+	if res.NotOnPhone != 1 || res.NoResponse != 0 || res.Failed != 0 {
+		t.Fatalf("unexpected LID notification result: %+v", res)
+	}
+}
+
+func TestRetryMediaTreatsBroadcastListsAsGroupLike(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+	f.downloadErr = whatsmeow.ErrMediaDownloadFailedWith403
+	var receiptSource types.MessageSource
+	f.onMediaRetry = func(info *types.MessageInfo, _ []byte) interface{} {
+		receiptSource = info.MessageSource
+		return &events.MediaRetry{MessageID: types.MessageID(info.ID), ChatID: info.Chat, Error: &events.MediaRetryError{Code: 2}}
+	}
+
+	chat := types.NewJID("123", types.BroadcastServer)
+	if err := a.db.UpsertChat(chat.String(), "broadcast", "List", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := a.db.UpsertMessage(store.UpsertMessageParams{
+		ChatJID: chat.String(), MsgID: "m1", Timestamp: time.Now(), FromMe: true,
+		MediaType: "image", DirectPath: "/direct/m1", MediaKey: []byte{1},
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	res, err := a.RetryMedia(context.Background(), RetryMediaOptions{Wait: time.Second})
+	if err != nil {
+		t.Fatalf("RetryMedia: %v", err)
+	}
+	if res.NotOnPhone != 1 || res.Failed != 0 {
+		t.Fatalf("unexpected broadcast result: %+v", res)
+	}
+	wantSender, _ := types.ParseJID(f.LinkedJID())
+	if !receiptSource.IsGroup || receiptSource.Sender != wantSender {
+		t.Fatalf("broadcast receipt source = %+v, want group-like sender %s", receiptSource, wantSender)
+	}
+}
+
+func TestRetryMediaUsesOwnSenderForOutgoingGroupMedia(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+	f.downloadErr = whatsmeow.ErrMediaDownloadFailedWith403
+	var receiptSender types.JID
+	f.onMediaRetry = func(info *types.MessageInfo, _ []byte) interface{} {
+		receiptSender = info.Sender
+		return &events.MediaRetry{MessageID: types.MessageID(info.ID), ChatID: info.Chat, Error: &events.MediaRetryError{Code: 2}}
+	}
+
+	chat := "123@g.us"
+	groupJID, _ := types.ParseJID(chat)
+	f.groups[groupJID] = &types.GroupInfo{JID: groupJID, AddressingMode: types.AddressingModePN}
+	if err := a.db.UpsertChat(chat, "group", "Group", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := a.db.UpsertMessage(store.UpsertMessageParams{
+		ChatJID: chat, MsgID: "m1", Timestamp: time.Now(), FromMe: true,
+		MediaType: "image", DirectPath: "/direct/m1", MediaKey: []byte{1},
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	res, err := a.RetryMedia(context.Background(), RetryMediaOptions{Wait: time.Second})
+	if err != nil {
+		t.Fatalf("RetryMedia: %v", err)
+	}
+	if res.NotOnPhone != 1 || res.Failed != 0 {
+		t.Fatalf("unexpected group result: %+v", res)
+	}
+	want, _ := types.ParseJID(f.LinkedJID())
+	if receiptSender != want {
+		t.Fatalf("receipt sender = %s, want %s", receiptSender, want)
+	}
+}
+
+func TestRetryMediaRejectsNegativeOptions(t *testing.T) {
+	a := newTestApp(t)
+	for _, opts := range []RetryMediaOptions{{Limit: -1}, {BatchSize: -1}, {Wait: -1}} {
+		if _, err := a.RetryMedia(context.Background(), opts); err == nil {
+			t.Fatalf("expected error for options %+v", opts)
+		}
+	}
+}
+
+func TestIsExpiredMediaDownload(t *testing.T) {
+	if !isExpiredMediaDownload(fmt.Errorf("wrapped: %w", whatsmeow.ErrMediaDownloadFailedWith410)) {
+		t.Fatalf("expected wrapped 410 to be expired")
+	}
+	if isExpiredMediaDownload(errors.New("timeout")) {
+		t.Fatalf("unexpected transient error classified as expired")
+	}
+}

--- a/internal/store/media.go
+++ b/internal/store/media.go
@@ -68,6 +68,34 @@ func (d *DB) ListPendingMediaDownloads(ctx context.Context, chatJID string, limi
 	return pending, nil
 }
 
+// ListPendingMediaBefore is like ListPendingMediaDownloads but only returns
+// messages older than beforeUnix (seconds). Used to sample pending media by age.
+func (d *DB) ListPendingMediaBefore(ctx context.Context, chatJID string, beforeUnix int64, limit int) ([]PendingMediaDownload, error) {
+	rows, err := d.q.ListPendingMediaBefore(ctx, storedb.ListPendingMediaBeforeParams{
+		BeforeTs:   beforeUnix,
+		ChatJid:    chatJID,
+		LimitCount: int64(limit),
+	})
+	if err != nil {
+		return nil, err
+	}
+	pending := make([]PendingMediaDownload, 0, len(rows))
+	for _, row := range rows {
+		pending = append(pending, PendingMediaDownload{ChatJID: row.ChatJid, MsgID: row.MsgID})
+	}
+	return pending, nil
+}
+
+// MarkMediaUnavailable records that a message's media is no longer retrievable
+// (the phone reported it gone via media retry), so pending queries skip it.
+func (d *DB) MarkMediaUnavailable(ctx context.Context, chatJID, msgID string, at time.Time) error {
+	return d.q.MarkMediaUnavailable(ctx, storedb.MarkMediaUnavailableParams{
+		MediaUnavailableAt: sqlNullInt64(unix(at)),
+		ChatJid:            chatJID,
+		MsgID:              msgID,
+	})
+}
+
 func (d *DB) MarkMediaDownloaded(chatJID, msgID, localPath string, downloadedAt time.Time) error {
 	return d.q.MarkMediaDownloaded(storeCtx(), storedb.MarkMediaDownloadedParams{
 		LocalPath:    nullStringIfEmpty(localPath),

--- a/internal/store/media_test.go
+++ b/internal/store/media_test.go
@@ -2,8 +2,10 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
+	"time"
 )
 
 func TestPendingMediaQueriesHonorCanceledContext(t *testing.T) {
@@ -16,5 +18,76 @@ func TestPendingMediaQueriesHonorCanceledContext(t *testing.T) {
 	}
 	if _, err := db.ListPendingMediaDownloads(ctx, "", 0); !errors.Is(err, context.Canceled) {
 		t.Fatalf("ListPendingMediaDownloads error = %v, want context.Canceled", err)
+	}
+	if _, err := db.ListPendingMediaBefore(ctx, "", 1, 0); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ListPendingMediaBefore error = %v, want context.Canceled", err)
+	}
+	if err := db.MarkMediaUnavailable(ctx, "chat", "msg", nowUTC()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("MarkMediaUnavailable error = %v, want context.Canceled", err)
+	}
+}
+
+func TestFreshMediaMetadataClearsUnavailableState(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	chat := "123@s.whatsapp.net"
+	if err := db.UpsertChat(chat, "dm", "Chat", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	message := UpsertMessageParams{
+		ChatJID:    chat,
+		MsgID:      "m1",
+		Timestamp:  time.Now(),
+		MediaType:  "image",
+		DirectPath: "/old",
+		MediaKey:   []byte{1},
+	}
+	if err := db.UpsertMessage(message); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+	if err := db.MarkMediaUnavailable(ctx, chat, "m1", time.Now()); err != nil {
+		t.Fatalf("MarkMediaUnavailable: %v", err)
+	}
+
+	message.DirectPath = "/fresh"
+	message.Timestamp = message.Timestamp.Add(time.Second)
+	if err := db.UpsertMessage(message); err != nil {
+		t.Fatalf("UpsertMessage fresh path: %v", err)
+	}
+	assertMediaUnavailableCleared(t, db, chat, "m1")
+
+	if err := db.MarkMediaUnavailable(ctx, chat, "m1", time.Now()); err != nil {
+		t.Fatalf("MarkMediaUnavailable again: %v", err)
+	}
+	message.DirectPath = "/stale"
+	message.Timestamp = message.Timestamp.Add(-time.Minute)
+	if err := db.UpsertMessage(message); err != nil {
+		t.Fatalf("UpsertMessage stale path: %v", err)
+	}
+	var directPath string
+	var unavailableAt sql.NullInt64
+	if err := db.sql.QueryRow(`SELECT direct_path, media_unavailable_at FROM messages WHERE chat_jid = ? AND msg_id = ?`, chat, "m1").Scan(&directPath, &unavailableAt); err != nil {
+		t.Fatalf("query stale upsert result: %v", err)
+	}
+	if directPath != "/fresh" {
+		t.Fatalf("direct_path = %q, want /fresh", directPath)
+	}
+	if !unavailableAt.Valid {
+		t.Fatal("stale media metadata cleared media_unavailable_at")
+	}
+	if err := db.MarkMediaDownloaded(chat, "m1", "/tmp/m1", time.Now()); err != nil {
+		t.Fatalf("MarkMediaDownloaded: %v", err)
+	}
+	assertMediaUnavailableCleared(t, db, chat, "m1")
+}
+
+func assertMediaUnavailableCleared(t *testing.T, db *DB, chatJID, msgID string) {
+	t.Helper()
+	var unavailableAt sql.NullInt64
+	if err := db.sql.QueryRow(`SELECT media_unavailable_at FROM messages WHERE chat_jid = ? AND msg_id = ?`, chatJID, msgID).Scan(&unavailableAt); err != nil {
+		t.Fatalf("query media_unavailable_at: %v", err)
+	}
+	if unavailableAt.Valid {
+		t.Fatalf("media_unavailable_at still set: %d", unavailableAt.Int64)
 	}
 }

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -33,6 +33,27 @@ var schemaMigrations = []migration{
 	{version: 17, name: "status messages", up: migrateStatusMessages},
 	{version: 18, name: "chat unread count column", up: migrateChatUnreadCountColumn},
 	{version: 19, name: "messages quoted columns", up: migrateMessagesQuotedColumns},
+	{version: 20, name: "messages media_unavailable_at column", up: migrateMessagesMediaUnavailableColumn},
+}
+
+func migrateMessagesMediaUnavailableColumn(d *DB) error {
+	hasTable, err := d.tableExists("messages")
+	if err != nil {
+		return err
+	}
+	if !hasTable {
+		return nil
+	}
+	has, err := d.tableHasColumn("messages", "media_unavailable_at")
+	if err != nil {
+		return err
+	}
+	if !has {
+		if _, err := d.sql.Exec(`ALTER TABLE messages ADD COLUMN media_unavailable_at INTEGER`); err != nil {
+			return fmt.Errorf("add messages.media_unavailable_at column: %w", err)
+		}
+	}
+	return nil
 }
 
 func (d *DB) ensureSchema() error {
@@ -105,6 +126,9 @@ func (d *DB) ensureCurrentSchema() error {
 	}
 	if err := migrateMessagesQuotedColumns(d); err != nil {
 		return fmt.Errorf("ensure current messages quoted columns: %w", err)
+	}
+	if err := migrateMessagesMediaUnavailableColumn(d); err != nil {
+		return fmt.Errorf("ensure current messages media unavailable column: %w", err)
 	}
 	return nil
 }

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -83,6 +83,7 @@ CREATE TABLE IF NOT EXISTS messages (
     file_length INTEGER,
     local_path TEXT,
     downloaded_at INTEGER,
+    media_unavailable_at INTEGER,
     revoked INTEGER NOT NULL DEFAULT 0,
     deleted_for_me INTEGER NOT NULL DEFAULT 0,
     edited INTEGER NOT NULL DEFAULT 0,

--- a/internal/store/schema_test.go
+++ b/internal/store/schema_test.go
@@ -35,6 +35,7 @@ func TestOpenCreatesExpectedSchema(t *testing.T) {
 		"reaction_emoji",
 		"local_path",
 		"downloaded_at",
+		"media_unavailable_at",
 		"revoked",
 		"deleted_for_me",
 		"edited",
@@ -135,6 +136,47 @@ func TestTableHasColumnAllowsSchemaIdentifiers(t *testing.T) {
 	}
 	if !hasColumn {
 		t.Fatalf("expected messages.display_text to exist")
+	}
+}
+
+func TestOpenRepairsRecordedMediaUnavailableMigrationMissingColumn(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wacli.db")
+	raw, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	legacySchema := strings.Replace(coreSchemaSQL, "    media_unavailable_at INTEGER,\n", "", 1)
+	if _, err := raw.Exec(legacySchema + `
+		CREATE TABLE schema_migrations (
+			version INTEGER PRIMARY KEY,
+			name TEXT NOT NULL,
+			applied_at INTEGER NOT NULL
+		);
+	`); err != nil {
+		_ = raw.Close()
+		t.Fatalf("create legacy schema: %v", err)
+	}
+	for _, migration := range schemaMigrations {
+		if _, err := raw.Exec(`INSERT INTO schema_migrations(version, name, applied_at) VALUES(?, ?, 1)`, migration.version, migration.name); err != nil {
+			_ = raw.Close()
+			t.Fatalf("record migration %d: %v", migration.version, err)
+		}
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw close: %v", err)
+	}
+
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open repaired DB: %v", err)
+	}
+	defer db.Close()
+	hasColumn, err := db.tableHasColumn("messages", "media_unavailable_at")
+	if err != nil {
+		t.Fatalf("tableHasColumn: %v", err)
+	}
+	if !hasColumn {
+		t.Fatalf("expected media_unavailable_at repair")
 	}
 }
 

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -208,6 +208,7 @@ ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
     file_length=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.file_length WHEN excluded.file_length>0 THEN excluded.file_length ELSE messages.file_length END,
     local_path=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE messages.local_path END,
     downloaded_at=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE messages.downloaded_at END,
+    media_unavailable_at=CASE WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_unavailable_at WHEN COALESCE(excluded.direct_path,'') != '' AND excluded.direct_path != COALESCE(messages.direct_path,'') THEN NULL ELSE messages.media_unavailable_at END,
     revoked=CASE WHEN excluded.revoked != 0 THEN 1 ELSE messages.revoked END,
     deleted_for_me=CASE WHEN excluded.deleted_for_me != 0 THEN 1 ELSE messages.deleted_for_me END,
     edited=CASE WHEN excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN 0 WHEN excluded.edited != 0 THEN 1 WHEN messages.edited != 0 THEN messages.edited ELSE 0 END,
@@ -372,7 +373,10 @@ LEFT JOIN chats c ON c.jid = m.chat_jid
 WHERE m.chat_jid = ? AND m.msg_id = ?;
 
 -- name: MarkMediaDownloaded :exec
-UPDATE messages SET local_path = ?, downloaded_at = ? WHERE chat_jid = ? AND msg_id = ?;
+UPDATE messages SET local_path = ?, downloaded_at = ?, media_unavailable_at = NULL WHERE chat_jid = ? AND msg_id = ?;
+
+-- name: MarkMediaUnavailable :exec
+UPDATE messages SET media_unavailable_at = ? WHERE chat_jid = ? AND msg_id = ?;
 
 -- name: CountPendingMediaDownloads :one
 SELECT COUNT(*)
@@ -383,6 +387,7 @@ WHERE COALESCE(m.media_type,'') != ''
   AND COALESCE(m.local_path,'') = ''
   AND m.revoked = 0
   AND m.deleted_for_me = 0
+  AND m.media_unavailable_at IS NULL
   AND (sqlc.arg(chat_jid) = '' OR m.chat_jid = sqlc.arg(chat_jid));
 
 -- name: ListPendingMediaDownloads :many
@@ -394,6 +399,22 @@ WHERE COALESCE(m.media_type,'') != ''
   AND COALESCE(m.local_path,'') = ''
   AND m.revoked = 0
   AND m.deleted_for_me = 0
+  AND m.media_unavailable_at IS NULL
+  AND (sqlc.arg(chat_jid) = '' OR m.chat_jid = sqlc.arg(chat_jid))
+ORDER BY m.ts DESC, m.rowid DESC
+LIMIT CASE WHEN sqlc.arg(limit_count) <= 0 THEN -1 ELSE sqlc.arg(limit_count) END;
+
+-- name: ListPendingMediaBefore :many
+SELECT m.chat_jid, m.msg_id
+FROM messages m
+WHERE COALESCE(m.media_type,'') != ''
+  AND COALESCE(m.direct_path,'') != ''
+  AND m.media_key IS NOT NULL AND length(m.media_key) > 0
+  AND COALESCE(m.local_path,'') = ''
+  AND m.revoked = 0
+  AND m.deleted_for_me = 0
+  AND m.media_unavailable_at IS NULL
+  AND m.ts < sqlc.arg(before_ts)
   AND (sqlc.arg(chat_jid) = '' OR m.chat_jid = sqlc.arg(chat_jid))
 ORDER BY m.ts DESC, m.rowid DESC
 LIMIT CASE WHEN sqlc.arg(limit_count) <= 0 THEN -1 ELSE sqlc.arg(limit_count) END;

--- a/internal/store/storedb/models.go
+++ b/internal/store/storedb/models.go
@@ -82,38 +82,39 @@ type GroupParticipant struct {
 }
 
 type Message struct {
-	Rowid           int64
-	ChatJid         string
-	ChatName        sql.NullString
-	MsgID           string
-	SenderJid       sql.NullString
-	SenderName      sql.NullString
-	Ts              int64
-	FromMe          int64
-	Text            sql.NullString
-	DisplayText     sql.NullString
-	QuotedMsgID     sql.NullString
-	QuotedSenderJid sql.NullString
-	IsForwarded     int64
-	ForwardingScore int64
-	ReactionToID    sql.NullString
-	ReactionEmoji   sql.NullString
-	MediaType       sql.NullString
-	MediaCaption    sql.NullString
-	Filename        sql.NullString
-	MimeType        sql.NullString
-	DirectPath      sql.NullString
-	MediaKey        []byte
-	FileSha256      []byte
-	FileEncSha256   []byte
-	FileLength      sql.NullInt64
-	LocalPath       sql.NullString
-	DownloadedAt    sql.NullInt64
-	Revoked         int64
-	DeletedForMe    int64
-	Edited          int64
-	EditedTs        int64
-	Buttons         sql.NullString
+	Rowid              int64
+	ChatJid            string
+	ChatName           sql.NullString
+	MsgID              string
+	SenderJid          sql.NullString
+	SenderName         sql.NullString
+	Ts                 int64
+	FromMe             int64
+	Text               sql.NullString
+	DisplayText        sql.NullString
+	QuotedMsgID        sql.NullString
+	QuotedSenderJid    sql.NullString
+	IsForwarded        int64
+	ForwardingScore    int64
+	ReactionToID       sql.NullString
+	ReactionEmoji      sql.NullString
+	MediaType          sql.NullString
+	MediaCaption       sql.NullString
+	Filename           sql.NullString
+	MimeType           sql.NullString
+	DirectPath         sql.NullString
+	MediaKey           []byte
+	FileSha256         []byte
+	FileEncSha256      []byte
+	FileLength         sql.NullInt64
+	LocalPath          sql.NullString
+	DownloadedAt       sql.NullInt64
+	MediaUnavailableAt sql.NullInt64
+	Revoked            int64
+	DeletedForMe       int64
+	Edited             int64
+	EditedTs           int64
+	Buttons            sql.NullString
 }
 
 type MessagesFt struct {

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -103,6 +103,7 @@ WHERE COALESCE(m.media_type,'') != ''
   AND COALESCE(m.local_path,'') = ''
   AND m.revoked = 0
   AND m.deleted_for_me = 0
+  AND m.media_unavailable_at IS NULL
   AND (?1 = '' OR m.chat_jid = ?1)
 `
 
@@ -751,6 +752,56 @@ func (q *Queries) ListLeftGroups(ctx context.Context) ([]ListLeftGroupsRow, erro
 	return items, nil
 }
 
+const listPendingMediaBefore = `-- name: ListPendingMediaBefore :many
+SELECT m.chat_jid, m.msg_id
+FROM messages m
+WHERE COALESCE(m.media_type,'') != ''
+  AND COALESCE(m.direct_path,'') != ''
+  AND m.media_key IS NOT NULL AND length(m.media_key) > 0
+  AND COALESCE(m.local_path,'') = ''
+  AND m.revoked = 0
+  AND m.deleted_for_me = 0
+  AND m.media_unavailable_at IS NULL
+  AND m.ts < ?1
+  AND (?2 = '' OR m.chat_jid = ?2)
+ORDER BY m.ts DESC, m.rowid DESC
+LIMIT CASE WHEN ?3 <= 0 THEN -1 ELSE ?3 END
+`
+
+type ListPendingMediaBeforeParams struct {
+	BeforeTs   int64
+	ChatJid    interface{}
+	LimitCount interface{}
+}
+
+type ListPendingMediaBeforeRow struct {
+	ChatJid string
+	MsgID   string
+}
+
+func (q *Queries) ListPendingMediaBefore(ctx context.Context, arg ListPendingMediaBeforeParams) ([]ListPendingMediaBeforeRow, error) {
+	rows, err := q.db.QueryContext(ctx, listPendingMediaBefore, arg.BeforeTs, arg.ChatJid, arg.LimitCount)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListPendingMediaBeforeRow
+	for rows.Next() {
+		var i ListPendingMediaBeforeRow
+		if err := rows.Scan(&i.ChatJid, &i.MsgID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listPendingMediaDownloads = `-- name: ListPendingMediaDownloads :many
 SELECT m.chat_jid, m.msg_id
 FROM messages m
@@ -760,6 +811,7 @@ WHERE COALESCE(m.media_type,'') != ''
   AND COALESCE(m.local_path,'') = ''
   AND m.revoked = 0
   AND m.deleted_for_me = 0
+  AND m.media_unavailable_at IS NULL
   AND (?1 = '' OR m.chat_jid = ?1)
 ORDER BY m.ts DESC, m.rowid DESC
 LIMIT CASE WHEN ?2 <= 0 THEN -1 ELSE ?2 END
@@ -946,7 +998,7 @@ func (q *Queries) MarkGroupLeft(ctx context.Context, arg MarkGroupLeftParams) er
 }
 
 const markMediaDownloaded = `-- name: MarkMediaDownloaded :exec
-UPDATE messages SET local_path = ?, downloaded_at = ? WHERE chat_jid = ? AND msg_id = ?
+UPDATE messages SET local_path = ?, downloaded_at = ?, media_unavailable_at = NULL WHERE chat_jid = ? AND msg_id = ?
 `
 
 type MarkMediaDownloadedParams struct {
@@ -963,6 +1015,21 @@ func (q *Queries) MarkMediaDownloaded(ctx context.Context, arg MarkMediaDownload
 		arg.ChatJid,
 		arg.MsgID,
 	)
+	return err
+}
+
+const markMediaUnavailable = `-- name: MarkMediaUnavailable :exec
+UPDATE messages SET media_unavailable_at = ? WHERE chat_jid = ? AND msg_id = ?
+`
+
+type MarkMediaUnavailableParams struct {
+	MediaUnavailableAt sql.NullInt64
+	ChatJid            string
+	MsgID              string
+}
+
+func (q *Queries) MarkMediaUnavailable(ctx context.Context, arg MarkMediaUnavailableParams) error {
+	_, err := q.db.ExecContext(ctx, markMediaUnavailable, arg.MediaUnavailableAt, arg.ChatJid, arg.MsgID)
 	return err
 }
 
@@ -1706,6 +1773,7 @@ ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
     file_length=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.file_length WHEN excluded.file_length>0 THEN excluded.file_length ELSE messages.file_length END,
     local_path=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE messages.local_path END,
     downloaded_at=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE messages.downloaded_at END,
+    media_unavailable_at=CASE WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_unavailable_at WHEN COALESCE(excluded.direct_path,'') != '' AND excluded.direct_path != COALESCE(messages.direct_path,'') THEN NULL ELSE messages.media_unavailable_at END,
     revoked=CASE WHEN excluded.revoked != 0 THEN 1 ELSE messages.revoked END,
     deleted_for_me=CASE WHEN excluded.deleted_for_me != 0 THEN 1 ELSE messages.deleted_for_me END,
     edited=CASE WHEN excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN 0 WHEN excluded.edited != 0 THEN 1 WHEN messages.edited != 0 THEN messages.edited ELSE 0 END,

--- a/internal/wa/mediaretry.go
+++ b/internal/wa/mediaretry.go
@@ -1,0 +1,67 @@
+package wa
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+// MediaRetryResult mirrors waMmsRetry.MediaRetryNotification_ResultType.
+const (
+	MediaRetryGeneralError    = 0
+	MediaRetrySuccess         = 1
+	MediaRetryNotFound        = 2 // phone no longer has the media
+	MediaRetryDecryptionError = 3
+)
+
+// SendMediaRetryReceipt asks the primary device (phone) to re-upload the media
+// for a message whose direct download has expired. The phone answers with a
+// MediaRetry event (delivered via the event handler) carrying a fresh location.
+func (c *Client) SendMediaRetryReceipt(ctx context.Context, info *types.MessageInfo, mediaKey []byte) error {
+	c.mu.Lock()
+	cli := c.client
+	c.mu.Unlock()
+	if cli == nil || !cli.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+	if info == nil {
+		return fmt.Errorf("message info is required")
+	}
+	retryInfo := rewriteMediaRetryInfoForLID(ctx, cli, *info, c.resolvePNToLIDLocked)
+	return cli.SendMediaRetryReceipt(ctx, &retryInfo, mediaKey)
+}
+
+func rewriteMediaRetryInfoForLID(ctx context.Context, cli *whatsmeow.Client, info types.MessageInfo, resolve pollVoteLIDResolver) types.MessageInfo {
+	if cli == nil || cli.Store == nil || cli.Store.LIDMigrationTimestamp <= 0 || resolve == nil {
+		return info
+	}
+	if info.Chat.Server == types.DefaultUserServer {
+		info.Chat = resolve(ctx, cli, info.Chat)
+		if info.Sender.Server == types.DefaultUserServer {
+			info.Sender = resolve(ctx, cli, info.Sender)
+		}
+	} else if info.AddressingMode == types.AddressingModeLID && info.Sender.Server == types.DefaultUserServer {
+		info.Sender = resolve(ctx, cli, info.Sender)
+	}
+	return info
+}
+
+// DecryptMediaRetry decrypts a MediaRetry notification with the message's media
+// key. On success it returns the new direct path to download from; resultCode
+// follows the MediaRetry* constants above (Success, NotFound, ...).
+func DecryptMediaRetry(evt *events.MediaRetry, mediaKey []byte) (directPath string, resultCode int, err error) {
+	notif, err := whatsmeow.DecryptMediaRetryNotification(evt, mediaKey)
+	if err != nil {
+		// The phone can report "gone" as an unencrypted error notification
+		// rather than a decrypted NOT_FOUND result; normalize both to NotFound.
+		if errors.Is(err, whatsmeow.ErrMediaNotAvailableOnPhone) {
+			return "", MediaRetryNotFound, nil
+		}
+		return "", MediaRetryGeneralError, err
+	}
+	return notif.GetDirectPath(), int(notif.GetResult()), nil
+}

--- a/internal/wa/mediaretry_test.go
+++ b/internal/wa/mediaretry_test.go
@@ -1,0 +1,74 @@
+package wa
+
+import (
+	"context"
+	"testing"
+
+	"go.mau.fi/whatsmeow"
+	waStore "go.mau.fi/whatsmeow/store"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+func TestRewriteMediaRetryInfoForLIDRewritesDM(t *testing.T) {
+	chat := types.NewJID("15551234567", types.DefaultUserServer)
+	sender := types.NewJID("15557654321", types.DefaultUserServer)
+	info := types.MessageInfo{MessageSource: types.MessageSource{Chat: chat, Sender: sender}, ID: "media-id"}
+	cli := &whatsmeow.Client{Store: &waStore.Device{LIDMigrationTimestamp: 1}}
+
+	got := rewriteMediaRetryInfoForLID(context.Background(), cli, info, func(_ context.Context, _ *whatsmeow.Client, jid types.JID) types.JID {
+		return types.NewJID(jid.User+"lid", types.HiddenUserServer)
+	})
+	if got.Chat.Server != types.HiddenUserServer || got.Sender.Server != types.HiddenUserServer {
+		t.Fatalf("rewritten source = %+v", got.MessageSource)
+	}
+}
+
+func TestRewriteMediaRetryInfoForLIDUsesGroupAddressingMode(t *testing.T) {
+	group := types.NewJID("120363001234567890", types.GroupServer)
+	sender := types.NewJID("15557654321", types.DefaultUserServer)
+	cli := &whatsmeow.Client{Store: &waStore.Device{LIDMigrationTimestamp: 1}}
+
+	for _, tc := range []struct {
+		name string
+		mode types.AddressingMode
+		want types.JID
+	}{
+		{name: "lid", mode: types.AddressingModeLID, want: types.NewJID(sender.User+"lid", types.HiddenUserServer)},
+		{name: "pn", mode: types.AddressingModePN, want: sender},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			info := types.MessageInfo{MessageSource: types.MessageSource{Chat: group, Sender: sender, IsGroup: true, AddressingMode: tc.mode}, ID: "media-id"}
+			got := rewriteMediaRetryInfoForLID(context.Background(), cli, info, func(_ context.Context, _ *whatsmeow.Client, jid types.JID) types.JID {
+				return types.NewJID(jid.User+"lid", types.HiddenUserServer)
+			})
+			if got.Sender != tc.want {
+				t.Fatalf("sender = %s, want %s", got.Sender, tc.want)
+			}
+		})
+	}
+}
+
+func TestDecryptMediaRetryNormalizesNotFound(t *testing.T) {
+	directPath, code, err := DecryptMediaRetry(&events.MediaRetry{
+		Error: &events.MediaRetryError{Code: 2},
+	}, nil)
+	if err != nil {
+		t.Fatalf("DecryptMediaRetry: %v", err)
+	}
+	if directPath != "" || code != MediaRetryNotFound {
+		t.Fatalf("result = (%q, %d), want empty path and not-found code", directPath, code)
+	}
+}
+
+func TestDecryptMediaRetryPreservesUnknownError(t *testing.T) {
+	_, code, err := DecryptMediaRetry(&events.MediaRetry{
+		Error: &events.MediaRetryError{Code: 9},
+	}, nil)
+	if err == nil {
+		t.Fatalf("expected unknown retry error")
+	}
+	if code != MediaRetryGeneralError {
+		t.Fatalf("code = %d, want general error", code)
+	}
+}


### PR DESCRIPTION
## Summary

- add `media retry` to recover CDN-expired media through WhatsApp's phone retry protocol
- keep retry batches bounded, correlate responses by chat plus message ID, and support migrated LID/group/broadcast addressing
- mark media permanently unavailable only after both the phone and the original CDN path confirm it is gone
- persist unavailable state with a repairable migration; clear it only for genuinely fresh media metadata or a completed download

Extracted from #291 after the backfill-only portion landed. Preserves Nat Torkington's authorship and changelog credit.

## Proof

- `go test -race ./internal/app ./internal/store ./internal/wa ./cmd/wacli`
- `pnpm test`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test:e2e`
- structured autoreview: clean, no accepted/actionable findings

## Live validation

- authenticated candidate opened and migrated the existing account store
- malformed `--before` failed before nonexistent-account access
- explicit `--before 1970-01-01 --limit 1` requested zero rows
- bounded live runs reconciled all JSON counts and outcomes
- rows from left groups failed safely before sending an ambiguously addressed receipt
- phone non-response remained pending and was selected again on a second bounded run; it was not marked unavailable
- final-branch positive recovery remained blocked because the linked phone emitted no retry response, including for recent outgoing media; no recovered-file claim is made

The original contributor's live run on #291 exercised the positive protocol path at scale: 964 requested, 801 recovered, 16 not on phone, 136 no response, and 11 failed.
