### PR TITLE
feat(sync): add quiet presence mode

### DIFF
--- a/cmd/wacli/sync.go
+++ b/cmd/wacli/sync.go
@@ -17,6 +17,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var idleExit time.Duration
 	var maxReconnect time.Duration
 	var staleThreshold time.Duration
+	var presenceModeFlag string
 	var downloadMedia bool
 	var refreshContacts bool
 	var refreshGroups bool
@@ -46,6 +47,10 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 			}
 			if maxStaleThreshold := appPkg.MaxStaleThreshold(); staleThreshold >= maxStaleThreshold {
 				return fmt.Errorf("--stale-threshold must be less than %s because whatsmeow auto-reconnects after that much keepalive failure, got %s", maxStaleThreshold, staleThreshold)
+			}
+			presenceMode, err := appPkg.ParseSyncPresenceMode(presenceModeFlag)
+			if err != nil {
+				return err
 			}
 			ctx, stop := signalContextWithEvents(out.NewEventWriter(os.Stderr, flags.events))
 			defer stop()
@@ -89,6 +94,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 
 			res, err := a.Sync(ctx, appPkg.SyncOptions{
 				Mode:                mode,
+				PresenceMode:        presenceMode,
 				AllowQR:             false,
 				AfterConnect:        afterConnect,
 				DownloadMedia:       downloadMedia,
@@ -125,6 +131,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().DurationVar(&idleExit, "idle-exit", 30*time.Second, "exit after being idle (once mode)")
 	cmd.Flags().DurationVar(&maxReconnect, "max-reconnect", 5*time.Minute, "give up reconnecting after this duration (0 = unlimited)")
 	cmd.Flags().DurationVar(&staleThreshold, "stale-threshold", 0, "force reconnect when keepalive failures last this long in follow mode (1s-<2m20s, 0 = disabled)")
+	cmd.Flags().StringVar(&presenceModeFlag, "presence-mode", string(appPkg.SyncPresenceModeNormal), "global sync presence behavior: normal or quiet")
 	cmd.Flags().BoolVar(&downloadMedia, "download-media", false, "download media in the background during sync")
 	cmd.Flags().BoolVar(&refreshContacts, "refresh-contacts", false, "refresh contacts from session store into local DB")
 	cmd.Flags().BoolVar(&refreshGroups, "refresh-groups", false, "refresh joined groups (live) into local DB")

--- a/cmd/wacli/sync_test.go
+++ b/cmd/wacli/sync_test.go
@@ -33,3 +33,13 @@ func TestSyncCommandRejectsIneffectiveStaleThreshold(t *testing.T) {
 		t.Fatalf("expected stale-threshold validation error, got %v", err)
 	}
 }
+
+func TestSyncCommandRejectsInvalidPresenceMode(t *testing.T) {
+	cmd := newSyncCmd(&rootFlags{})
+	cmd.SetArgs([]string{"--presence-mode", "loud"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--presence-mode must be one of: normal, quiet") {
+		t.Fatalf("expected presence-mode validation error, got %v", err)
+	}
+}

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -7,7 +7,7 @@ Read when: running continuous capture, one-shot sync, contact/group refresh, or 
 ## Command
 
 ```bash
-wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-threshold DURATION] [--max-messages N] [--max-db-size SIZE] [--download-media] [--refresh-contacts] [--refresh-groups] [--refresh-channels] [--events] [--webhook URL] [--webhook-secret SECRET]
+wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-threshold DURATION] [--presence-mode normal|quiet] [--max-messages N] [--max-db-size SIZE] [--download-media] [--refresh-contacts] [--refresh-groups] [--refresh-channels] [--events] [--webhook URL] [--webhook-secret SECRET]
 ```
 
 ## Modes
@@ -35,6 +35,7 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-t
 - Sync stores WhatsApp status broadcasts in `status_messages`, separate from normal chat `messages`.
 - In an interactive terminal, routine connected/history/progress updates share one updating stderr status line. Warnings and errors still print as separate lines so they remain visible.
 - `--stale-threshold DURATION` in follow mode detects keepalive failures. If whatsmeow reports that the last successful keepalive is older than this duration, sync force-closes the connection and reconnects. Healthy quiet sessions are not reconnected just because no chat events arrive. Disabled by default (`0`); accepted values are `1s` up to but not including `2m20s`, which reserves one maximum keepalive probe interval plus response deadline before whatsmeow's own 3-minute auto-reconnect window.
+- `--presence-mode normal|quiet` controls global linked-device presence during sync. `normal` is the default and preserves the existing behavior: sync sends available presence after connecting or receiving a push-name update, then sends unavailable presence on cleanup. `quiet` suppresses the available-presence sends while keeping the final unavailable cleanup; use it for personal-number mirrors where keeping primary-phone notifications audible matters. WhatsApp ultimately controls notification routing, so this mode avoids the active linked-device signal but cannot guarantee phone behavior on every platform.
 - A `stale` NDJSON event is emitted when the threshold is exceeded, containing `threshold`, `idle_duration`, `error_count`, and `source` fields.
 - While `sync --follow` is running, a `HEARTBEAT` file is written to the store directory (at most once per minute) with the last observed follow activity timestamp in RFC 3339 format. External watchdogs or `wacli doctor` can read this as an activity marker; quiet healthy sessions may not update it because successful keepalives are silent, and keepalive health is reported separately through `stale` events.
 - `--events` emits one NDJSON lifecycle event per stderr line for machine consumers. Routine human progress/status lines, interrupt prompts, and command errors are emitted as events while events are enabled.
@@ -45,6 +46,7 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-t
 wacli sync --once
 wacli sync --follow --max-reconnect 10m
 wacli sync --follow --stale-threshold 2m
+wacli sync --follow --presence-mode quiet
 wacli sync --follow --max-messages 250000 --max-db-size 2GB
 wacli sync --once --refresh-contacts --refresh-groups --refresh-channels
 wacli sync --follow --download-media

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -31,7 +31,7 @@ type WAClient interface {
 
 	AddEventHandler(handler func(interface{})) uint32
 	RemoveEventHandler(id uint32)
-	ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay time.Duration) error
+	ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay time.Duration, opts wa.ConnectOptions) error
 
 	ResolveChatName(ctx context.Context, chat types.JID, pushName string) string
 	ResolveLIDToPN(ctx context.Context, jid types.JID) types.JID

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -225,8 +225,9 @@ func (f *fakeWA) RemoveEventHandler(id uint32) {
 	delete(f.handlers, id)
 }
 
-func (f *fakeWA) ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay time.Duration) error {
-	return f.Connect(ctx, wa.ConnectOptions{AllowQR: false})
+func (f *fakeWA) ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay time.Duration, opts wa.ConnectOptions) error {
+	opts.AllowQR = false
+	return f.Connect(ctx, opts)
 }
 
 func (f *fakeWA) ResolveChatName(ctx context.Context, chat types.JID, pushName string) string {

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -200,6 +200,9 @@ func (f *fakeWA) Connect(ctx context.Context, opts wa.ConnectOptions) error {
 			return ctx.Err()
 		}
 	}
+	if authed && !opts.SuppressInitialAvailablePresence {
+		_ = f.SendPresence(ctx, types.PresenceAvailable)
+	}
 	f.emit(&events.Connected{})
 	for _, e := range eventsToEmit {
 		f.emit(e)

--- a/internal/app/heartbeat_test.go
+++ b/internal/app/heartbeat_test.go
@@ -263,7 +263,7 @@ func TestSyncFollowEmitsStaleEvent(t *testing.T) {
 	defer cancel()
 	done := make(chan error, 1)
 	go func() {
-		_, err := a.runSyncFollow(ctx, time.Second, &messagesStored, &connectionEpoch, disconnected, staleReconnect)
+		_, err := a.runSyncFollow(ctx, time.Second, SyncPresenceModeNormal, &messagesStored, &connectionEpoch, disconnected, staleReconnect)
 		done <- err
 	}()
 

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -269,10 +269,11 @@ func (a *App) syncAppStateDeltas(ctx context.Context) {
 
 func (a *App) connectForSync(ctx context.Context, opts SyncOptions) error {
 	connectOpts := wa.ConnectOptions{
-		AllowQR:         opts.AllowQR,
-		OnQRCode:        opts.OnQRCode,
-		PairPhoneNumber: opts.PairPhoneNumber,
-		OnPairCode:      opts.OnPairCode,
+		AllowQR:                          opts.AllowQR,
+		OnQRCode:                         opts.OnQRCode,
+		PairPhoneNumber:                  opts.PairPhoneNumber,
+		OnPairCode:                       opts.OnPairCode,
+		SuppressInitialAvailablePresence: !opts.PresenceMode.SendsAvailablePresence(),
 		// Only detach for already-authenticated sync, not for auth
 		// bootstrap (AllowQR / phone pairing) where caller
 		// cancellation must bound the QR/pairing flow.

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -34,8 +34,31 @@ const (
 	SyncModeFollow    SyncMode = "follow"
 )
 
+type SyncPresenceMode string
+
+const (
+	SyncPresenceModeNormal SyncPresenceMode = "normal"
+	SyncPresenceModeQuiet  SyncPresenceMode = "quiet"
+)
+
+func ParseSyncPresenceMode(value string) (SyncPresenceMode, error) {
+	switch SyncPresenceMode(strings.TrimSpace(value)) {
+	case "", SyncPresenceModeNormal:
+		return SyncPresenceModeNormal, nil
+	case SyncPresenceModeQuiet:
+		return SyncPresenceModeQuiet, nil
+	default:
+		return "", fmt.Errorf("--presence-mode must be one of: normal, quiet")
+	}
+}
+
+func (m SyncPresenceMode) SendsAvailablePresence() bool {
+	return m != SyncPresenceModeQuiet
+}
+
 type SyncOptions struct {
 	Mode                SyncMode
+	PresenceMode        SyncPresenceMode
 	AllowQR             bool
 	OnQRCode            func(string)
 	PairPhoneNumber     string
@@ -67,6 +90,9 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 
 	if opts.Mode == "" {
 		opts.Mode = SyncModeFollow
+	}
+	if opts.PresenceMode == "" {
+		opts.PresenceMode = SyncPresenceModeNormal
 	}
 	if (opts.Mode == SyncModeBootstrap || opts.Mode == SyncModeOnce) && opts.IdleExit <= 0 {
 		opts.IdleExit = 30 * time.Second

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -233,9 +233,9 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 
 	var err error
 	if opts.Mode == SyncModeFollow {
-		_, err = a.runSyncFollow(syncCtx, opts.MaxReconnect, &messagesStored, &connectionEpoch, disconnected, staleReconnect)
+		_, err = a.runSyncFollow(syncCtx, opts.MaxReconnect, opts.PresenceMode, &messagesStored, &connectionEpoch, disconnected, staleReconnect)
 	} else {
-		_, err = a.runSyncUntilIdle(syncCtx, opts.IdleExit, opts.MaxReconnect, &messagesStored, &lastEvent, disconnected)
+		_, err = a.runSyncUntilIdle(syncCtx, opts.IdleExit, opts.MaxReconnect, opts.PresenceMode, &messagesStored, &lastEvent, disconnected)
 	}
 	limitErr := limits.Err()
 	// Successful one-shot modes must finish queued downloads before cleanup

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -112,7 +112,7 @@ func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, message
 		case *events.Connected:
 			a.emitOrPrint("connected", nil, "\nConnected.\n")
 			ps.mu.Lock()
-			if !ps.cleanupStarted {
+			if !ps.cleanupStarted && opts.PresenceMode.SendsAvailablePresence() {
 				a.sendPresenceBounded(types.PresenceAvailable)
 			}
 			ps.mu.Unlock()
@@ -120,7 +120,7 @@ func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, message
 			a.handleKeepAliveTimeout(opts, v, staleReconnect)
 		case *events.PushNameSetting:
 			ps.mu.Lock()
-			if !ps.cleanupStarted {
+			if !ps.cleanupStarted && opts.PresenceMode.SendsAvailablePresence() {
 				a.sendPresenceBounded(types.PresenceAvailable)
 			}
 			ps.mu.Unlock()

--- a/internal/app/sync_idle.go
+++ b/internal/app/sync_idle.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"sync/atomic"
 	"time"
+
+	"github.com/openclaw/wacli/internal/wa"
 )
 
-func (a *App) runSyncFollow(ctx context.Context, maxReconnect time.Duration, messagesStored, connectionEpoch *atomic.Int64, disconnected <-chan struct{}, staleReconnect <-chan staleReconnectRequest) (SyncResult, error) {
+func (a *App) runSyncFollow(ctx context.Context, maxReconnect time.Duration, presenceMode SyncPresenceMode, messagesStored, connectionEpoch *atomic.Int64, disconnected <-chan struct{}, staleReconnect <-chan staleReconnectRequest) (SyncResult, error) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -27,20 +29,20 @@ func (a *App) runSyncFollow(ctx context.Context, maxReconnect time.Duration, mes
 			// Client.Connect can see the existing socket as still live and return nil.
 			a.wa.Close()
 			connectionEpoch.Store(nowUTC().UnixNano())
-			if err := a.reconnect(ctx, maxReconnect); err != nil {
+			if err := a.reconnect(ctx, maxReconnect, presenceMode); err != nil {
 				return SyncResult{MessagesStored: messagesStored.Load()}, err
 			}
 		case <-disconnected:
 			a.emitOrPrint("reconnecting", nil, "Reconnecting...\n")
 			connectionEpoch.Store(nowUTC().UnixNano())
-			if err := a.reconnect(ctx, maxReconnect); err != nil {
+			if err := a.reconnect(ctx, maxReconnect, presenceMode); err != nil {
 				return SyncResult{MessagesStored: messagesStored.Load()}, err
 			}
 		}
 	}
 }
 
-func (a *App) runSyncUntilIdle(ctx context.Context, idleExit, maxReconnect time.Duration, messagesStored, lastEvent *atomic.Int64, disconnected <-chan struct{}) (SyncResult, error) {
+func (a *App) runSyncUntilIdle(ctx context.Context, idleExit, maxReconnect time.Duration, presenceMode SyncPresenceMode, messagesStored, lastEvent *atomic.Int64, disconnected <-chan struct{}) (SyncResult, error) {
 	poll := 250 * time.Millisecond
 	if idleExit >= 2*time.Second {
 		poll = 1 * time.Second
@@ -54,7 +56,7 @@ func (a *App) runSyncUntilIdle(ctx context.Context, idleExit, maxReconnect time.
 			return SyncResult{MessagesStored: messagesStored.Load()}, nil
 		case <-disconnected:
 			a.emitOrPrint("reconnecting", nil, "Reconnecting...\n")
-			if err := a.reconnect(ctx, maxReconnect); err != nil {
+			if err := a.reconnect(ctx, maxReconnect, presenceMode); err != nil {
 				return SyncResult{MessagesStored: messagesStored.Load()}, err
 			}
 		case <-ticker.C:
@@ -73,14 +75,16 @@ func (a *App) runSyncUntilIdle(ctx context.Context, idleExit, maxReconnect time.
 // reconnect wraps ReconnectWithBackoff with an optional deadline. If maxDuration
 // is positive, reconnection gives up after that long; otherwise it retries until
 // ctx is cancelled.
-func (a *App) reconnect(ctx context.Context, maxDuration time.Duration) error {
+func (a *App) reconnect(ctx context.Context, maxDuration time.Duration, presenceMode SyncPresenceMode) error {
 	rctx := ctx
 	var cancel context.CancelFunc
 	if maxDuration > 0 {
 		rctx, cancel = context.WithTimeout(ctx, maxDuration)
 		defer cancel()
 	}
-	err := a.wa.ReconnectWithBackoff(rctx, 2*time.Second, 30*time.Second)
+	err := a.wa.ReconnectWithBackoff(rctx, 2*time.Second, 30*time.Second, wa.ConnectOptions{
+		SuppressInitialAvailablePresence: !presenceMode.SendsAvailablePresence(),
+	})
 	if err != nil && ctx.Err() == nil {
 		return fmt.Errorf("could not reconnect after %s: %w", maxDuration, err)
 	}

--- a/internal/app/sync_presence_test.go
+++ b/internal/app/sync_presence_test.go
@@ -116,6 +116,59 @@ func TestSyncQuietPresenceModeSkipsAvailablePresence(t *testing.T) {
 	}
 }
 
+func TestSyncQuietPresenceModeSkipsAvailablePresenceAfterReconnect(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	reconnected := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				f.mu.Lock()
+				connectCalls := f.connectCalls
+				f.mu.Unlock()
+				if connectCalls >= 2 {
+					close(reconnected)
+					cancel()
+					return
+				}
+			}
+		}
+	}()
+
+	captureStderr(t, func() {
+		_, err := a.Sync(ctx, SyncOptions{
+			Mode:         SyncModeFollow,
+			AllowQR:      false,
+			MaxReconnect: time.Second,
+			PresenceMode: SyncPresenceModeQuiet,
+			AfterConnect: func(context.Context) error {
+				f.emit(&events.StreamReplaced{})
+				return nil
+			},
+		})
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("Sync: %v", err)
+		}
+	})
+
+	select {
+	case <-reconnected:
+	default:
+		t.Fatal("expected StreamReplaced to trigger reconnect")
+	}
+	assertPresenceCalls(t, f, types.PresenceUnavailable)
+}
+
 // TestSyncPresenceFailureWarnsAndContinues verifies that a failed presence
 // update is logged as a warning and does not abort the sync loop.
 func TestSyncPresenceFailureWarnsAndContinues(t *testing.T) {

--- a/internal/app/sync_presence_test.go
+++ b/internal/app/sync_presence_test.go
@@ -77,6 +77,56 @@ func TestSyncSendsAvailablePresenceOnPushNameSetting(t *testing.T) {
 	assertPresenceCalls(t, f, types.PresenceAvailable, types.PresenceAvailable, types.PresenceUnavailable)
 }
 
+// TestSyncQuietPresenceModeSkipsAvailablePresence verifies the personal-mirror
+// mode does not mark the linked device globally available while sync is live,
+// but still sends unavailable on cleanup as a safe final state.
+func TestSyncQuietPresenceModeSkipsAvailablePresence(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	captureStderr(t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := a.Sync(ctx, SyncOptions{
+			Mode:         SyncModeOnce,
+			AllowQR:      false,
+			IdleExit:     time.Millisecond,
+			WarnNoLimits: false,
+			PresenceMode: SyncPresenceModeQuiet,
+		})
+		if err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+	})
+
+	assertPresenceCalls(t, f, types.PresenceUnavailable)
+}
+
+func TestSyncQuietPresenceModeSkipsPushNameAvailablePresence(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+	f.connectEvents = []interface{}{&events.PushNameSetting{}}
+
+	captureStderr(t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := a.Sync(ctx, SyncOptions{
+			Mode:         SyncModeOnce,
+			AllowQR:      false,
+			IdleExit:     time.Millisecond,
+			WarnNoLimits: false,
+			PresenceMode: SyncPresenceModeQuiet,
+		})
+		if err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+	})
+
+	assertPresenceCalls(t, f, types.PresenceUnavailable)
+}
+
 // TestSyncPresenceFailureWarnsAndContinues verifies that a failed presence
 // update is logged as a warning and does not abort the sync loop.
 func TestSyncPresenceFailureWarnsAndContinues(t *testing.T) {

--- a/internal/app/sync_presence_test.go
+++ b/internal/app/sync_presence_test.go
@@ -40,7 +40,7 @@ func TestSyncSendsAvailablePresenceOnConnected(t *testing.T) {
 		t.Fatalf("missing connected line in stderr:\n%s", raw)
 	}
 
-	assertPresenceCalls(t, f, types.PresenceAvailable, types.PresenceUnavailable)
+	assertPresenceCalls(t, f, types.PresenceAvailable, types.PresenceAvailable, types.PresenceUnavailable)
 }
 
 // TestSyncSendsAvailablePresenceOnPushNameSetting ensures that once the
@@ -74,57 +74,46 @@ func TestSyncSendsAvailablePresenceOnPushNameSetting(t *testing.T) {
 		t.Fatalf("missing connected line in stderr:\n%s", raw)
 	}
 
-	assertPresenceCalls(t, f, types.PresenceAvailable, types.PresenceAvailable, types.PresenceUnavailable)
+	assertPresenceCalls(t, f, types.PresenceAvailable, types.PresenceAvailable, types.PresenceAvailable, types.PresenceUnavailable)
 }
 
 // TestSyncQuietPresenceModeSkipsAvailablePresence verifies the personal-mirror
 // mode does not mark the linked device globally available while sync is live,
-// but still sends unavailable on cleanup as a safe final state.
+// including the lower-level authenticated-connect path, but still sends
+// unavailable on cleanup as a safe final state.
 func TestSyncQuietPresenceModeSkipsAvailablePresence(t *testing.T) {
-	a := newTestApp(t)
-	f := newFakeWA()
-	a.wa = f
+	tests := []struct {
+		name          string
+		connectEvents []interface{}
+	}{
+		{name: "connected only"},
+		{name: "push name", connectEvents: []interface{}{&events.PushNameSetting{}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := newTestApp(t)
+			f := newFakeWA()
+			f.connectEvents = tt.connectEvents
+			a.wa = f
 
-	captureStderr(t, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		_, err := a.Sync(ctx, SyncOptions{
-			Mode:         SyncModeOnce,
-			AllowQR:      false,
-			IdleExit:     time.Millisecond,
-			WarnNoLimits: false,
-			PresenceMode: SyncPresenceModeQuiet,
+			captureStderr(t, func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+				_, err := a.Sync(ctx, SyncOptions{
+					Mode:         SyncModeOnce,
+					AllowQR:      false,
+					IdleExit:     time.Millisecond,
+					WarnNoLimits: false,
+					PresenceMode: SyncPresenceModeQuiet,
+				})
+				if err != nil {
+					t.Fatalf("Sync: %v", err)
+				}
+			})
+
+			assertPresenceCalls(t, f, types.PresenceUnavailable)
 		})
-		if err != nil {
-			t.Fatalf("Sync: %v", err)
-		}
-	})
-
-	assertPresenceCalls(t, f, types.PresenceUnavailable)
-}
-
-func TestSyncQuietPresenceModeSkipsPushNameAvailablePresence(t *testing.T) {
-	a := newTestApp(t)
-	f := newFakeWA()
-	a.wa = f
-	f.connectEvents = []interface{}{&events.PushNameSetting{}}
-
-	captureStderr(t, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		_, err := a.Sync(ctx, SyncOptions{
-			Mode:         SyncModeOnce,
-			AllowQR:      false,
-			IdleExit:     time.Millisecond,
-			WarnNoLimits: false,
-			PresenceMode: SyncPresenceModeQuiet,
-		})
-		if err != nil {
-			t.Fatalf("Sync: %v", err)
-		}
-	})
-
-	assertPresenceCalls(t, f, types.PresenceUnavailable)
+	}
 }
 
 // TestSyncPresenceFailureWarnsAndContinues verifies that a failed presence
@@ -151,7 +140,7 @@ func TestSyncPresenceFailureWarnsAndContinues(t *testing.T) {
 		}
 	})
 
-	waitForPresenceCalls(t, f, 2)
+	waitForPresenceCalls(t, f, 3)
 
 	if !strings.Contains(raw, "send_presence_failed") {
 		t.Fatalf("missing send_presence_failed warning event in stderr:\n%s", raw)
@@ -183,7 +172,7 @@ func TestSyncSendsAvailablePresenceOnConnectedIsSynchronous(t *testing.T) {
 		}
 	})
 
-	waitForPresenceCalls(t, f, 2)
+	waitForPresenceCalls(t, f, 3)
 }
 
 func assertPresenceCalls(t *testing.T, f *fakeWA, want ...types.Presence) {
@@ -248,8 +237,8 @@ func TestSyncSendsUnavailableOnErrorExit(t *testing.T) {
 		}
 	})
 
-	// The Connected event fires during Connect (before AfterConnect fails),
-	// so available is sent first. The defer then sends unavailable on the
-	// error exit — proving cleanup runs on all post-connect exits.
-	assertPresenceCalls(t, f, types.PresenceAvailable, types.PresenceUnavailable)
+	// The initial authenticated-connect presence and Connected event both send
+	// available in normal mode. The defer then sends unavailable on the error
+	// exit, proving cleanup runs on all post-connect exits.
+	assertPresenceCalls(t, f, types.PresenceAvailable, types.PresenceAvailable, types.PresenceUnavailable)
 }

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -1897,7 +1897,7 @@ func TestSyncFollowIgnoresKeepAliveTimeoutFromPreviousConnection(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
-	_, err := a.runSyncFollow(ctx, time.Second, &messagesStored, &connectionEpoch, disconnected, staleReconnect)
+	_, err := a.runSyncFollow(ctx, time.Second, SyncPresenceModeNormal, &messagesStored, &connectionEpoch, disconnected, staleReconnect)
 	if err != nil {
 		t.Fatalf("runSyncFollow: %v", err)
 	}

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -110,6 +110,10 @@ type ConnectOptions struct {
 	OnQRCode        func(code string)
 	PairPhoneNumber string
 	OnPairCode      func(code string)
+	// SuppressInitialAvailablePresence skips the post-connect available
+	// presence update for callers that need a quiet linked-device session.
+	// The default false preserves normal WhatsApp linked-device behavior.
+	SuppressInitialAvailablePresence bool
 	// DetachSocket, when true, connects the websocket with a detached
 	// context so it is not closed when the caller's context is cancelled.
 	// This allows graceful shutdown to send a final PresenceUnavailable
@@ -186,6 +190,9 @@ func (c *Client) Connect(ctx context.Context, opts ConnectOptions) error {
 	}
 
 	if authed {
+		if opts.SuppressInitialAvailablePresence {
+			return nil
+		}
 		sendInitialAvailablePresence(ctx, cli)
 		return nil
 	}

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -975,13 +975,15 @@ func (c *Client) GetBusinessProfile(ctx context.Context, jid types.JID) (*types.
 }
 
 // Reconnect loop helper.
-func (c *Client) ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay time.Duration) error {
+func (c *Client) ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay time.Duration, opts ConnectOptions) error {
+	opts.AllowQR = false
+	opts.DetachSocket = true
 	delay := minDelay
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		if err := c.Connect(ctx, ConnectOptions{AllowQR: false, DetachSocket: true}); err == nil {
+		if err := c.Connect(ctx, opts); err == nil {
 			return nil
 		}
 		select {


### PR DESCRIPTION
## Summary

- Add `wacli sync --presence-mode normal|quiet`, defaulting to `normal`.
- Preserve current sync presence behaviour by default.
- In `quiet` mode, suppress available presence on authenticated connect, connect events, push-name updates, and reconnect/backoff paths while still sending unavailable presence on cleanup.
- Document the personal mirror use case and add initial-connect and reconnect regression tests.

## Why

Long-running `sync --follow` sessions can keep the linked device globally available. For personal-number mirror deployments, that can interfere with primary phone notification behaviour. Quiet mode gives operators an explicit opt-in that avoids available-presence updates without weakening the existing cleanup safety.

## Testing

- Focused reconnect regression: `go test ./internal/app ./internal/wa ./cmd/wacli -run 'TestSyncQuietPresenceModeSkipsAvailablePresenceAfterReconnect|TestSyncQuietPresenceModeSkipsAvailablePresence|TestSyncFollowReconnectsAfterStreamReplaced|TestSyncCommandRejectsInvalidPresenceMode' -count=1`
- Full gate: `pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check` in an unprivileged copy.
- Rebased onto current `upstream/main` before running the gate.

### Redacted live behaviour proof

At PR head `70c028d`, I built a temporary diagnostic copy with stderr-only tracing around the existing connect options and `SendPresence` call. The tracing only printed presence decisions and was not included in the PR diff. I then ran a one-shot quiet sync against an authenticated personal mirror store:

```text
$ ./wacli-proof --store REDACTED --events sync --once --idle-exit 5s \
    --max-reconnect 30s --presence-mode quiet \
    --max-messages 50000 --max-db-size 1GB
proof: connect authenticated=true suppress_initial_available=true detach_socket=true
{"event":"connected","ts":1783663275593}
{"event":"idle_exit","data":{"idle_duration":"5s","messages_synced":0},"ts":1783663281180}
proof: send_presence=unavailable
Messages stored: 0

$ d4j-whatsapp --store REDACTED --read-only doctor --json
{"lock_held":false,"authenticated":true,"connected":false,"connection_state":"disconnected"}
```

The live quiet run produced no `send_presence=available` call and did produce the final `send_presence=unavailable` cleanup. The focused reconnect test forces `StreamReplaced`, waits for the second authenticated connect, and verifies that the complete quiet session still records only the final unavailable presence.

The full gate is run unprivileged because `internal/fsutil` intentionally tests owner-only permission behaviour that root bypasses.

Closes #297
