### PR TITLE
fix: restore stored media quote replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.13.1 - Unreleased
 
+### Fixed
+
+- Send: allow text replies to quote stored documents and other supported media by rebuilding their saved message content. (#307 - thanks @suifatt7799-oss)
+
 ## 0.13.0 - 2026-07-17
 
 ### Highlights

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -976,7 +976,7 @@ func validateMessageCanForward(msg store.Message) error {
 		return fmt.Errorf("reaction messages cannot be forwarded")
 	}
 	mediaType := strings.ToLower(strings.TrimSpace(msg.MediaType))
-	if mediaType != "" && !isForwardableMediaType(mediaType) {
+	if mediaType != "" && !isStoredMediaType(mediaType) {
 		return fmt.Errorf("%s messages cannot be forwarded", mediaType)
 	}
 	if mediaType == "" && strings.TrimSpace(messageForwardText(msg)) == "" {
@@ -1024,7 +1024,7 @@ func buildForwardedMessage(msg store.Message, mediaInfo *store.MediaDownloadInfo
 	if mediaInfo == nil {
 		return forwardedMessagePayload{}, fmt.Errorf("message has no media metadata")
 	}
-	if err := validateForwardMediaInfo(*mediaInfo); err != nil {
+	if err := validateStoredMediaInfo(*mediaInfo); err != nil {
 		return forwardedMessagePayload{}, err
 	}
 
@@ -1042,32 +1042,44 @@ func buildForwardedMessage(msg store.Message, mediaInfo *store.MediaDownloadInfo
 		ForwardingScore: forwardingScore,
 	}
 	ctx := forwardedContextInfo(forwardingScore)
+	message, err := buildStoredMediaMessage(mediaType, msg.MediaCaption, *mediaInfo, ctx)
+	if err != nil {
+		return forwardedMessagePayload{}, err
+	}
+	payload.Message = message
+	if mediaType == "document" && strings.TrimSpace(payload.Filename) == "" {
+		payload.Filename = "document"
+	}
+	return payload, nil
+}
+
+func buildStoredMediaMessage(mediaType, caption string, mediaInfo store.MediaDownloadInfo, ctx *waProto.ContextInfo) (*waProto.Message, error) {
 	switch mediaType {
 	case "image":
-		payload.Message = &waProto.Message{ImageMessage: &waProto.ImageMessage{
+		return &waProto.Message{ImageMessage: &waProto.ImageMessage{
 			DirectPath:    proto.String(mediaInfo.DirectPath),
 			MediaKey:      mediaInfo.MediaKey,
 			FileSHA256:    mediaInfo.FileSHA256,
 			FileEncSHA256: mediaInfo.FileEncSHA256,
 			FileLength:    proto.Uint64(mediaInfo.FileLength),
 			Mimetype:      proto.String(mediaInfo.MimeType),
-			Caption:       proto.String(msg.MediaCaption),
+			Caption:       proto.String(caption),
 			ContextInfo:   ctx,
-		}}
+		}}, nil
 	case "video", "gif":
-		payload.Message = &waProto.Message{VideoMessage: &waProto.VideoMessage{
+		return &waProto.Message{VideoMessage: &waProto.VideoMessage{
 			DirectPath:    proto.String(mediaInfo.DirectPath),
 			MediaKey:      mediaInfo.MediaKey,
 			FileSHA256:    mediaInfo.FileSHA256,
 			FileEncSHA256: mediaInfo.FileEncSHA256,
 			FileLength:    proto.Uint64(mediaInfo.FileLength),
 			Mimetype:      proto.String(mediaInfo.MimeType),
-			Caption:       proto.String(msg.MediaCaption),
+			Caption:       proto.String(caption),
 			GifPlayback:   proto.Bool(mediaType == "gif"),
 			ContextInfo:   ctx,
-		}}
+		}}, nil
 	case "audio":
-		payload.Message = &waProto.Message{AudioMessage: &waProto.AudioMessage{
+		return &waProto.Message{AudioMessage: &waProto.AudioMessage{
 			DirectPath:    proto.String(mediaInfo.DirectPath),
 			MediaKey:      mediaInfo.MediaKey,
 			FileSHA256:    mediaInfo.FileSHA256,
@@ -1075,14 +1087,13 @@ func buildForwardedMessage(msg store.Message, mediaInfo *store.MediaDownloadInfo
 			FileLength:    proto.Uint64(mediaInfo.FileLength),
 			Mimetype:      proto.String(mediaInfo.MimeType),
 			ContextInfo:   ctx,
-		}}
+		}}, nil
 	case "document":
 		name := strings.TrimSpace(mediaInfo.Filename)
 		if name == "" {
 			name = "document"
 		}
-		payload.Filename = name
-		payload.Message = &waProto.Message{DocumentMessage: &waProto.DocumentMessage{
+		return &waProto.Message{DocumentMessage: &waProto.DocumentMessage{
 			DirectPath:    proto.String(mediaInfo.DirectPath),
 			MediaKey:      mediaInfo.MediaKey,
 			FileSHA256:    mediaInfo.FileSHA256,
@@ -1091,11 +1102,11 @@ func buildForwardedMessage(msg store.Message, mediaInfo *store.MediaDownloadInfo
 			Mimetype:      proto.String(mediaInfo.MimeType),
 			FileName:      proto.String(name),
 			Title:         proto.String(name),
-			Caption:       proto.String(msg.MediaCaption),
+			Caption:       proto.String(caption),
 			ContextInfo:   ctx,
-		}}
+		}}, nil
 	case "sticker":
-		payload.Message = &waProto.Message{StickerMessage: &waProto.StickerMessage{
+		return &waProto.Message{StickerMessage: &waProto.StickerMessage{
 			DirectPath:    proto.String(mediaInfo.DirectPath),
 			MediaKey:      mediaInfo.MediaKey,
 			FileSHA256:    mediaInfo.FileSHA256,
@@ -1103,14 +1114,13 @@ func buildForwardedMessage(msg store.Message, mediaInfo *store.MediaDownloadInfo
 			FileLength:    proto.Uint64(mediaInfo.FileLength),
 			Mimetype:      proto.String(mediaInfo.MimeType),
 			ContextInfo:   ctx,
-		}}
+		}}, nil
 	default:
-		return forwardedMessagePayload{}, fmt.Errorf("%s messages cannot be forwarded", mediaType)
+		return nil, fmt.Errorf("unsupported stored media type %q", mediaType)
 	}
-	return payload, nil
 }
 
-func isForwardableMediaType(mediaType string) bool {
+func isStoredMediaType(mediaType string) bool {
 	switch strings.ToLower(strings.TrimSpace(mediaType)) {
 	case "image", "video", "gif", "audio", "document", "sticker":
 		return true
@@ -1119,7 +1129,7 @@ func isForwardableMediaType(mediaType string) bool {
 	}
 }
 
-func validateForwardMediaInfo(info store.MediaDownloadInfo) error {
+func validateStoredMediaInfo(info store.MediaDownloadInfo) error {
 	if strings.TrimSpace(info.DirectPath) == "" || len(info.MediaKey) == 0 || len(info.FileSHA256) == 0 || len(info.FileEncSHA256) == 0 || info.FileLength == 0 {
 		return fmt.Errorf("message has incomplete media metadata (run `wacli sync` first)")
 	}

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -499,7 +499,7 @@ func buildTextReplyContextInfo(db *store.DB, chat types.JID, replyTo, replyToSen
 	if err != nil {
 		return nil, fmt.Errorf("lookup quoted message: %w", err)
 	}
-	quotedMessage, err := storedTextQuotedMessage(quoted)
+	quotedMessage, err := storedQuotedMessage(db, quoted)
 	if err != nil {
 		return nil, fmt.Errorf("cannot quote message %s: %w", replyTo, err)
 	}
@@ -515,12 +515,25 @@ func buildTextReplyContextInfo(db *store.DB, chat types.JID, replyTo, replyToSen
 	}, nil
 }
 
-func storedTextQuotedMessage(msg store.Message) (*waProto.Message, error) {
+func storedQuotedMessage(db *store.DB, msg store.Message) (*waProto.Message, error) {
 	if msg.Revoked || msg.DeletedForMe {
 		return nil, fmt.Errorf("stored message was deleted")
 	}
-	if strings.TrimSpace(msg.MediaType) != "" || msg.ReactionToID != "" || len(msg.Buttons) > 0 {
+	if msg.ReactionToID != "" || len(msg.Buttons) > 0 {
 		return nil, fmt.Errorf("stored message content is not supported for quoted text replies")
+	}
+	if mediaType := strings.ToLower(strings.TrimSpace(msg.MediaType)); mediaType != "" {
+		if !isStoredMediaType(mediaType) {
+			return nil, fmt.Errorf("unsupported stored media type %q", mediaType)
+		}
+		mediaInfo, err := db.GetMediaDownloadInfo(msg.ChatJID, msg.MsgID)
+		if err != nil {
+			return nil, fmt.Errorf("load stored media metadata: %w", err)
+		}
+		if err := validateStoredMediaInfo(mediaInfo); err != nil {
+			return nil, err
+		}
+		return buildStoredMediaMessage(mediaType, msg.MediaCaption, mediaInfo, nil)
 	}
 	if strings.TrimSpace(msg.Text) == "" {
 		return nil, fmt.Errorf("stored message has no supported text content")

--- a/cmd/wacli/send_test.go
+++ b/cmd/wacli/send_test.go
@@ -390,7 +390,7 @@ func TestSendTextMessageRejectsUnconstructableQuotesBeforeSending(t *testing.T) 
 			wantError: "not found in local store",
 		},
 		{
-			name: "unsupported content",
+			name: "unsupported media type",
 			seed: func(t *testing.T, db *store.DB, chat types.JID) {
 				t.Helper()
 				if err := db.UpsertMessage(store.UpsertMessageParams{
@@ -398,12 +398,30 @@ func TestSendTextMessageRejectsUnconstructableQuotesBeforeSending(t *testing.T) 
 					MsgID:     "quoted",
 					SenderJID: chat.String(),
 					Timestamp: time.Now(),
-					MediaType: "image",
+					MediaType: "location",
 				}); err != nil {
 					t.Fatalf("UpsertMessage: %v", err)
 				}
 			},
-			wantError: "content is not supported",
+			wantError: "unsupported stored media type",
+		},
+		{
+			name: "incomplete document metadata",
+			seed: func(t *testing.T, db *store.DB, chat types.JID) {
+				t.Helper()
+				if err := db.UpsertMessage(store.UpsertMessageParams{
+					ChatJID:   chat.String(),
+					MsgID:     "quoted",
+					SenderJID: chat.String(),
+					Timestamp: time.Now(),
+					MediaType: "document",
+					Filename:  "incomplete.pdf",
+					MimeType:  "application/pdf",
+				}); err != nil {
+					t.Fatalf("UpsertMessage: %v", err)
+				}
+			},
+			wantError: "incomplete media metadata",
 		},
 	}
 
@@ -427,6 +445,60 @@ func TestSendTextMessageRejectsUnconstructableQuotesBeforeSending(t *testing.T) 
 				t.Fatalf("calls: SendText=%d SendProtoMessage=%d, want 0/0", sender.textCalls, sender.protoCalls)
 			}
 		})
+	}
+}
+
+func TestSendTextMessageQuotesStoredDocument(t *testing.T) {
+	db := openSendTestDB(t)
+	chat := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+	if err := db.UpsertChat(chat.String(), "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := db.UpsertMessage(store.UpsertMessageParams{
+		ChatJID:       chat.String(),
+		MsgID:         "quoted-document",
+		Timestamp:     time.Now(),
+		FromMe:        true,
+		MediaType:     "document",
+		MediaCaption:  "test document",
+		Filename:      "test.pdf",
+		MimeType:      "application/pdf",
+		DirectPath:    "/v/t62/test-document",
+		MediaKey:      []byte("media-key"),
+		FileSHA256:    []byte("plain-hash"),
+		FileEncSHA256: []byte("encrypted-hash"),
+		FileLength:    1234,
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+	sender := &recordingTextSender{linkedJID: "15550000000@s.whatsapp.net"}
+
+	_, err := sendTextMessageWithSender(context.Background(), sender, db, chat, "reply", "quoted-document", "15550000000@s.whatsapp.net", nil, nil, textEphemeralOptions{})
+	if err != nil {
+		t.Fatalf("sendTextMessageWithSender: %v", err)
+	}
+	info := requireExtendedText(t, sender.protoMsg).GetContextInfo()
+	if info.GetStanzaID() != "quoted-document" {
+		t.Fatalf("stanza ID = %q, want quoted-document", info.GetStanzaID())
+	}
+	if info.GetParticipant() != "15550000000@s.whatsapp.net" {
+		t.Fatalf("participant = %q", info.GetParticipant())
+	}
+	doc := info.GetQuotedMessage().GetDocumentMessage()
+	if doc == nil {
+		t.Fatal("quoted document message is nil")
+	}
+	if doc.GetFileName() != "test.pdf" || doc.GetTitle() != "test.pdf" || doc.GetMimetype() != "application/pdf" {
+		t.Fatalf("quoted document identity: filename=%q title=%q mime=%q", doc.GetFileName(), doc.GetTitle(), doc.GetMimetype())
+	}
+	if doc.GetCaption() != "test document" || doc.GetDirectPath() != "/v/t62/test-document" || doc.GetFileLength() != 1234 {
+		t.Fatalf("quoted document metadata: caption=%q direct_path=%q length=%d", doc.GetCaption(), doc.GetDirectPath(), doc.GetFileLength())
+	}
+	if string(doc.GetMediaKey()) != "media-key" || string(doc.GetFileSHA256()) != "plain-hash" || string(doc.GetFileEncSHA256()) != "encrypted-hash" {
+		t.Fatal("quoted document media hashes or key were not preserved")
+	}
+	if sender.textCalls != 0 || sender.protoCalls != 1 {
+		t.Fatalf("calls: SendText=%d SendProtoMessage=%d, want 0/1", sender.textCalls, sender.protoCalls)
 	}
 }
 

--- a/docs/send.md
+++ b/docs/send.md
@@ -38,7 +38,8 @@ wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 - `--ephemeral` sends text with `ContextInfo.Expiration`, matching the disappearing-send path. For groups, wacli uses the live group timer when available; otherwise it falls back to a 7-day default. Set `--ephemeral-duration` to choose an explicit expiration.
 - `--message` is literal by default. Pass `--message-escapes` to interpret `\n`, `\r`, `\t`, `\\`, and `\"` before sending.
 - Use repeatable `--mention USER` with a phone number or user JID to add WhatsApp mentions to `send text`.
-- `--reply-to` quotes a stored message ID.
+- `send text --reply-to` reconstructs the stored text or supported media quote content (image, video/GIF, audio, document, or sticker); stored media must have complete sync metadata.
+- Other send commands use `--reply-to` to quote a stored message ID.
 - For unsynced group replies, pass `--reply-to-sender`.
 - `send react` defaults to thumbs-up.
 - Pass `--reaction ""` to clear a reaction.


### PR DESCRIPTION
## Summary

- rebuild stored media payloads when `send text --reply-to` targets a document or another supported media message
- share that reconstruction with the existing message-forwarding path so quoted and forwarded media cannot drift
- keep unknown media types and incomplete stored metadata as pre-send errors
- document the behavior and credit @suifatt7799-oss in the changelog

## Root cause

The quoted-text repair in #302 correctly began requiring a complete `QuotedMessage`, but its stored-message guard rejected every row with a non-empty media type. The local store already retains the direct path, media key, hashes, length, MIME type, filename, and caption needed to reconstruct supported media messages, so rejecting a stored PDF was unnecessary.

## Validation

- `go test ./cmd/wacli -run 'TestSendTextMessage(RejectsUnconstructableQuotesBeforeSending|QuotesStoredDocument)|TestBuildForwardedMediaMessage'`
- `go test -tags sqlite_fts5 ./cmd/wacli -run 'TestSendTextMessage(RejectsUnconstructableQuotesBeforeSending|QuotesStoredDocument)|TestBuildForwardedMediaMessage'`
- `pnpm -s format:check && pnpm -s lint && pnpm -s test && pnpm -s build && git diff --check`
- `go test -race ./cmd/wacli`
- clean exact-head binary: revision `9a0531169d35aab0ba0f809296340aa710934cd3`, `vcs.modified=false`, SHA-256 `b1cf8f72f02ad2be9ce1e7131ff6ab24d109bab54ba1fc811c3d862841b9abea`
- AutoReview: clean, no accepted or actionable findings
- source-blind binary smoke: version, send-text help, read-only account listing, and FTS-enabled doctor output passed

Live WhatsApp delivery remains pending because this machine has no authenticated test store or controlled recipient. The issue reporter has offered to exercise a candidate patch against the live reproduction.

Fixes #307
