### PR TITLE
fix: open SQLite stores on Windows

### DIFF
--- a/cmd/wacli/auth_status_readonly.go
+++ b/cmd/wacli/auth_status_readonly.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/openclaw/wacli/internal/sqliteutil"
 	"go.mau.fi/whatsmeow/types"
 )
 
@@ -53,7 +54,7 @@ func readOnlySessionSQLiteURI(path string) string {
 	if !sqliteSessionSidecarsExist(path) {
 		params += "&immutable=1"
 	}
-	return fmt.Sprintf("file:%s?%s", path, params)
+	return sqliteutil.FileURI(path, params)
 }
 
 func sqliteSessionSidecarsExist(path string) bool {

--- a/cmd/wacli/auth_test.go
+++ b/cmd/wacli/auth_test.go
@@ -134,6 +134,16 @@ func TestReadOnlyAuthStatusReadsLiveWALSidecars(t *testing.T) {
 	}
 }
 
+func TestReadOnlySessionSQLiteURIWindowsPath(t *testing.T) {
+	uri := readOnlySessionSQLiteURI(`C:\Users\me\.wacli\session.db`)
+	if !strings.HasPrefix(uri, "file:///C:/Users/me/.wacli/session.db?") {
+		t.Fatalf("readOnlySessionSQLiteURI = %q, want absolute Windows file URI", uri)
+	}
+	if !strings.Contains(uri, "mode=ro") {
+		t.Fatalf("readOnlySessionSQLiteURI = %q, want read-only query parameter", uri)
+	}
+}
+
 func TestReadOnlySessionSQLiteURIUsesLockingForLiveState(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.db")
 	if err := os.WriteFile(path, []byte(""), 0o600); err != nil {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -149,6 +149,16 @@ func TestReadOnlySessionURIEscapesPathDelimiters(t *testing.T) {
 	}
 }
 
+func TestReadOnlySessionURIWindowsPath(t *testing.T) {
+	uri := readOnlySessionURI(`C:\Users\me\.wacli\session.db`)
+	if !strings.HasPrefix(uri, "file:///C:/Users/me/.wacli/session.db?") {
+		t.Fatalf("readOnlySessionURI = %q, want absolute Windows file URI", uri)
+	}
+	if !strings.Contains(uri, "mode=ro") {
+		t.Fatalf("readOnlySessionURI = %q, want read-only query parameter", uri)
+	}
+}
+
 func TestReadOnlyLocalResolverUsesExactPercentEscapedStorePath(t *testing.T) {
 	storeDir := filepath.Join(t.TempDir(), "store%3fprod%23one")
 	writer, err := New(Options{StoreDir: storeDir})

--- a/internal/app/session_resolver.go
+++ b/internal/app/session_resolver.go
@@ -5,11 +5,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"strings"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/openclaw/wacli/internal/sqliteutil"
 	"github.com/openclaw/wacli/internal/wa"
 	"go.mau.fi/whatsmeow/types"
 )
@@ -45,7 +45,7 @@ func readOnlySessionURI(path string) string {
 	if !sessionSQLiteSidecarsExist(path) {
 		params += "&immutable=1"
 	}
-	return (&url.URL{Scheme: "file", Path: path, RawQuery: params}).String()
+	return sqliteutil.FileURI(path, params)
 }
 
 func sessionSQLiteSidecarsExist(path string) bool {

--- a/internal/sqliteutil/files.go
+++ b/internal/sqliteutil/files.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // ChmodFiles applies mode to a SQLite database and existing WAL/SHM sidecars.
@@ -19,5 +20,19 @@ func ChmodFiles(path string, mode os.FileMode) error {
 }
 
 func FileURI(path, rawQuery string) string {
-	return (&url.URL{Scheme: "file", Path: path, RawQuery: rawQuery}).String()
+	return (&url.URL{Scheme: "file", Path: sqliteFileURLPath(path), RawQuery: rawQuery}).String()
+}
+
+func sqliteFileURLPath(path string) string {
+	if len(path) >= 3 && isASCIIAlpha(path[0]) && path[1] == ':' && (path[2] == '\\' || path[2] == '/') {
+		return "/" + strings.ReplaceAll(path, `\`, "/")
+	}
+	if strings.HasPrefix(path, `\\`) {
+		return strings.ReplaceAll(path, `\`, "/")
+	}
+	return path
+}
+
+func isASCIIAlpha(value byte) bool {
+	return value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z'
 }

--- a/internal/sqliteutil/files_test.go
+++ b/internal/sqliteutil/files_test.go
@@ -51,6 +51,32 @@ func TestFileURIEscapesPathDelimiters(t *testing.T) {
 	}
 }
 
+func TestFileURIWindowsPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "drive letter",
+			path: `C:\Users\me\My Store\wacli.db`,
+			want: "file:///C:/Users/me/My%20Store/wacli.db?_foreign_keys=on",
+		},
+		{
+			name: "UNC share",
+			path: `\\server\share\My Store\wacli.db`,
+			want: "file:////server/share/My%20Store/wacli.db?_foreign_keys=on",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FileURI(tt.path, "_foreign_keys=on"); got != tt.want {
+				t.Fatalf("FileURI(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func writeTestFileMode(path string, data []byte, perm os.FileMode) error {
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Normalize absolute Windows drive paths into valid SQLite file URIs instead of URI authorities.
- Preserve UNC paths with an empty URI authority and route writable, read-only session, and auth-status database openers through the same helper.
- Add regressions for drive-letter, UNC, and both read-only call paths while preserving Unix path escaping and query behavior.

Disclosure: AI was used to understand the codebase and review the fix.

## Why

On Windows, `wacli auth` could serialize `C:\Users\...` as `file://C:%5CUsers...`. SQLite interprets `C:` as a URI authority and rejects the database before QR pairing with `invalid uri authority`. A shared constructor prevents the writable and read-only database paths from diverging.

Closes #303

Thanks @LeoDupont for the report and suggested affected call sites.

## Validation

Before the fix, the focused regression produced:

```text
FileURI("C:\\Users\\me\\My Store\\wacli.db") = "file://C:%5CUsers%5Cme%5CMy%20Store%5Cwacli.db?_foreign_keys=on"
```

After the fix, drive-letter and UNC inputs serialize as:

```text
file:///C:/Users/me/My%20Store/wacli.db?_foreign_keys=on
file:////server/share/My%20Store/wacli.db?_foreign_keys=on
```

Passed:

- `go test ./internal/sqliteutil ./internal/app ./cmd/wacli -count=1`
- `go test -tags sqlite_fts5 ./internal/sqliteutil ./internal/app ./cmd/wacli -count=1`
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `go fmt ./...`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/sqliteutil -o "$TMPDIR/sqliteutil.test.exe"`
- `git diff --check`

A live `wacli auth` run on Windows was not performed because an authenticated Windows environment was not available. The source-level regression runs on every host, and the helper package was also cross-compiled for Windows amd64.

No flags, environment variables, configuration, schema, or dependency behavior changed.
