### PR TITLE
fix(store): retain deleted message payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 0.13.1 - Unreleased
 
+### Added
+
+- Messages: add an explicit, confirmation-gated `messages purge` command that irreversibly erases one retained payload while keeping a durable suppression tombstone.
+
+### Changed
+
+- Messages: retain original text, interactive, reply, and media metadata behind timestamped deletion tombstones; keep sync/history imports merge-only so missing rows never imply deletion.
+
 ### Fixed
 
 - Send: allow text replies to quote stored documents and other supported media by rebuilding their saved message content. (#307 - thanks @suifatt7799-oss)

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -30,6 +30,7 @@ func newMessagesCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newMessagesContextCmd(flags))
 	cmd.AddCommand(newMessagesExportCmd(flags))
 	cmd.AddCommand(newMessagesDeleteCmd(flags))
+	cmd.AddCommand(newMessagesPurgeCmd(flags))
 	cmd.AddCommand(newMessagesRevokeCmd(flags))
 	cmd.AddCommand(newMessagesEditCmd(flags))
 	cmd.AddCommand(newMessagesForwardCmd(flags))
@@ -536,6 +537,11 @@ func newMessagesDeleteCmd(flags *rootFlags) *cobra.Command {
 						return fmt.Errorf("store deleted-for-me message state: %w", err)
 					}
 					return fmt.Errorf("delete local media: %w", deleteMediaErr)
+				}
+				if deleteMedia && strings.TrimSpace(msg.LocalPath) != "" {
+					if err := a.DB().ClearMessageLocalMedia(msg.ChatJID, msg.MsgID); err != nil {
+						return fmt.Errorf("clear deleted local media state: %w", err)
+					}
 				}
 				if err := a.DB().MarkMessageDeletedForMe(msg.ChatJID, msg.MsgID, msg.SenderJID, msg.FromMe, time.Now().UTC()); err != nil {
 					return fmt.Errorf("store deleted-for-me message state: %w", err)

--- a/cmd/wacli/messages_format.go
+++ b/cmd/wacli/messages_format.go
@@ -121,6 +121,15 @@ func writeMessageShow(dst io.Writer, m store.Message) error {
 	if m.DeletedForMe {
 		fmt.Fprintln(dst, "Deleted for me: yes")
 	}
+	if m.DeletedAt != nil {
+		fmt.Fprintf(dst, "Deleted at: %s\n", m.DeletedAt.Local().Format(time.RFC3339))
+	}
+	if m.DeletionReason != "" {
+		fmt.Fprintf(dst, "Deletion reason: %s\n", sanitize(m.DeletionReason))
+	}
+	if m.PayloadPurgedAt != nil {
+		fmt.Fprintf(dst, "Payload purged at: %s\n", m.PayloadPurgedAt.Local().Format(time.RFC3339))
+	}
 	fmt.Fprintf(dst, "\n%s\n", sanitizeBody(messageText(m)))
 	if raw := messageRawText(m); raw != "" {
 		fmt.Fprintf(dst, "\nRaw text:\n%s\n", sanitizeBody(raw))

--- a/cmd/wacli/messages_purge.go
+++ b/cmd/wacli/messages_purge.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/openclaw/wacli/internal/out"
+	"github.com/openclaw/wacli/internal/store"
+	"github.com/spf13/cobra"
+)
+
+func newMessagesPurgeCmd(flags *rootFlags) *cobra.Command {
+	var chat string
+	var id string
+	var dryRun bool
+	var confirm bool
+	cmd := &cobra.Command{
+		Use:   "purge",
+		Short: "Permanently remove one tombstoned message payload",
+		Long: `Permanently erase the retained payload of one tombstoned message.
+
+This only purges the retained local wacli payload. It does not delete anything
+from WhatsApp. A minimal suppression tombstone remains so later imports cannot
+restore the payload. Live messages must first receive an explicit deletion event.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			chat = strings.TrimSpace(chat)
+			id = strings.TrimSpace(id)
+			if chat == "" || id == "" {
+				return fmt.Errorf("--chat and --id are required")
+			}
+			if err := flags.requireWritable(); err != nil {
+				return err
+			}
+			ctx, cancel := withTimeout(context.Background(), flags)
+			defer cancel()
+			a, lk, err := newApp(ctx, flags, true, false)
+			if err != nil {
+				return err
+			}
+			defer closeApp(a, lk)
+
+			msg, err := a.DB().GetMessage(chat, id)
+			if err != nil {
+				return err
+			}
+			if msg.DeletedAt == nil {
+				return store.ErrMessageNotTombstoned
+			}
+			if dryRun {
+				if flags.asJSON {
+					return out.WriteJSON(os.Stdout, map[string]any{"would_purge": 1, "message": msg})
+				}
+				fmt.Fprintf(os.Stderr, "Would permanently purge tombstoned message %s in %s.\n", sanitize(id), sanitize(chat))
+				return nil
+			}
+			if !confirm {
+				fmt.Fprintf(os.Stderr, "Permanently purge retained payload for message %s in %s? This cannot be undone. [y/N] ", sanitize(id), sanitize(chat))
+				answer, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+				answer = strings.TrimSpace(strings.ToLower(answer))
+				if answer != "y" && answer != "yes" {
+					fmt.Fprintln(os.Stderr, "Aborted.")
+					return nil
+				}
+			}
+			if _, err := deleteLocalMediaIfRequested(true, msg.LocalPath); err != nil {
+				return fmt.Errorf("delete retained local media: %w", err)
+			}
+			if err := a.DB().PurgeMessage(chat, id); err != nil {
+				if errors.Is(err, store.ErrMessageNotTombstoned) {
+					return store.ErrMessageNotTombstoned
+				}
+				return err
+			}
+			if flags.asJSON {
+				return out.WriteJSON(os.Stdout, map[string]any{"purged": 1, "chat": chat, "id": id})
+			}
+			fmt.Fprintf(os.Stderr, "Purged message %s in %s.\n", sanitize(id), sanitize(chat))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&chat, "chat", "", "chat JID")
+	cmd.Flags().StringVar(&id, "id", "", "tombstoned message ID")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show the retained payload without purging it")
+	cmd.Flags().BoolVar(&confirm, "confirm", false, "skip confirmation prompt")
+	return cmd
+}

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -39,7 +39,7 @@ Open the database in SQLite read-only mode:
 sqlite3 "file:$HOME/.wacli/wacli.db?mode=ro" \
   "SELECT chat_jid, msg_id, datetime(ts, 'unixepoch') AS at, display_text
    FROM messages
-   WHERE revoked = 0 AND deleted_for_me = 0
+   WHERE deleted_at IS NULL
    ORDER BY ts DESC
    LIMIT 20"
 ```
@@ -57,7 +57,7 @@ conn.row_factory = sqlite3.Row
 rows = conn.execute("""
     SELECT chat_jid, msg_id, sender_jid, sender_name, ts, display_text
     FROM messages
-    WHERE revoked = 0 AND deleted_for_me = 0
+    WHERE deleted_at IS NULL
     ORDER BY ts DESC
     LIMIT ?
 """, (50,)).fetchall()
@@ -80,8 +80,7 @@ SELECT
   COALESCE(m.display_text, m.text, '') AS text
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
-WHERE m.revoked = 0
-  AND m.deleted_for_me = 0
+WHERE m.deleted_at IS NULL
 ORDER BY m.ts DESC
 LIMIT 100;
 ```
@@ -91,10 +90,23 @@ Incremental scan cursor:
 ```sql
 SELECT rowid, chat_jid, msg_id, sender_jid, ts, display_text
 FROM messages
-WHERE rowid > ?
+WHERE rowid > ? AND deleted_at IS NULL
 ORDER BY rowid ASC
 LIMIT 1000;
 ```
+
+The `rowid` cursor discovers inserts only. Deletion is an in-place update, so this cursor must not be used as a deletion feed. A companion that retains payloads must periodically reconcile the complete tombstone and purge-key sets by `(chat_jid, msg_id)`:
+
+```sql
+SELECT chat_jid, msg_id, deleted_at, deletion_reason, payload_purged_at
+FROM messages
+WHERE deleted_at IS NOT NULL;
+
+SELECT chat_jid, msg_id, purged_at, deleted_at, deletion_reason
+FROM message_payload_purges;
+```
+
+The purge ledger intentionally survives chat cleanup cascades. Missing rows in any scan are never evidence of deletion.
 
 Recent WhatsApp call events:
 

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -16,6 +16,7 @@ wacli messages show --chat JID --id MSG_ID
 wacli messages context --chat JID --id MSG_ID [--before N] [--after N]
 wacli messages edit --chat JID --id MSG_ID --message TEXT [--post-send-wait 2s]
 wacli messages delete --chat JID --id MSG_ID [--for-me] [--delete-media] [--post-send-wait 2s]
+wacli messages purge --chat JID --id MSG_ID [--dry-run] [--confirm]
 wacli messages revoke --chat JID --id MSG_ID [--post-send-wait 2s]
 wacli messages forward --chat JID --id MSG_ID --to RECIPIENT [--pick N] [--post-send-wait 2s]
 ```
@@ -49,7 +50,9 @@ wacli messages forward --chat JID --id MSG_ID --to RECIPIENT [--pick N] [--post-
 - `messages delete --for-me` removes a stored message only for your WhatsApp account using WhatsApp's `deleteMessageForMe` app-state patch; it can target messages sent by you or by others. `--delete-media` is only valid with `--for-me`.
 - `messages forward` forwards a stored text, image, video, GIF, audio, sticker, or document message to another recipient and marks the outgoing copy as forwarded. Media forwards require synced media metadata; reaction forwarding is not supported.
 - These commands look up the target in the local store first and honor `--read-only`/`WACLI_READONLY`. Delete-for-everyone and edit require a message sent by you.
-- Deleted messages and WhatsApp delete-for-me events are kept as local tombstones for direct `messages show`, but are hidden from normal list/search/starred/export results.
+- Deleted messages and WhatsApp delete-for-me events are kept as local tombstones with `deleted_at` and `deletion_reason`. Their original text, reply, interactive, and media metadata remains available to direct `messages show`, but tombstones stay hidden from normal list/search/starred/export results and FTS.
+- Sync, history, and backfill ingestion merge messages by chat JID and message ID. A message missing from any partial import is left unchanged, and a later live copy does not resurrect an existing tombstone.
+- `messages purge` is the deliberate payload-erasure path. It only accepts an already tombstoned row, removes downloaded local media, clears its retained `wacli.db` payload, and requires confirmation unless `--confirm` is passed. A minimal tombstone with `payload_purged_at` and a non-cascading purge-ledger key remain so later sync or history imports cannot restore the payload after chat cleanup.
 
 ## LID mapping
 
@@ -69,6 +72,7 @@ wacli messages context --chat 1234567890@s.whatsapp.net --id ABC123 --before 3 -
 wacli messages edit --chat 1234567890@s.whatsapp.net --id ABC123 --message "updated text"
 wacli messages delete --chat 1234567890@s.whatsapp.net --id ABC123
 wacli messages delete --chat 1234567890@s.whatsapp.net --id ABC123 --for-me
+wacli messages purge --chat 1234567890@s.whatsapp.net --id ABC123 --dry-run
 wacli messages revoke --chat 1234567890@s.whatsapp.net --id ABC123
 wacli messages forward --chat 1234567890@s.whatsapp.net --id ABC123 --to "Family"
 ```

--- a/internal/app/lid_migration.go
+++ b/internal/app/lid_migration.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"go.mau.fi/whatsmeow/types"
@@ -25,7 +26,20 @@ func (a *App) migrateHistoricalLIDs(ctx context.Context) error {
 		if pn.IsEmpty() || pn.Server != types.DefaultUserServer {
 			continue
 		}
-		if err := a.db.MigrateLIDToPN(raw, canonicalJIDString(pn)); err != nil {
+		pnJID := canonicalJIDString(pn)
+		pendingMedia, err := a.db.LIDMigrationPurgedMedia(raw, pnJID)
+		if err != nil {
+			return fmt.Errorf("load purged alias media for historical LID %s: %w", raw, err)
+		}
+		for _, media := range pendingMedia {
+			if err := os.Remove(media.LocalPath); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("remove purged alias media for historical LID %s: %w", raw, err)
+			}
+			if err := a.db.ClearMessageLocalMedia(media.ChatJID, media.MsgID); err != nil {
+				return fmt.Errorf("clear purged alias media for historical LID %s: %w", raw, err)
+			}
+		}
+		if err := a.db.MigrateLIDToPN(raw, pnJID); err != nil {
 			return fmt.Errorf("migrate historical LID %s: %w", raw, err)
 		}
 	}

--- a/internal/app/lid_migration_test.go
+++ b/internal/app/lid_migration_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -52,6 +54,51 @@ func TestEnsureAuthedMigratesHistoricalLIDs(t *testing.T) {
 	}
 	if len(lids) != 0 {
 		t.Fatalf("HistoricalLIDJIDs = %#v, want none", lids)
+	}
+}
+
+func TestEnsureAuthedRemovesPurgedAliasMediaBeforeLIDMigration(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+	lid := types.JID{User: "999123456789", Server: types.HiddenUserServer}
+	pn := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+	f.lids[lid.ToNonAD()] = pn
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, chat := range []string{lid.String(), pn.String()} {
+		if err := a.db.UpsertChat(chat, "dm", "Alice", base); err != nil {
+			t.Fatal(err)
+		}
+		if err := a.db.UpsertMessage(store.UpsertMessageParams{ChatJID: chat, MsgID: "mid", Timestamp: base, Text: "payload"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	aliasPath := filepath.Join(t.TempDir(), "alias-media.bin")
+	if err := os.WriteFile(aliasPath, []byte("alias media"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.db.MarkMediaDownloaded(pn.String(), "mid", aliasPath, base); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.db.MarkMessageRevoked(lid.String(), "mid"); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.db.PurgeMessage(lid.String(), "mid"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := a.EnsureAuthed(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(aliasPath); !os.IsNotExist(err) {
+		t.Fatalf("purged alias media still exists: %v", err)
+	}
+	msg, err := a.db.GetMessage(pn.String(), "mid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.PayloadPurgedAt == nil || msg.LocalPath != "" || msg.Text != "" {
+		t.Fatalf("migrated purge state = %+v", msg)
 	}
 }
 

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -717,8 +717,15 @@ func TestDeleteForMeEventMarksMessageDeletedForCurrentUser(t *testing.T) {
 	if msg.Revoked || !msg.DeletedForMe {
 		t.Fatalf("flags revoked=%v deleted_for_me=%v", msg.Revoked, msg.DeletedForMe)
 	}
-	if msg.Text != "" || msg.DisplayText != store.DeletedForMeMessageDisplayText {
+	if msg.Text != "secret local copy" || msg.DisplayText != "secret local copy" {
 		t.Fatalf("text=%q display=%q", msg.Text, msg.DisplayText)
+	}
+	wantDeletedAt := base.Add(time.Minute)
+	if msg.DeletedAt == nil || !msg.DeletedAt.Equal(wantDeletedAt) {
+		t.Fatalf("deleted_at=%v want %v", msg.DeletedAt, wantDeletedAt)
+	}
+	if msg.DeletionReason != store.MessageDeletionReasonWhatsAppDeleteForMe {
+		t.Fatalf("deletion_reason=%q", msg.DeletionReason)
 	}
 	listed, err := a.db.ListMessages(store.ListMessagesParams{ChatJID: chat.String(), Limit: 10})
 	if err != nil {

--- a/internal/store/lid_migration.go
+++ b/internal/store/lid_migration.go
@@ -3,9 +3,18 @@ package store
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 )
+
+var ErrLIDMigrationPurgedMediaPending = errors.New("purged alias media must be removed before LID migration")
+
+type MessageLocalMedia struct {
+	ChatJID   string
+	MsgID     string
+	LocalPath string
+}
 
 // HistoricalLIDJIDs returns distinct hidden-user JIDs stored in chat and
 // message/poll identity columns. The app layer resolves these through whatsmeow.
@@ -26,6 +35,8 @@ func (d *DB) HistoricalLIDJIDs() ([]string, error) {
 		SELECT chat_jid FROM poll_votes WHERE chat_jid GLOB '*@lid'
 		UNION
 		SELECT voter_jid FROM poll_votes WHERE voter_jid GLOB '*@lid'
+		UNION
+		SELECT chat_jid FROM message_payload_purges WHERE chat_jid GLOB '*@lid'
 		ORDER BY 1
 	`)
 	if err != nil {
@@ -60,6 +71,13 @@ func (d *DB) MigrateLIDToPN(lidJID, pnJID string) error {
 	if lidJID == pnJID {
 		return nil
 	}
+	pendingMedia, err := d.LIDMigrationPurgedMedia(lidJID, pnJID)
+	if err != nil {
+		return err
+	}
+	if len(pendingMedia) > 0 {
+		return fmt.Errorf("%w: %d file(s)", ErrLIDMigrationPurgedMediaPending, len(pendingMedia))
+	}
 
 	tx, err := d.sql.Begin()
 	if err != nil {
@@ -92,6 +110,41 @@ func (d *DB) MigrateLIDToPN(lidJID, pnJID string) error {
 	}
 	tx = nil
 	return nil
+}
+
+func (d *DB) LIDMigrationPurgedMedia(lidJID, pnJID string) ([]MessageLocalMedia, error) {
+	lidJID = strings.TrimSpace(lidJID)
+	pnJID = strings.TrimSpace(pnJID)
+	if lidJID == "" || pnJID == "" {
+		return nil, fmt.Errorf("lid and phone-number JIDs are required")
+	}
+	rows, err := d.sql.Query(`
+		SELECT DISTINCT m.chat_jid, m.msg_id, m.local_path
+		FROM messages m
+		WHERE m.chat_jid IN (?, ?)
+			AND COALESCE(m.local_path, '') != ''
+			AND EXISTS (
+				SELECT 1 FROM message_payload_purges p
+				WHERE p.chat_jid IN (?, ?) AND p.msg_id = m.msg_id
+			)
+		ORDER BY m.chat_jid, m.msg_id, m.local_path
+	`, lidJID, pnJID, lidJID, pnJID)
+	if err != nil {
+		return nil, fmt.Errorf("load purged alias media: %w", err)
+	}
+	defer rows.Close()
+	var out []MessageLocalMedia
+	for rows.Next() {
+		var item MessageLocalMedia
+		if err := rows.Scan(&item.ChatJID, &item.MsgID, &item.LocalPath); err != nil {
+			return nil, fmt.Errorf("scan purged alias media: %w", err)
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func migrateLIDChatToPN(tx *sql.Tx, lidJID, pnJID string) error {
@@ -164,13 +217,26 @@ func migrateLIDChatToPN(tx *sql.Tx, lidJID, pnJID string) error {
 
 func migrateLIDMessagesToPN(tx *sql.Tx, lidJID, pnJID string) error {
 	if _, err := tx.Exec(`
+		INSERT INTO message_payload_purges(chat_jid, msg_id, purged_at, deleted_at, deletion_reason)
+		SELECT ?, msg_id, purged_at, deleted_at, deletion_reason
+		FROM message_payload_purges
+		WHERE chat_jid = ?
+		ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
+			purged_at = min(message_payload_purges.purged_at, excluded.purged_at),
+			deleted_at = min(message_payload_purges.deleted_at, excluded.deleted_at),
+			deletion_reason = COALESCE(NULLIF(message_payload_purges.deletion_reason, ''), excluded.deletion_reason)
+	`, pnJID, lidJID); err != nil {
+		return fmt.Errorf("migrate lid message purge ledger: %w", err)
+	}
+
+	if _, err := tx.Exec(`
 		INSERT INTO messages(
 			chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, display_text,
 			quoted_msg_id, quoted_sender_jid,
 			is_forwarded, forwarding_score, reaction_to_id, reaction_emoji,
 			media_type, media_caption, filename, mime_type, direct_path,
 			media_key, file_sha256, file_enc_sha256, file_length, local_path, downloaded_at,
-			revoked, deleted_for_me, edited, edited_ts, buttons
+			revoked, deleted_for_me, deleted_at, deletion_reason, payload_purged_at, edited, edited_ts, buttons
 		)
 		SELECT
 			?,
@@ -182,8 +248,8 @@ func migrateLIDMessagesToPN(tx *sql.Tx, lidJID, pnJID string) error {
 			from_me,
 			text,
 			display_text,
-			CASE WHEN revoked != 0 OR deleted_for_me != 0 THEN NULL ELSE quoted_msg_id END,
-			CASE WHEN revoked != 0 OR deleted_for_me != 0 THEN NULL WHEN quoted_sender_jid = ? THEN ? ELSE quoted_sender_jid END,
+			quoted_msg_id,
+			CASE WHEN quoted_sender_jid = ? THEN ? ELSE quoted_sender_jid END,
 			is_forwarded,
 			forwarding_score,
 			reaction_to_id,
@@ -201,47 +267,116 @@ func migrateLIDMessagesToPN(tx *sql.Tx, lidJID, pnJID string) error {
 			downloaded_at,
 			revoked,
 			deleted_for_me,
+			deleted_at,
+			deletion_reason,
+			payload_purged_at,
 			edited,
 			edited_ts,
 			buttons
-		FROM messages
+		FROM messages AS source
 		WHERE chat_jid = ?
+			AND (source.payload_purged_at IS NOT NULL OR NOT EXISTS (
+				SELECT 1 FROM message_payload_purges p WHERE p.chat_jid = ? AND p.msg_id = source.msg_id
+			))
 		ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
 			chat_name = COALESCE(NULLIF(messages.chat_name, ''), excluded.chat_name),
 			sender_jid = COALESCE(NULLIF(messages.sender_jid, ''), excluded.sender_jid),
 			sender_name = COALESCE(NULLIF(messages.sender_name, ''), excluded.sender_name),
-			ts = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 THEN messages.ts WHEN excluded.edited != 0 THEN messages.ts WHEN messages.edited != 0 AND excluded.edited = 0 THEN excluded.ts ELSE max(messages.ts, excluded.ts) END,
+			ts = CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN messages.ts WHEN excluded.edited != 0 THEN messages.ts WHEN messages.edited != 0 AND excluded.edited = 0 THEN excluded.ts ELSE max(messages.ts, excluded.ts) END,
 			from_me = messages.from_me,
-			text = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN excluded.edited != 0 AND (messages.edited = 0 OR excluded.edited_ts > messages.edited_ts) THEN excluded.text WHEN messages.edited != 0 AND excluded.edited = 0 THEN messages.text ELSE COALESCE(NULLIF(messages.text, ''), excluded.text) END,
-			display_text = CASE WHEN messages.deleted_for_me != 0 OR excluded.deleted_for_me != 0 THEN ? WHEN messages.revoked != 0 OR excluded.revoked != 0 THEN ? WHEN excluded.edited != 0 AND (messages.edited = 0 OR excluded.edited_ts > messages.edited_ts) THEN excluded.display_text WHEN messages.edited != 0 AND excluded.edited = 0 THEN messages.display_text ELSE COALESCE(NULLIF(messages.display_text, ''), excluded.display_text) END,
-			quoted_msg_id = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE COALESCE(NULLIF(messages.quoted_msg_id, ''), excluded.quoted_msg_id) END,
-			quoted_sender_jid = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE COALESCE(NULLIF(messages.quoted_sender_jid, ''), excluded.quoted_sender_jid) END,
+			text = CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.text, ''), excluded.text) WHEN excluded.edited != 0 AND (messages.edited = 0 OR excluded.edited_ts > messages.edited_ts) THEN excluded.text WHEN messages.edited != 0 AND excluded.edited = 0 THEN messages.text ELSE COALESCE(NULLIF(messages.text, ''), excluded.text) END,
+			display_text = CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.display_text, ''), excluded.display_text) WHEN excluded.edited != 0 AND (messages.edited = 0 OR excluded.edited_ts > messages.edited_ts) THEN excluded.display_text WHEN messages.edited != 0 AND excluded.edited = 0 THEN messages.display_text ELSE COALESCE(NULLIF(messages.display_text, ''), excluded.display_text) END,
+			quoted_msg_id = COALESCE(NULLIF(messages.quoted_msg_id, ''), excluded.quoted_msg_id),
+			quoted_sender_jid = COALESCE(NULLIF(messages.quoted_sender_jid, ''), excluded.quoted_sender_jid),
 			is_forwarded = CASE WHEN messages.is_forwarded != 0 THEN messages.is_forwarded ELSE excluded.is_forwarded END,
 			forwarding_score = max(messages.forwarding_score, excluded.forwarding_score),
 			reaction_to_id = COALESCE(NULLIF(messages.reaction_to_id, ''), excluded.reaction_to_id),
 			reaction_emoji = COALESCE(NULLIF(messages.reaction_emoji, ''), excluded.reaction_emoji),
-			media_type = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE COALESCE(NULLIF(messages.media_type, ''), excluded.media_type) END,
-			media_caption = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE COALESCE(NULLIF(messages.media_caption, ''), excluded.media_caption) END,
-			filename = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE COALESCE(NULLIF(messages.filename, ''), excluded.filename) END,
-			mime_type = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE COALESCE(NULLIF(messages.mime_type, ''), excluded.mime_type) END,
-			direct_path = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE COALESCE(NULLIF(messages.direct_path, ''), excluded.direct_path) END,
-			media_key = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN messages.media_key IS NOT NULL AND length(messages.media_key) > 0 THEN messages.media_key ELSE excluded.media_key END,
-			file_sha256 = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN messages.file_sha256 IS NOT NULL AND length(messages.file_sha256) > 0 THEN messages.file_sha256 ELSE excluded.file_sha256 END,
-			file_enc_sha256 = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN messages.file_enc_sha256 IS NOT NULL AND length(messages.file_enc_sha256) > 0 THEN messages.file_enc_sha256 ELSE excluded.file_enc_sha256 END,
-			file_length = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN messages.file_length IS NOT NULL AND messages.file_length > 0 THEN messages.file_length ELSE excluded.file_length END,
-			local_path = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE COALESCE(NULLIF(messages.local_path, ''), excluded.local_path) END,
-			downloaded_at = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN messages.downloaded_at IS NOT NULL AND messages.downloaded_at > 0 THEN messages.downloaded_at ELSE excluded.downloaded_at END,
+			media_type = COALESCE(NULLIF(messages.media_type, ''), excluded.media_type),
+			media_caption = COALESCE(NULLIF(messages.media_caption, ''), excluded.media_caption),
+			filename = COALESCE(NULLIF(messages.filename, ''), excluded.filename),
+			mime_type = COALESCE(NULLIF(messages.mime_type, ''), excluded.mime_type),
+			direct_path = COALESCE(NULLIF(messages.direct_path, ''), excluded.direct_path),
+			media_key = CASE WHEN messages.media_key IS NOT NULL AND length(messages.media_key) > 0 THEN messages.media_key ELSE excluded.media_key END,
+			file_sha256 = CASE WHEN messages.file_sha256 IS NOT NULL AND length(messages.file_sha256) > 0 THEN messages.file_sha256 ELSE excluded.file_sha256 END,
+			file_enc_sha256 = CASE WHEN messages.file_enc_sha256 IS NOT NULL AND length(messages.file_enc_sha256) > 0 THEN messages.file_enc_sha256 ELSE excluded.file_enc_sha256 END,
+			file_length = CASE WHEN messages.file_length IS NOT NULL AND messages.file_length > 0 THEN messages.file_length ELSE excluded.file_length END,
+			local_path = COALESCE(NULLIF(messages.local_path, ''), excluded.local_path),
+			downloaded_at = CASE WHEN messages.downloaded_at IS NOT NULL AND messages.downloaded_at > 0 THEN messages.downloaded_at ELSE excluded.downloaded_at END,
 			revoked = CASE WHEN messages.revoked != 0 OR excluded.revoked != 0 THEN 1 ELSE 0 END,
 			deleted_for_me = CASE WHEN messages.deleted_for_me != 0 OR excluded.deleted_for_me != 0 THEN 1 ELSE 0 END,
-			edited = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN 0 WHEN messages.edited != 0 OR excluded.edited != 0 THEN 1 ELSE 0 END,
-			edited_ts = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN 0 ELSE max(COALESCE(messages.edited_ts, 0), COALESCE(excluded.edited_ts, 0)) END,
-			buttons = CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE COALESCE(messages.buttons, excluded.buttons) END
-	`, pnJID, lidJID, pnJID, lidJID, pnJID, lidJID, DeletedForMeMessageDisplayText, DeletedMessageDisplayText); err != nil {
+			deleted_at = COALESCE(messages.deleted_at, excluded.deleted_at),
+			deletion_reason = CASE WHEN messages.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.deletion_reason, ''), excluded.deletion_reason) ELSE excluded.deletion_reason END,
+			payload_purged_at = COALESCE(messages.payload_purged_at, excluded.payload_purged_at),
+			edited = CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN 0 WHEN messages.edited != 0 OR excluded.edited != 0 THEN 1 ELSE 0 END,
+			edited_ts = CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN 0 ELSE max(COALESCE(messages.edited_ts, 0), COALESCE(excluded.edited_ts, 0)) END,
+			buttons = COALESCE(messages.buttons, excluded.buttons)
+		WHERE messages.payload_purged_at IS NULL
+	`, pnJID, lidJID, pnJID, lidJID, pnJID, lidJID, pnJID); err != nil {
 		return fmt.Errorf("merge lid messages into pn chat: %w", err)
+	}
+
+	if _, err := tx.Exec(`
+		UPDATE messages
+		SET deleted_at = COALESCE(deleted_at, (
+				SELECT p.deleted_at FROM message_payload_purges p
+				WHERE p.chat_jid = messages.chat_jid AND p.msg_id = messages.msg_id
+			)),
+			deletion_reason = COALESCE(NULLIF(deletion_reason, ''), (
+				SELECT p.deletion_reason FROM message_payload_purges p
+				WHERE p.chat_jid = messages.chat_jid AND p.msg_id = messages.msg_id
+			)),
+			payload_purged_at = COALESCE(payload_purged_at, (
+				SELECT p.purged_at FROM message_payload_purges p
+				WHERE p.chat_jid = messages.chat_jid AND p.msg_id = messages.msg_id
+			))
+		WHERE chat_jid = ?
+			AND EXISTS (
+				SELECT 1 FROM message_payload_purges p
+				WHERE p.chat_jid = messages.chat_jid AND p.msg_id = messages.msg_id
+			)
+	`, pnJID); err != nil {
+		return fmt.Errorf("apply migrated message purge ledger: %w", err)
+	}
+
+	if _, err := tx.Exec(`
+		UPDATE messages SET
+			chat_name = NULL,
+			sender_jid = NULL,
+			sender_name = NULL,
+			text = NULL,
+			display_text = NULL,
+			quoted_msg_id = NULL,
+			quoted_sender_jid = NULL,
+			is_forwarded = 0,
+			forwarding_score = 0,
+			reaction_to_id = NULL,
+			reaction_emoji = NULL,
+			media_type = NULL,
+			media_caption = NULL,
+			filename = NULL,
+			mime_type = NULL,
+			direct_path = NULL,
+			media_key = NULL,
+			file_sha256 = NULL,
+			file_enc_sha256 = NULL,
+			file_length = NULL,
+			local_path = NULL,
+			downloaded_at = NULL,
+			media_unavailable_at = NULL,
+			edited = 0,
+			edited_ts = 0,
+			buttons = NULL
+		WHERE chat_jid = ? AND payload_purged_at IS NOT NULL
+	`, pnJID); err != nil {
+		return fmt.Errorf("preserve purged lid message tombstones: %w", err)
 	}
 
 	if _, err := tx.Exec(`DELETE FROM messages WHERE chat_jid = ?`, lidJID); err != nil {
 		return fmt.Errorf("delete migrated lid messages: %w", err)
+	}
+	if _, err := tx.Exec(`DELETE FROM message_payload_purges WHERE chat_jid = ?`, lidJID); err != nil {
+		return fmt.Errorf("delete migrated lid message purge ledger: %w", err)
 	}
 	return nil
 }
@@ -262,6 +397,15 @@ func migrateLIDPollsToPN(tx *sql.Tx, lidJID, pnJID string) error {
 	}
 	if _, err := tx.Exec(`DELETE FROM polls WHERE chat_jid = ? OR (sender_jid = ? AND chat_jid NOT GLOB '*@g.us')`, lidJID, lidJID); err != nil {
 		return fmt.Errorf("delete migrated lid polls: %w", err)
+	}
+	if _, err := tx.Exec(`
+		DELETE FROM polls
+		WHERE EXISTS (
+			SELECT 1 FROM message_payload_purges p
+			WHERE p.chat_jid = polls.chat_jid AND p.msg_id = polls.msg_id
+		)
+	`); err != nil {
+		return fmt.Errorf("suppress destination-only purged polls: %w", err)
 	}
 
 	if _, err := tx.Exec(`
@@ -285,6 +429,16 @@ func migrateLIDPollsToPN(tx *sql.Tx, lidJID, pnJID string) error {
 	}
 	if _, err := tx.Exec(`DELETE FROM poll_votes WHERE chat_jid = ? OR voter_jid = ?`, lidJID, lidJID); err != nil {
 		return fmt.Errorf("delete migrated lid poll votes: %w", err)
+	}
+	if _, err := tx.Exec(`
+		DELETE FROM poll_votes
+		WHERE EXISTS (
+			SELECT 1 FROM message_payload_purges p
+			WHERE p.chat_jid = poll_votes.chat_jid
+				AND (p.msg_id = poll_votes.poll_msg_id OR p.msg_id = poll_votes.vote_msg_id)
+		)
+	`); err != nil {
+		return fmt.Errorf("suppress migrated purged poll votes: %w", err)
 	}
 	return nil
 }
@@ -329,6 +483,21 @@ func migrateLIDPollRowsToPN(tx *sql.Tx, lidJID, pnJID string) error {
 		destSender := p.senderJID
 		if destSender == lidJID && !strings.HasSuffix(p.chatJID, "@g.us") {
 			destSender = pnJID
+		}
+		var payloadPurged int
+		if err := tx.QueryRow(`
+			SELECT EXISTS(SELECT 1 FROM message_payload_purges WHERE chat_jid = ? AND msg_id = ?)
+		`, destChat, p.msgID).Scan(&payloadPurged); err != nil {
+			return fmt.Errorf("check migrated poll purge ledger: %w", err)
+		}
+		if payloadPurged != 0 {
+			if _, err := tx.Exec(`DELETE FROM poll_votes WHERE chat_jid = ? AND poll_msg_id = ?`, destChat, p.msgID); err != nil {
+				return fmt.Errorf("delete purged migrated poll votes: %w", err)
+			}
+			if _, err := tx.Exec(`DELETE FROM polls WHERE chat_jid = ? AND msg_id = ?`, destChat, p.msgID); err != nil {
+				return fmt.Errorf("delete purged migrated poll: %w", err)
+			}
+			continue
 		}
 		optionsJSON, err := mergedPollOptionsJSONTx(tx, destChat, p.msgID, p.optionsJSON)
 		if err != nil {

--- a/internal/store/lid_migration_test.go
+++ b/internal/store/lid_migration_test.go
@@ -68,6 +68,24 @@ func TestHistoricalLIDJIDsFindsChatAndMessageColumns(t *testing.T) {
 	}
 }
 
+func TestHistoricalLIDJIDsFindsPurgeLedgerOnlyIdentity(t *testing.T) {
+	db := openTestDB(t)
+	lid := "888123456789@lid"
+	if _, err := db.sql.Exec(`
+		INSERT INTO message_payload_purges(chat_jid, msg_id, purged_at, deleted_at, deletion_reason)
+		VALUES(?, 'mid', 3, 2, 'whatsapp-revoke')
+	`, lid); err != nil {
+		t.Fatal(err)
+	}
+	got, err := db.HistoricalLIDJIDs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{lid}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("HistoricalLIDJIDs = %#v, want %#v", got, want)
+	}
+}
+
 func TestMigrateLIDToPNMergesChatsAndMessages(t *testing.T) {
 	db := openTestDB(t)
 	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -341,7 +359,7 @@ func TestMigrateLIDToPNPreservesButtons(t *testing.T) {
 	}
 }
 
-func TestMigrateLIDToPNClearsQuotedMetadataOnDeletedMessages(t *testing.T) {
+func TestMigrateLIDToPNPreservesDeletedMessagePayload(t *testing.T) {
 	db := openTestDB(t)
 	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 
@@ -357,6 +375,9 @@ func TestMigrateLIDToPNClearsQuotedMetadataOnDeletedMessages(t *testing.T) {
 		Timestamp:       base,
 		QuotedMsgID:     "quoted",
 		QuotedSenderJID: lid,
+		Text:            "retained reply",
+		MediaType:       "document",
+		Filename:        "proof.pdf",
 		DeletedForMe:    true,
 	}); err != nil {
 		t.Fatalf("UpsertMessage: %v", err)
@@ -376,8 +397,90 @@ func TestMigrateLIDToPNClearsQuotedMetadataOnDeletedMessages(t *testing.T) {
 	if !msg.DeletedForMe {
 		t.Fatalf("DeletedForMe = false")
 	}
-	if msg.QuotedMsgID != "" || msg.QuotedSenderJID != "" {
+	if msg.QuotedMsgID != "quoted" || msg.QuotedSenderJID != pn {
 		t.Fatalf("deleted quoted metadata = id %q sender %q", msg.QuotedMsgID, msg.QuotedSenderJID)
+	}
+	if msg.Text != "retained reply" || msg.MediaType != "document" || msg.Filename != "proof.pdf" {
+		t.Fatalf("deleted payload = %+v", msg)
+	}
+	if msg.DeletedAt == nil || msg.DeletionReason != MessageDeletionReasonWhatsAppDeleteForMe {
+		t.Fatalf("deleted tombstone = %v %q", msg.DeletedAt, msg.DeletionReason)
+	}
+}
+
+func TestMigrateLIDToPNPreservesPayloadPurgeSuppression(t *testing.T) {
+	db := openTestDB(t)
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	pn := "15551234567@s.whatsapp.net"
+	lid := "999123456789@lid"
+	for _, chat := range []string{pn, lid} {
+		if err := db.UpsertChat(chat, "dm", "Alice", base); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, id := range []string{"purged-lid", "purged-pn", "ledger-lid", "ledger-pn"} {
+		if err := db.UpsertMessage(UpsertMessageParams{ChatJID: pn, MsgID: id, Timestamp: base, Text: "pn payload"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.UpsertMessage(UpsertMessageParams{ChatJID: lid, MsgID: id, Timestamp: base, Text: "lid payload"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.MarkMessageRevoked(lid, "purged-lid"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.PurgeMessage(lid, "purged-lid"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.MarkMessageRevoked(pn, "purged-pn"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.PurgeMessage(pn, "purged-pn"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.MarkMessageRevoked(lid, "ledger-lid"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.PurgeMessage(lid, "ledger-lid"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.MarkMessageRevoked(pn, "ledger-pn"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.PurgeMessage(pn, "ledger-pn"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`DELETE FROM messages WHERE (chat_jid = ? AND msg_id = ?) OR (chat_jid = ? AND msg_id = ?)`, lid, "ledger-lid", pn, "ledger-pn"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertPoll(Poll{ChatJID: pn, MsgID: "ledger-lid", Question: "destination-only secret", Options: []string{"secret"}, CreatedAt: base}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.MigrateLIDToPN(lid, pn); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"purged-lid", "purged-pn", "ledger-lid"} {
+		msg, err := db.GetMessage(pn, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if msg.PayloadPurgedAt == nil || msg.Text != "" {
+			t.Fatalf("%s purge suppression after LID migration = %+v", id, msg)
+		}
+	}
+	var messageCount, purgeCount int
+	if err := db.sql.QueryRow(`SELECT count(*) FROM messages WHERE chat_jid = ? AND msg_id = ?`, pn, "ledger-pn").Scan(&messageCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.sql.QueryRow(`SELECT count(*) FROM message_payload_purges WHERE chat_jid = ? AND msg_id = ?`, pn, "ledger-pn").Scan(&purgeCount); err != nil {
+		t.Fatal(err)
+	}
+	if messageCount != 0 || purgeCount != 1 {
+		t.Fatalf("destination-ledger suppression counts: messages=%d purges=%d", messageCount, purgeCount)
+	}
+	if got := countRows(t, db.sql, `SELECT count(*) FROM polls WHERE msg_id = 'ledger-lid'`); got != 0 {
+		t.Fatalf("destination-only purged poll rows = %d", got)
 	}
 }
 

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -3,12 +3,15 @@ package store
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/openclaw/wacli/internal/store/storedb"
 )
+
+var ErrMessageNotTombstoned = errors.New("message is not tombstoned")
 
 type UpsertMessageParams struct {
 	ChatJID         string
@@ -39,10 +42,12 @@ type UpsertMessageParams struct {
 	Edited          bool
 	Revoked         bool
 	DeletedForMe    bool
+	DeletedAt       time.Time
+	DeletionReason  string
 }
 
 func messageSelectColumns(snippet string) string {
-	return fmt.Sprintf(`m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), %s`, snippetSQL(snippet))
+	return fmt.Sprintf(`m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), COALESCE(m.buttons,''), %s`, snippetSQL(snippet))
 }
 
 func snippetSQL(snippet string) string {
@@ -53,25 +58,25 @@ func snippetSQL(snippet string) string {
 }
 
 func (d *DB) UpsertMessage(p UpsertMessageParams) error {
-	if p.Revoked || p.DeletedForMe {
-		p.Text = ""
-		p.Buttons = nil
-		p.QuotedMsgID = ""
-		p.QuotedSenderJID = ""
-		if p.DeletedForMe {
-			p.DisplayText = DeletedForMeMessageDisplayText
-		} else {
-			p.DisplayText = DeletedMessageDisplayText
+	var deletedAt sql.NullInt64
+	if p.Revoked || p.DeletedForMe || !p.DeletedAt.IsZero() {
+		if p.DeletedAt.IsZero() {
+			p.DeletedAt = p.Timestamp
 		}
-		p.MediaType = ""
-		p.MediaCaption = ""
-		p.Filename = ""
-		p.MimeType = ""
-		p.DirectPath = ""
-		p.MediaKey = nil
-		p.FileSHA256 = nil
-		p.FileEncSHA256 = nil
-		p.FileLength = 0
+		if p.DeletedAt.IsZero() {
+			p.DeletedAt = nowUTC()
+		}
+		deletedAt = sql.NullInt64{Int64: unix(p.DeletedAt), Valid: true}
+		if strings.TrimSpace(p.DeletionReason) == "" {
+			switch {
+			case p.DeletedForMe:
+				p.DeletionReason = MessageDeletionReasonWhatsAppDeleteForMe
+			case p.Revoked:
+				p.DeletionReason = MessageDeletionReasonWhatsAppRevoke
+			default:
+				p.DeletionReason = MessageDeletionReasonExplicit
+			}
+		}
 	}
 	var buttonsJSON sql.NullString
 	if len(p.Buttons) > 0 {
@@ -110,17 +115,22 @@ func (d *DB) UpsertMessage(p UpsertMessageParams) error {
 		FileLength:      sqlNullInt64(int64(p.FileLength)),
 		Revoked:         boolToInt64(p.Revoked),
 		DeletedForMe:    boolToInt64(p.DeletedForMe),
+		DeletedAt:       deletedAt,
+		DeletionReason:  nullString(p.DeletionReason),
 		Edited:          boolToInt64(p.Edited),
 		EditedTs:        editedTS,
 		Buttons:         buttonsJSON,
+		ChatJid_2:       strings.TrimSpace(p.ChatJID),
+		MsgID_2:         strings.TrimSpace(p.MsgID),
 	})
 }
 
 func (d *DB) MarkMessageRevoked(chatJID, msgID string) error {
 	n, err := d.q.MarkMessageRevoked(storeCtx(), storedb.MarkMessageRevokedParams{
-		DisplayText: sql.NullString{String: DeletedMessageDisplayText, Valid: true},
-		ChatJid:     strings.TrimSpace(chatJID),
-		MsgID:       strings.TrimSpace(msgID),
+		DeletedAt:      sql.NullInt64{Int64: nowUTC().Unix(), Valid: true},
+		DeletionReason: nullString(MessageDeletionReasonWhatsAppRevoke),
+		ChatJid:        strings.TrimSpace(chatJID),
+		MsgID:          strings.TrimSpace(msgID),
 	})
 	if err != nil {
 		return err
@@ -144,9 +154,10 @@ func (d *DB) MarkMessageDeletedForMe(chatJID, msgID, senderJID string, fromMe bo
 		deletedAt = nowUTC()
 	}
 	n, err := d.q.MarkMessageDeletedForMe(storeCtx(), storedb.MarkMessageDeletedForMeParams{
-		DisplayText: sql.NullString{String: DeletedForMeMessageDisplayText, Valid: true},
-		ChatJid:     chatJID,
-		MsgID:       msgID,
+		DeletedAt:      sql.NullInt64{Int64: unix(deletedAt), Valid: true},
+		DeletionReason: nullString(MessageDeletionReasonWhatsAppDeleteForMe),
+		ChatJid:        chatJID,
+		MsgID:          msgID,
 	})
 	if err != nil {
 		return err
@@ -161,6 +172,7 @@ func (d *DB) MarkMessageDeletedForMe(chatJID, msgID, senderJID string, fromMe bo
 		Timestamp:    deletedAt,
 		FromMe:       fromMe,
 		DeletedForMe: true,
+		DeletedAt:    deletedAt,
 	})
 }
 
@@ -174,10 +186,26 @@ func (d *DB) MarkMessageDeletedForMePreserveMedia(chatJID, msgID string) error {
 		return fmt.Errorf("message ID is required")
 	}
 	n, err := d.q.MarkMessageDeletedForMePreserveMedia(storeCtx(), storedb.MarkMessageDeletedForMePreserveMediaParams{
-		DisplayText: sql.NullString{String: DeletedForMeMessageDisplayText, Valid: true},
-		ChatJid:     chatJID,
-		MsgID:       msgID,
+		DeletedAt:      sql.NullInt64{Int64: nowUTC().Unix(), Valid: true},
+		DeletionReason: nullString(MessageDeletionReasonWhatsAppDeleteForMe),
+		ChatJid:        chatJID,
+		MsgID:          msgID,
 	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (d *DB) ClearMessageLocalMedia(chatJID, msgID string) error {
+	res, err := d.sql.Exec(`UPDATE messages SET local_path = NULL, downloaded_at = NULL WHERE chat_jid = ? AND msg_id = ?`, strings.TrimSpace(chatJID), strings.TrimSpace(msgID))
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
 	if err != nil {
 		return err
 	}
@@ -203,6 +231,91 @@ func (d *DB) UpdateMessageText(chatJID, msgID, text string) error {
 	return nil
 }
 
+func (d *DB) PurgeMessage(chatJID, msgID string) error {
+	chatJID = strings.TrimSpace(chatJID)
+	msgID = strings.TrimSpace(msgID)
+	if chatJID == "" {
+		return fmt.Errorf("chat JID is required")
+	}
+	if msgID == "" {
+		return fmt.Errorf("message ID is required")
+	}
+	tx, err := d.sql.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var deletedAt sql.NullInt64
+	var deletionReason sql.NullString
+	if err := tx.QueryRow(`SELECT deleted_at, deletion_reason FROM messages WHERE chat_jid = ? AND msg_id = ?`, chatJID, msgID).Scan(&deletedAt, &deletionReason); err != nil {
+		return err
+	}
+	if !deletedAt.Valid {
+		return ErrMessageNotTombstoned
+	}
+	if strings.TrimSpace(deletionReason.String) == "" {
+		deletionReason = nullString(MessageDeletionReasonExplicit)
+	}
+	purgedAt := nowUTC().Unix()
+	if _, err := tx.Exec(`
+		INSERT INTO message_payload_purges(chat_jid, msg_id, purged_at, deleted_at, deletion_reason)
+		VALUES(?, ?, ?, ?, ?)
+		ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
+			purged_at = min(message_payload_purges.purged_at, excluded.purged_at),
+			deleted_at = min(message_payload_purges.deleted_at, excluded.deleted_at),
+			deletion_reason = COALESCE(NULLIF(message_payload_purges.deletion_reason, ''), excluded.deletion_reason)
+	`, chatJID, msgID, purgedAt, deletedAt.Int64, deletionReason.String); err != nil {
+		return err
+	}
+	for _, stmt := range []string{
+		`DELETE FROM poll_votes WHERE chat_jid = ? AND (poll_msg_id = ? OR vote_msg_id = ?)`,
+		`DELETE FROM polls WHERE chat_jid = ? AND msg_id = ?`,
+		`DELETE FROM starred WHERE chat_jid = ? AND msg_id = ?`,
+	} {
+		args := []any{chatJID, msgID}
+		if strings.Contains(stmt, "vote_msg_id") {
+			args = append(args, msgID)
+		}
+		if _, err := tx.Exec(stmt, args...); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.Exec(`
+		UPDATE messages SET
+			chat_name = NULL,
+			sender_jid = NULL,
+			sender_name = NULL,
+			text = NULL,
+			display_text = NULL,
+			quoted_msg_id = NULL,
+			quoted_sender_jid = NULL,
+			is_forwarded = 0,
+			forwarding_score = 0,
+			reaction_to_id = NULL,
+			reaction_emoji = NULL,
+			media_type = NULL,
+			media_caption = NULL,
+			filename = NULL,
+			mime_type = NULL,
+			direct_path = NULL,
+			media_key = NULL,
+			file_sha256 = NULL,
+			file_enc_sha256 = NULL,
+			file_length = NULL,
+			local_path = NULL,
+			downloaded_at = NULL,
+			media_unavailable_at = NULL,
+			edited = 0,
+			edited_ts = 0,
+			buttons = NULL,
+			payload_purged_at = COALESCE(payload_purged_at, ?)
+		WHERE chat_jid = ? AND msg_id = ?
+	`, purgedAt, chatJID, msgID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 type ListMessagesParams struct {
 	ChatJID   string
 	ChatJIDs  []string
@@ -225,7 +338,7 @@ func (d *DB) ListMessages(p ListMessagesParams) ([]Message, error) {
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
-		WHERE m.revoked = 0 AND m.deleted_for_me = 0`
+		WHERE m.deleted_at IS NULL`
 	var args []interface{}
 	query, args = appendStringFilter(query, args, "m.chat_jid", p.ChatJID, p.ChatJIDs)
 	if p.After != nil {
@@ -403,8 +516,11 @@ func (d *DB) scanMessages(query string, args ...interface{}) ([]Message, error) 
 		var starredAt int64
 		var revoked int
 		var deletedForMe int
+		var deletedAt int64
+		var deletionReason string
+		var payloadPurgedAt int64
 		var buttonsJSON string
-		if err := rows.Scan(&m.rowID, &m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &m.SenderName, &ts, &fromMe, &m.Text, &m.DisplayText, &m.QuotedMsgID, &m.QuotedSenderJID, &forwarded, &forwardingScore, &m.ReactionToID, &m.ReactionEmoji, &m.MediaType, &m.MediaCaption, &m.Filename, &m.MimeType, &m.DirectPath, &m.LocalPath, &downloadedAt, &starred, &starredAt, &revoked, &deletedForMe, &buttonsJSON, &m.Snippet); err != nil {
+		if err := rows.Scan(&m.rowID, &m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &m.SenderName, &ts, &fromMe, &m.Text, &m.DisplayText, &m.QuotedMsgID, &m.QuotedSenderJID, &forwarded, &forwardingScore, &m.ReactionToID, &m.ReactionEmoji, &m.MediaType, &m.MediaCaption, &m.Filename, &m.MimeType, &m.DirectPath, &m.LocalPath, &downloadedAt, &starred, &starredAt, &revoked, &deletedForMe, &deletedAt, &deletionReason, &payloadPurgedAt, &buttonsJSON, &m.Snippet); err != nil {
 			return nil, err
 		}
 		m.Timestamp = fromUnix(ts)
@@ -416,6 +532,9 @@ func (d *DB) scanMessages(query string, args ...interface{}) ([]Message, error) 
 		m.StarredAt = fromUnix(starredAt)
 		m.Revoked = revoked != 0
 		m.DeletedForMe = deletedForMe != 0
+		m.DeletedAt = timePointerFromUnix(deletedAt)
+		m.DeletionReason = deletionReason
+		m.PayloadPurgedAt = timePointerFromUnix(payloadPurgedAt)
 		if buttonsJSON != "" {
 			_ = json.Unmarshal([]byte(buttonsJSON), &m.Buttons)
 		}
@@ -431,7 +550,7 @@ func messageFromGetRow(row storedb.GetMessageRow) Message {
 		row.ForwardingScore, row.ReactionToID, row.ReactionEmoji, row.MediaType,
 		row.MediaCaption, row.Filename, row.MimeType, row.DirectPath, row.LocalPath,
 		row.DownloadedAt, row.Column24, row.StarredAt, row.Revoked, row.DeletedForMe,
-		row.Buttons, row.Column29,
+		row.DeletedAt, row.DeletionReason, row.PayloadPurgedAt, row.Buttons, row.Column32,
 	)
 }
 
@@ -442,7 +561,7 @@ func messageFromBeforeRow(row storedb.MessageContextBeforeRow) Message {
 		row.ForwardingScore, row.ReactionToID, row.ReactionEmoji, row.MediaType,
 		row.MediaCaption, row.Filename, row.MimeType, row.DirectPath, row.LocalPath,
 		row.DownloadedAt, row.Column24, row.StarredAt, row.Revoked, row.DeletedForMe,
-		row.Buttons, row.Column29,
+		row.DeletedAt, row.DeletionReason, row.PayloadPurgedAt, row.Buttons, row.Column32,
 	)
 }
 
@@ -453,11 +572,11 @@ func messageFromAfterRow(row storedb.MessageContextAfterRow) Message {
 		row.ForwardingScore, row.ReactionToID, row.ReactionEmoji, row.MediaType,
 		row.MediaCaption, row.Filename, row.MimeType, row.DirectPath, row.LocalPath,
 		row.DownloadedAt, row.Column24, row.StarredAt, row.Revoked, row.DeletedForMe,
-		row.Buttons, row.Column29,
+		row.DeletedAt, row.DeletionReason, row.PayloadPurgedAt, row.Buttons, row.Column32,
 	)
 }
 
-func messageFromScalars(rowID int64, chatJID, chatName, msgID, senderJID, senderName string, ts, fromMe int64, text, displayText, quotedMsgID, quotedSenderJID string, forwarded, forwardingScore int64, reactionToID, reactionEmoji, mediaType, mediaCaption, filename, mimeType, directPath, localPath string, downloadedAt, starred, starredAt, revoked, deletedForMe int64, buttonsJSON, snippet string) Message {
+func messageFromScalars(rowID int64, chatJID, chatName, msgID, senderJID, senderName string, ts, fromMe int64, text, displayText, quotedMsgID, quotedSenderJID string, forwarded, forwardingScore int64, reactionToID, reactionEmoji, mediaType, mediaCaption, filename, mimeType, directPath, localPath string, downloadedAt, starred, starredAt, revoked, deletedForMe, deletedAt int64, deletionReason string, payloadPurgedAt int64, buttonsJSON, snippet string) Message {
 	m := Message{
 		rowID:           rowID,
 		ChatJID:         chatJID,
@@ -486,12 +605,23 @@ func messageFromScalars(rowID int64, chatJID, chatName, msgID, senderJID, sender
 		StarredAt:       fromUnix(starredAt),
 		Revoked:         revoked != 0,
 		DeletedForMe:    deletedForMe != 0,
+		DeletedAt:       timePointerFromUnix(deletedAt),
+		DeletionReason:  deletionReason,
+		PayloadPurgedAt: timePointerFromUnix(payloadPurgedAt),
 		Snippet:         snippet,
 	}
 	if buttonsJSON != "" {
 		_ = json.Unmarshal([]byte(buttonsJSON), &m.Buttons)
 	}
 	return m
+}
+
+func timePointerFromUnix(value int64) *time.Time {
+	if value <= 0 {
+		return nil
+	}
+	t := fromUnix(value)
+	return &t
 }
 
 func messageInfoFromOldestRow(row storedb.GetOldestMessageInfoRow) MessageInfo {

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -808,8 +809,11 @@ func TestMessageRevokedTombstoneIsHiddenFromListAndSearch(t *testing.T) {
 	if !deleted.Revoked {
 		t.Fatalf("deleted.Revoked = false")
 	}
-	if deleted.Text != "" || deleted.DisplayText != DeletedMessageDisplayText {
+	if deleted.Text != "secret needle" || deleted.DisplayText != "secret needle" {
 		t.Fatalf("deleted text=%q display=%q", deleted.Text, deleted.DisplayText)
+	}
+	if deleted.DeletedAt == nil || deleted.DeletionReason != MessageDeletionReasonWhatsAppRevoke {
+		t.Fatalf("deleted tombstone = %v %q", deleted.DeletedAt, deleted.DeletionReason)
 	}
 
 	msgs, err := db.ListMessages(ListMessagesParams{ChatJID: chat, Limit: 10})
@@ -861,8 +865,11 @@ func TestMessageDeletedForMeTombstoneIsHiddenFromListAndSearch(t *testing.T) {
 	if deleted.Revoked || !deleted.DeletedForMe {
 		t.Fatalf("deleted flags revoked=%v deleted_for_me=%v", deleted.Revoked, deleted.DeletedForMe)
 	}
-	if deleted.Text != "" || deleted.DisplayText != DeletedForMeMessageDisplayText {
+	if deleted.Text != "local secret needle" || deleted.DisplayText != "local secret needle" {
 		t.Fatalf("deleted text=%q display=%q", deleted.Text, deleted.DisplayText)
+	}
+	if deleted.DeletedAt == nil || !deleted.DeletedAt.Equal(now.Add(3*time.Second)) || deleted.DeletionReason != MessageDeletionReasonWhatsAppDeleteForMe {
+		t.Fatalf("deleted tombstone = %v %q", deleted.DeletedAt, deleted.DeletionReason)
 	}
 	if !deleted.Timestamp.Equal(now.Add(time.Second)) {
 		t.Fatalf("deleted timestamp = %s, want original message timestamp", deleted.Timestamp)
@@ -981,7 +988,7 @@ func TestMessageButtonsListRowRoundTrip(t *testing.T) {
 	}
 }
 
-func TestMessageButtonsClearedOnRevoke(t *testing.T) {
+func TestMessageButtonsPreservedOnRevoke(t *testing.T) {
 	db := openTestDB(t)
 
 	chat := "biz@s.whatsapp.net"
@@ -1008,12 +1015,12 @@ func TestMessageButtonsClearedOnRevoke(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetMessage: %v", err)
 	}
-	if len(msg.Buttons) != 0 {
-		t.Fatalf("expected buttons cleared after revoke, got %+v", msg.Buttons)
+	if len(msg.Buttons) != 1 || msg.Buttons[0].URL != "https://example.com" {
+		t.Fatalf("expected buttons retained after revoke, got %+v", msg.Buttons)
 	}
 }
 
-func TestMessageButtonsClearedOnDeletedForMe(t *testing.T) {
+func TestMessageButtonsPreservedOnDeletedForMe(t *testing.T) {
 	db := openTestDB(t)
 
 	chat := "biz@s.whatsapp.net"
@@ -1040,8 +1047,8 @@ func TestMessageButtonsClearedOnDeletedForMe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetMessage: %v", err)
 	}
-	if len(msg.Buttons) != 0 {
-		t.Fatalf("expected buttons cleared after deleted-for-me, got %+v", msg.Buttons)
+	if len(msg.Buttons) != 1 || msg.Buttons[0].ID != "yes" {
+		t.Fatalf("expected buttons retained after deleted-for-me, got %+v", msg.Buttons)
 	}
 }
 
@@ -1082,8 +1089,139 @@ func TestMarkMessageDeletedForMePreserveMediaKeepsLocalPath(t *testing.T) {
 	if msg.LocalPath != "/tmp/media.jpg" || msg.DownloadedAt.IsZero() {
 		t.Fatalf("media metadata was not preserved: path=%q downloaded_at=%v", msg.LocalPath, msg.DownloadedAt)
 	}
-	if len(msg.Buttons) != 0 {
-		t.Fatalf("expected buttons cleared after deleted-for-me, got %+v", msg.Buttons)
+	if len(msg.Buttons) != 1 || msg.Buttons[0].ID != "yes" {
+		t.Fatalf("expected buttons retained after deleted-for-me, got %+v", msg.Buttons)
+	}
+}
+
+func TestMessageStoreImportsMergeWithoutDeletingUnseenRows(t *testing.T) {
+	db := openTestDB(t)
+	chat := "chat@s.whatsapp.net"
+	now := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	if err := db.UpsertChat(chat, "dm", "Alice", now); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"seen-again", "not-seen"} {
+		if err := db.UpsertMessage(UpsertMessageParams{ChatJID: chat, MsgID: id, Timestamp: now, Text: id}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{ChatJID: chat, MsgID: "seen-again", Timestamp: now.Add(time.Minute), Text: "updated"}); err != nil {
+		t.Fatal(err)
+	}
+	unseen, err := db.GetMessage(chat, "not-seen")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unseen.DeletedAt != nil || unseen.Text != "not-seen" {
+		t.Fatalf("unseen merge row = %+v", unseen)
+	}
+	msgs, err := db.ListMessages(ListMessagesParams{ChatJID: chat, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("merge removed unseen row: %+v", msgs)
+	}
+}
+
+func TestTombstoneFirstImportRetainsLaterHistoryPayload(t *testing.T) {
+	db := openTestDB(t)
+	chat := "chat@s.whatsapp.net"
+	messageAt := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	deletedAt := messageAt.Add(time.Hour)
+	if err := db.UpsertChat(chat, "dm", "Alice", messageAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{ChatJID: chat, MsgID: "mid", Timestamp: deletedAt, Revoked: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID: chat, MsgID: "mid", SenderJID: chat, SenderName: "Alice", Timestamp: messageAt,
+		FromMe: true, Text: "history payload", DisplayText: "history display",
+		IsForwarded: true, ForwardingScore: 2, ReactionToID: "target", ReactionEmoji: "👍",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := db.GetMessage(chat, "mid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !msg.Revoked || msg.DeletedAt == nil || !msg.DeletedAt.Equal(deletedAt) {
+		t.Fatalf("tombstone state = %+v", msg)
+	}
+	if !msg.Timestamp.Equal(messageAt) || !msg.FromMe || msg.Text != "history payload" || msg.DisplayText != "history display" {
+		t.Fatalf("history payload was not retained: %+v", msg)
+	}
+	if !msg.IsForwarded || msg.ForwardingScore != 2 || msg.ReactionToID != "target" || msg.ReactionEmoji != "👍" {
+		t.Fatalf("history metadata was not retained: %+v", msg)
+	}
+}
+
+func TestPurgeMessageRequiresTombstoneAndKeepsSuppressionMarker(t *testing.T) {
+	db := openTestDB(t)
+	chat := "chat@s.whatsapp.net"
+	now := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	if err := db.UpsertChat(chat, "dm", "Alice", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID: chat, MsgID: "mid", Timestamp: now, Text: "retained",
+		MediaType: "document", Filename: "proof.pdf",
+		Buttons: []Button{{Type: "quick_reply", DisplayText: "Keep", ID: "keep"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.PurgeMessage(chat, "mid"); !errors.Is(err, ErrMessageNotTombstoned) {
+		t.Fatalf("live purge error = %v", err)
+	}
+	if err := db.MarkMessageRevoked(chat, "mid"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.PurgeMessage(chat, "mid"); err != nil {
+		t.Fatal(err)
+	}
+	purged, err := db.GetMessage(chat, "mid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if purged.PayloadPurgedAt == nil || purged.DeletedAt == nil || !purged.Revoked {
+		t.Fatalf("purged tombstone metadata = %+v", purged)
+	}
+	if purged.Text != "" || purged.MediaType != "" || purged.Filename != "" || len(purged.Buttons) != 0 {
+		t.Fatalf("purged payload retained data: %+v", purged)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID: chat, MsgID: "mid", Timestamp: now.Add(time.Hour), Text: "restored by history",
+		MediaType: "document", Filename: "restored.pdf",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	purged, err = db.GetMessage(chat, "mid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if purged.Text != "" || purged.Filename != "" || purged.PayloadPurgedAt == nil {
+		t.Fatalf("history import restored purged payload: %+v", purged)
+	}
+	if _, err := db.sql.Exec(`DELETE FROM chats WHERE jid = ?`, chat); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertChat(chat, "dm", "Alice", now.Add(2*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{ChatJID: chat, MsgID: "mid", Timestamp: now.Add(2 * time.Hour), Text: "restored after cleanup"}); err != nil {
+		t.Fatal(err)
+	}
+	var messageCount, purgeCount int
+	if err := db.sql.QueryRow(`SELECT count(*) FROM messages WHERE chat_jid = ? AND msg_id = ?`, chat, "mid").Scan(&messageCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.sql.QueryRow(`SELECT count(*) FROM message_payload_purges WHERE chat_jid = ? AND msg_id = ?`, chat, "mid").Scan(&purgeCount); err != nil {
+		t.Fatal(err)
+	}
+	if messageCount != 0 || purgeCount != 1 {
+		t.Fatalf("post-cleanup suppression counts: messages=%d purges=%d", messageCount, purgeCount)
 	}
 }
 

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -34,6 +34,91 @@ var schemaMigrations = []migration{
 	{version: 18, name: "chat unread count column", up: migrateChatUnreadCountColumn},
 	{version: 19, name: "messages quoted columns", up: migrateMessagesQuotedColumns},
 	{version: 20, name: "messages media_unavailable_at column", up: migrateMessagesMediaUnavailableColumn},
+	{version: 21, name: "message tombstone metadata", up: migrateMessageTombstoneMetadata},
+}
+
+func migrateMessageTombstoneMetadata(d *DB) error {
+	hasTable, err := d.tableExists("messages")
+	if err != nil {
+		return err
+	}
+	if !hasTable {
+		return nil
+	}
+	if err := ensureMessageTombstoneColumns(d); err != nil {
+		return err
+	}
+	if err := ensureMessagePayloadPurgesTable(d); err != nil {
+		return err
+	}
+	if _, err := d.sql.Exec(`
+		UPDATE messages
+		SET deleted_at = COALESCE(deleted_at, ts),
+			deletion_reason = COALESCE(deletion_reason, CASE
+				WHEN deleted_for_me != 0 THEN 'legacy-whatsapp-delete-for-me'
+				WHEN revoked != 0 THEN 'legacy-whatsapp-revoke'
+			END)
+		WHERE revoked != 0 OR deleted_for_me != 0
+	`); err != nil {
+		return fmt.Errorf("backfill message tombstone metadata: %w", err)
+	}
+	if _, err := d.sql.Exec(`
+		INSERT INTO message_payload_purges(chat_jid, msg_id, purged_at, deleted_at, deletion_reason)
+		SELECT chat_jid, msg_id, payload_purged_at, deleted_at, COALESCE(deletion_reason, 'explicit-payload-purge')
+		FROM messages
+		WHERE payload_purged_at IS NOT NULL
+		ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
+			purged_at = min(message_payload_purges.purged_at, excluded.purged_at),
+			deleted_at = min(message_payload_purges.deleted_at, excluded.deleted_at),
+			deletion_reason = COALESCE(NULLIF(message_payload_purges.deletion_reason, ''), excluded.deletion_reason)
+	`); err != nil {
+		return fmt.Errorf("backfill message payload purge ledger: %w", err)
+	}
+	return migrateMessagesFTS(d)
+}
+
+func ensureMessageTombstoneColumns(d *DB) error {
+	hasTable, err := d.tableExists("messages")
+	if err != nil || !hasTable {
+		return err
+	}
+	if err := addMessageColumnIfMissing(d, "deleted_at", `ALTER TABLE messages ADD COLUMN deleted_at INTEGER`); err != nil {
+		return err
+	}
+	if err := addMessageColumnIfMissing(d, "deletion_reason", `ALTER TABLE messages ADD COLUMN deletion_reason TEXT`); err != nil {
+		return err
+	}
+	return addMessageColumnIfMissing(d, "payload_purged_at", `ALTER TABLE messages ADD COLUMN payload_purged_at INTEGER`)
+}
+
+func ensureMessagePayloadPurgesTable(d *DB) error {
+	if _, err := d.sql.Exec(`
+		CREATE TABLE IF NOT EXISTS message_payload_purges (
+			chat_jid TEXT NOT NULL,
+			msg_id TEXT NOT NULL,
+			purged_at INTEGER NOT NULL,
+			deleted_at INTEGER NOT NULL,
+			deletion_reason TEXT NOT NULL,
+			PRIMARY KEY (chat_jid, msg_id)
+		)
+	`); err != nil {
+		return fmt.Errorf("ensure message payload purge ledger: %w", err)
+	}
+	return nil
+}
+
+func addMessageColumnIfMissing(d *DB, column, ddl string) error {
+	has, err := d.tableHasColumn("messages", column)
+	if err != nil {
+		return err
+	}
+	if has {
+		return nil
+	}
+	if _, err := d.sql.Exec(ddl); err != nil {
+		return fmt.Errorf("add messages.%s column: %w", column, err)
+	}
+	return nil
 }
 
 func migrateMessagesMediaUnavailableColumn(d *DB) error {
@@ -129,6 +214,12 @@ func (d *DB) ensureCurrentSchema() error {
 	}
 	if err := migrateMessagesMediaUnavailableColumn(d); err != nil {
 		return fmt.Errorf("ensure current messages media unavailable column: %w", err)
+	}
+	if err := ensureMessageTombstoneColumns(d); err != nil {
+		return fmt.Errorf("ensure current message tombstone columns: %w", err)
+	}
+	if err := ensureMessagePayloadPurgesTable(d); err != nil {
+		return fmt.Errorf("ensure current message payload purge ledger: %w", err)
 	}
 	return nil
 }
@@ -565,7 +656,7 @@ func migrateMessagesFTS(d *DB) error {
 		DROP TRIGGER IF EXISTS messages_ad;
 		DROP TRIGGER IF EXISTS messages_au;
 
-		CREATE TRIGGER messages_ai AFTER INSERT ON messages WHEN new.revoked = 0 AND new.deleted_for_me = 0 BEGIN
+		CREATE TRIGGER messages_ai AFTER INSERT ON messages WHEN new.deleted_at IS NULL BEGIN
 			INSERT INTO messages_fts(rowid, text, media_caption, filename, chat_name, sender_name, display_text)
 			VALUES (new.rowid, COALESCE(new.text,''), COALESCE(new.media_caption,''), COALESCE(new.filename,''), COALESCE(new.chat_name,''), COALESCE(new.sender_name,''), COALESCE(new.display_text,''));
 		END;
@@ -578,7 +669,7 @@ func migrateMessagesFTS(d *DB) error {
 			DELETE FROM messages_fts WHERE rowid = old.rowid;
 			INSERT INTO messages_fts(rowid, text, media_caption, filename, chat_name, sender_name, display_text)
 			SELECT new.rowid, COALESCE(new.text,''), COALESCE(new.media_caption,''), COALESCE(new.filename,''), COALESCE(new.chat_name,''), COALESCE(new.sender_name,''), COALESCE(new.display_text,'')
-			WHERE new.revoked = 0 AND new.deleted_for_me = 0;
+			WHERE new.deleted_at IS NULL;
 		END;
 	`); err != nil {
 		d.ftsEnabled = false
@@ -596,7 +687,7 @@ func migrateMessagesFTS(d *DB) error {
 			       COALESCE(sender_name,''),
 			       COALESCE(display_text,'')
 			FROM messages
-			WHERE revoked = 0 AND deleted_for_me = 0
+			WHERE deleted_at IS NULL
 		`); err != nil {
 			d.ftsEnabled = false
 			return nil

--- a/internal/store/polls.go
+++ b/internal/store/polls.go
@@ -74,6 +74,8 @@ func (d *DB) UpsertPoll(p Poll) error {
 		OptionsJson:     string(optsJSON),
 		SelectableCount: int64(p.SelectableCount),
 		CreatedTs:       createdTS.UTC().Unix(),
+		ChatJid_2:       p.ChatJID,
+		MsgID_2:         p.MsgID,
 	}); err != nil {
 		return fmt.Errorf("upsert poll: %w", err)
 	}
@@ -117,7 +119,8 @@ func (d *DB) ListPolls(filter PollListFilter) ([]Poll, error) {
 	q := `SELECT p.chat_jid, p.msg_id, COALESCE(p.sender_jid,''), p.question, p.options_json, p.selectable_count, p.created_ts
 	      FROM polls p
 	      LEFT JOIN messages m ON m.chat_jid = p.chat_jid AND m.msg_id = p.msg_id
-	      WHERE (m.msg_id IS NULL OR (m.revoked = 0 AND m.deleted_for_me = 0))`
+	      WHERE (m.msg_id IS NULL OR m.deleted_at IS NULL)
+	        AND NOT EXISTS (SELECT 1 FROM message_payload_purges x WHERE x.chat_jid = p.chat_jid AND x.msg_id = p.msg_id)`
 	args := []any{}
 	chatJIDs := cleanPollFilterChatJIDs(filter)
 	switch {
@@ -238,6 +241,10 @@ func (d *DB) UpsertPollVote(v PollVote) error {
 		VoteMsgID:           v.VoteMsgID,
 		SelectedOptionsJson: string(selJSON),
 		Ts:                  ts.UTC().UnixMilli(),
+		ChatJid_2:           v.ChatJID,
+		MsgID:               v.PollMsgID,
+		ChatJid_3:           v.ChatJID,
+		MsgID_2:             v.VoteMsgID,
 	}); err != nil {
 		return fmt.Errorf("upsert poll vote: %w", err)
 	}

--- a/internal/store/polls_test.go
+++ b/internal/store/polls_test.go
@@ -381,6 +381,54 @@ func TestPollQueriesHideDeletedMessages(t *testing.T) {
 	}
 }
 
+func TestPollPayloadCannotReturnAfterMessagePurge(t *testing.T) {
+	db := openTestDB(t)
+	chat := "chat@s.whatsapp.net"
+	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	if err := db.UpsertChat(chat, "dm", "Chat", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{ChatJID: chat, MsgID: "poll", Timestamp: now, Text: "Poll: secret?"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertPoll(Poll{ChatJID: chat, MsgID: "poll", Question: "secret?", Options: []string{"yes", "no"}, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertPollVote(PollVote{ChatJID: chat, PollMsgID: "poll", VoterJID: "voter@s.whatsapp.net", VoteMsgID: "vote", Selected: []string{"yes"}, VotedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.MarkMessageRevoked(chat, "poll"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.PurgeMessage(chat, "poll"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`DELETE FROM chats WHERE jid = ?`, chat); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertChat(chat, "dm", "Chat", now.Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{ChatJID: chat, MsgID: "poll", Timestamp: now.Add(time.Hour), Text: "restored poll"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertPoll(Poll{ChatJID: chat, MsgID: "poll", Question: "restored?", Options: []string{"secret"}, CreatedAt: now.Add(time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertPollVote(PollVote{ChatJID: chat, PollMsgID: "poll", VoterJID: "voter@s.whatsapp.net", VoteMsgID: "vote-2", Selected: []string{"secret"}, VotedAt: now.Add(time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	if got := countRows(t, db.sql, `SELECT count(*) FROM polls WHERE chat_jid = 'chat@s.whatsapp.net' AND msg_id = 'poll'`); got != 0 {
+		t.Fatalf("restored poll rows = %d", got)
+	}
+	if got := countRows(t, db.sql, `SELECT count(*) FROM poll_votes WHERE chat_jid = 'chat@s.whatsapp.net' AND poll_msg_id = 'poll'`); got != 0 {
+		t.Fatalf("restored poll vote rows = %d", got)
+	}
+	if _, err := db.GetPoll(chat, "poll"); !IsPollNotFound(err) {
+		t.Fatalf("GetPoll after purge = %v", err)
+	}
+}
+
 func TestDeletePollRemovesVotes(t *testing.T) {
 	db := openTestDB(t)
 

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -86,6 +86,9 @@ CREATE TABLE IF NOT EXISTS messages (
     media_unavailable_at INTEGER,
     revoked INTEGER NOT NULL DEFAULT 0,
     deleted_for_me INTEGER NOT NULL DEFAULT 0,
+    deleted_at INTEGER,
+    deletion_reason TEXT,
+    payload_purged_at INTEGER,
     edited INTEGER NOT NULL DEFAULT 0,
     edited_ts INTEGER NOT NULL DEFAULT 0,
     buttons TEXT,
@@ -95,6 +98,15 @@ CREATE TABLE IF NOT EXISTS messages (
 
 CREATE INDEX IF NOT EXISTS idx_messages_chat_ts ON messages(chat_jid, ts);
 CREATE INDEX IF NOT EXISTS idx_messages_ts ON messages(ts);
+
+CREATE TABLE IF NOT EXISTS message_payload_purges (
+    chat_jid TEXT NOT NULL,
+    msg_id TEXT NOT NULL,
+    purged_at INTEGER NOT NULL,
+    deleted_at INTEGER NOT NULL,
+    deletion_reason TEXT NOT NULL,
+    PRIMARY KEY (chat_jid, msg_id)
+);
 
 CREATE TABLE IF NOT EXISTS status_messages (
     rowid INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/store/schema_test.go
+++ b/internal/store/schema_test.go
@@ -38,12 +38,18 @@ func TestOpenCreatesExpectedSchema(t *testing.T) {
 		"media_unavailable_at",
 		"revoked",
 		"deleted_for_me",
+		"deleted_at",
+		"deletion_reason",
+		"payload_purged_at",
 		"edited",
 		"edited_ts",
 	} {
 		if !cols[want] {
 			t.Fatalf("expected messages column %q to exist", want)
 		}
+	}
+	if exists, err := db.tableExists("message_payload_purges"); err != nil || !exists {
+		t.Fatalf("message_payload_purges table exists = %v, err = %v", exists, err)
 	}
 
 	callCols, err := tableColumns(db.sql, "call_events")
@@ -109,6 +115,66 @@ func TestOpenCreatesExpectedSchema(t *testing.T) {
 	}
 	if !indexExists(t, db.sql, "idx_status_messages_ts") {
 		t.Fatalf("expected status_messages timestamp index to exist")
+	}
+}
+
+func TestOpenMigratesLegacyMessageTombstonesWithoutPayloadLoss(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wacli.db")
+	raw, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacySchema := strings.Replace(coreSchemaSQL, "    deleted_at INTEGER,\n    deletion_reason TEXT,\n    payload_purged_at INTEGER,\n", "", 1)
+	legacySchema = strings.Replace(legacySchema, `CREATE TABLE IF NOT EXISTS message_payload_purges (
+    chat_jid TEXT NOT NULL,
+    msg_id TEXT NOT NULL,
+    purged_at INTEGER NOT NULL,
+    deleted_at INTEGER NOT NULL,
+    deletion_reason TEXT NOT NULL,
+    PRIMARY KEY (chat_jid, msg_id)
+);
+
+`, "", 1)
+	if _, err := raw.Exec(legacySchema + `
+		CREATE TABLE schema_migrations (
+			version INTEGER PRIMARY KEY,
+			name TEXT NOT NULL,
+			applied_at INTEGER NOT NULL
+		);
+		INSERT INTO chats(jid, kind, name) VALUES('chat@s.whatsapp.net', 'dm', 'Alice');
+		INSERT INTO messages(chat_jid, msg_id, ts, from_me, text, display_text, media_type, filename, revoked, buttons)
+		VALUES('chat@s.whatsapp.net', 'mid', 123, 1, 'retained text', 'retained display', 'document', 'proof.pdf', 1, '[{"type":"url","display_text":"Open","url":"https://example.com"}]');
+	`); err != nil {
+		_ = raw.Close()
+		t.Fatalf("create legacy store: %v", err)
+	}
+	for _, migration := range schemaMigrations {
+		if migration.version >= 21 {
+			continue
+		}
+		if _, err := raw.Exec(`INSERT INTO schema_migrations(version, name, applied_at) VALUES(?, ?, 1)`, migration.version, migration.name); err != nil {
+			_ = raw.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open migrated store: %v", err)
+	}
+	defer db.Close()
+	msg, err := db.GetMessage("chat@s.whatsapp.net", "mid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Text != "retained text" || msg.DisplayText != "retained display" || msg.MediaType != "document" || msg.Filename != "proof.pdf" || len(msg.Buttons) != 1 {
+		t.Fatalf("migrated payload = %+v", msg)
+	}
+	if msg.DeletedAt == nil || msg.DeletedAt.Unix() != 123 || msg.DeletionReason != "legacy-whatsapp-revoke" {
+		t.Fatalf("migrated tombstone = %v %q", msg.DeletedAt, msg.DeletionReason)
 	}
 }
 

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -60,7 +60,7 @@ func (d *DB) searchLIKE(p SearchMessagesParams) ([]Message, error) {
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
-	WHERE m.revoked = 0 AND m.deleted_for_me = 0 AND (LOWER(m.text) LIKE LOWER(?) ESCAPE '\' OR LOWER(m.display_text) LIKE LOWER(?) ESCAPE '\' OR LOWER(m.media_caption) LIKE LOWER(?) ESCAPE '\' OR LOWER(m.filename) LIKE LOWER(?) ESCAPE '\' OR LOWER(COALESCE(m.chat_name,'')) LIKE LOWER(?) ESCAPE '\' OR LOWER(COALESCE(m.sender_name,'')) LIKE LOWER(?) ESCAPE '\' OR LOWER(COALESCE(c.name,'')) LIKE LOWER(?) ESCAPE '\')`
+	WHERE m.deleted_at IS NULL AND (LOWER(m.text) LIKE LOWER(?) ESCAPE '\' OR LOWER(m.display_text) LIKE LOWER(?) ESCAPE '\' OR LOWER(m.media_caption) LIKE LOWER(?) ESCAPE '\' OR LOWER(m.filename) LIKE LOWER(?) ESCAPE '\' OR LOWER(COALESCE(m.chat_name,'')) LIKE LOWER(?) ESCAPE '\' OR LOWER(COALESCE(m.sender_name,'')) LIKE LOWER(?) ESCAPE '\' OR LOWER(COALESCE(c.name,'')) LIKE LOWER(?) ESCAPE '\')`
 	// Escape wildcards before wrapping in % so user input is literal (#56).
 	needle := likeContains(p.Query)
 	args := []interface{}{needle, needle, needle, needle, needle, needle, needle}
@@ -95,7 +95,7 @@ func (d *DB) searchFTS(p SearchMessagesParams) ([]Message, error) {
 		JOIN messages m ON messages_fts.rowid = m.rowid
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
-		WHERE messages_fts MATCH ? AND m.revoked = 0 AND m.deleted_for_me = 0`
+		WHERE messages_fts MATCH ? AND m.deleted_at IS NULL`
 	// Sanitize to prevent FTS5 query-syntax injection (#57).
 	// Each token is individually quoted so multi-word queries still work
 	// as implicit AND (both words present, any order).

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -173,67 +173,60 @@ INSERT INTO messages(
     quoted_msg_id, quoted_sender_jid,
     is_forwarded, forwarding_score, reaction_to_id, reaction_emoji,
     media_type, media_caption, filename, mime_type, direct_path,
-    media_key, file_sha256, file_enc_sha256, file_length, revoked, deleted_for_me, edited, edited_ts, buttons
-) VALUES (
+    media_key, file_sha256, file_enc_sha256, file_length, revoked, deleted_for_me,
+    deleted_at, deletion_reason, edited, edited_ts, buttons
+) SELECT
     ?, ?, ?, ?, ?,
     ?, ?, ?, ?,
     ?, ?,
     ?, ?, ?, ?,
     ?, ?, ?, ?, ?,
     ?, ?, ?, ?,
-    ?, ?, ?, ?, ?
+    ?, ?, ?, ?,
+    ?, ?, ?
+WHERE NOT EXISTS (
+    SELECT 1 FROM message_payload_purges p WHERE p.chat_jid = ? AND p.msg_id = ?
 )
 ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
     chat_name=COALESCE(NULLIF(excluded.chat_name,''), messages.chat_name),
-    sender_jid=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.sender_jid ELSE excluded.sender_jid END,
-    sender_name=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.sender_name ELSE COALESCE(NULLIF(excluded.sender_name,''), messages.sender_name) END,
-    ts=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 THEN messages.ts WHEN excluded.edited != 0 THEN messages.ts WHEN messages.edited != 0 AND excluded.edited = 0 THEN excluded.ts WHEN excluded.ts < messages.ts AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.ts ELSE excluded.ts END,
-    from_me=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.from_me ELSE excluded.from_me END,
-    text=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.text ELSE excluded.text END,
-    display_text=CASE WHEN excluded.deleted_for_me != 0 THEN excluded.display_text WHEN messages.deleted_for_me != 0 THEN messages.display_text WHEN excluded.revoked != 0 THEN excluded.display_text WHEN messages.revoked != 0 THEN messages.display_text WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.display_text WHEN excluded.display_text IS NOT NULL AND excluded.display_text != '' THEN excluded.display_text ELSE messages.display_text END,
-    quoted_msg_id=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.quoted_msg_id ELSE COALESCE(NULLIF(excluded.quoted_msg_id,''), messages.quoted_msg_id) END,
-    quoted_sender_jid=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.quoted_sender_jid ELSE COALESCE(NULLIF(excluded.quoted_sender_jid,''), messages.quoted_sender_jid) END,
-    is_forwarded=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.is_forwarded ELSE excluded.is_forwarded END,
-    forwarding_score=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.forwarding_score ELSE excluded.forwarding_score END,
-    reaction_to_id=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.reaction_to_id ELSE COALESCE(NULLIF(excluded.reaction_to_id,''), messages.reaction_to_id) END,
-    reaction_emoji=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.reaction_emoji ELSE COALESCE(NULLIF(excluded.reaction_emoji,''), messages.reaction_emoji) END,
-    media_type=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_type ELSE excluded.media_type END,
-    media_caption=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_caption ELSE excluded.media_caption END,
-    filename=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.filename ELSE COALESCE(NULLIF(excluded.filename,''), messages.filename) END,
-    mime_type=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.mime_type ELSE COALESCE(NULLIF(excluded.mime_type,''), messages.mime_type) END,
-    direct_path=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.direct_path ELSE COALESCE(NULLIF(excluded.direct_path,''), messages.direct_path) END,
-    media_key=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_key WHEN excluded.media_key IS NOT NULL AND length(excluded.media_key)>0 THEN excluded.media_key ELSE messages.media_key END,
-    file_sha256=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.file_sha256 WHEN excluded.file_sha256 IS NOT NULL AND length(excluded.file_sha256)>0 THEN excluded.file_sha256 ELSE messages.file_sha256 END,
-    file_enc_sha256=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.file_enc_sha256 WHEN excluded.file_enc_sha256 IS NOT NULL AND length(excluded.file_enc_sha256)>0 THEN excluded.file_enc_sha256 ELSE messages.file_enc_sha256 END,
-    file_length=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.file_length WHEN excluded.file_length>0 THEN excluded.file_length ELSE messages.file_length END,
-    local_path=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE messages.local_path END,
-    downloaded_at=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE messages.downloaded_at END,
-    media_unavailable_at=CASE WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_unavailable_at WHEN COALESCE(excluded.direct_path,'') != '' AND excluded.direct_path != COALESCE(messages.direct_path,'') THEN NULL ELSE messages.media_unavailable_at END,
+    sender_jid=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.sender_jid,''), excluded.sender_jid) WHEN (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.sender_jid ELSE excluded.sender_jid END,
+    sender_name=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.sender_name,''), excluded.sender_name) WHEN (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.sender_name ELSE COALESCE(NULLIF(excluded.sender_name,''), messages.sender_name) END,
+    ts=CASE WHEN messages.deleted_at IS NOT NULL AND excluded.deleted_at IS NULL AND COALESCE(messages.text,'') = '' AND COALESCE(NULLIF(NULLIF(messages.display_text, 'This message was deleted'), 'This message was deleted for me'),'') = '' AND COALESCE(messages.media_type,'') = '' AND COALESCE(messages.quoted_msg_id,'') = '' AND messages.buttons IS NULL THEN excluded.ts WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN messages.ts WHEN excluded.edited != 0 THEN messages.ts WHEN messages.edited != 0 AND excluded.edited = 0 THEN excluded.ts WHEN excluded.ts < messages.ts AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.ts ELSE excluded.ts END,
+    from_me=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN CASE WHEN messages.from_me != 0 OR excluded.from_me != 0 THEN 1 ELSE 0 END WHEN (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.from_me ELSE excluded.from_me END,
+    text=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.text,''), excluded.text) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.text ELSE excluded.text END,
+    display_text=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(NULLIF(NULLIF(messages.display_text,''), 'This message was deleted'), 'This message was deleted for me'), excluded.display_text) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.display_text WHEN excluded.display_text IS NOT NULL AND excluded.display_text != '' THEN excluded.display_text ELSE messages.display_text END,
+    quoted_msg_id=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.quoted_msg_id,''), excluded.quoted_msg_id) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.quoted_msg_id ELSE COALESCE(NULLIF(excluded.quoted_msg_id,''), messages.quoted_msg_id) END,
+    quoted_sender_jid=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.quoted_sender_jid,''), excluded.quoted_sender_jid) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.quoted_sender_jid ELSE COALESCE(NULLIF(excluded.quoted_sender_jid,''), messages.quoted_sender_jid) END,
+    is_forwarded=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN CASE WHEN messages.is_forwarded != 0 OR excluded.is_forwarded != 0 THEN 1 ELSE 0 END WHEN (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.is_forwarded ELSE excluded.is_forwarded END,
+    forwarding_score=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN max(messages.forwarding_score, excluded.forwarding_score) WHEN (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.forwarding_score ELSE excluded.forwarding_score END,
+    reaction_to_id=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.reaction_to_id,''), excluded.reaction_to_id) WHEN (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.reaction_to_id ELSE COALESCE(NULLIF(excluded.reaction_to_id,''), messages.reaction_to_id) END,
+    reaction_emoji=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.reaction_emoji,''), excluded.reaction_emoji) WHEN (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.reaction_emoji ELSE COALESCE(NULLIF(excluded.reaction_emoji,''), messages.reaction_emoji) END,
+    media_type=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.media_type,''), excluded.media_type) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_type ELSE excluded.media_type END,
+    media_caption=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.media_caption,''), excluded.media_caption) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_caption ELSE excluded.media_caption END,
+    filename=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.filename,''), excluded.filename) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.filename ELSE COALESCE(NULLIF(excluded.filename,''), messages.filename) END,
+    mime_type=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.mime_type,''), excluded.mime_type) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.mime_type ELSE COALESCE(NULLIF(excluded.mime_type,''), messages.mime_type) END,
+    direct_path=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.direct_path,''), excluded.direct_path) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.direct_path ELSE COALESCE(NULLIF(excluded.direct_path,''), messages.direct_path) END,
+    media_key=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN CASE WHEN messages.media_key IS NOT NULL AND length(messages.media_key)>0 THEN messages.media_key ELSE excluded.media_key END WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_key WHEN excluded.media_key IS NOT NULL AND length(excluded.media_key)>0 THEN excluded.media_key ELSE messages.media_key END,
+    file_sha256=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN CASE WHEN messages.file_sha256 IS NOT NULL AND length(messages.file_sha256)>0 THEN messages.file_sha256 ELSE excluded.file_sha256 END WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.file_sha256 WHEN excluded.file_sha256 IS NOT NULL AND length(excluded.file_sha256)>0 THEN excluded.file_sha256 ELSE messages.file_sha256 END,
+    file_enc_sha256=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN CASE WHEN messages.file_enc_sha256 IS NOT NULL AND length(messages.file_enc_sha256)>0 THEN messages.file_enc_sha256 ELSE excluded.file_enc_sha256 END WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.file_enc_sha256 WHEN excluded.file_enc_sha256 IS NOT NULL AND length(excluded.file_enc_sha256)>0 THEN excluded.file_enc_sha256 ELSE messages.file_enc_sha256 END,
+    file_length=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN CASE WHEN messages.file_length IS NOT NULL AND messages.file_length>0 THEN messages.file_length ELSE excluded.file_length END WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.file_length WHEN excluded.file_length>0 THEN excluded.file_length ELSE messages.file_length END,
+    local_path=messages.local_path,
+    downloaded_at=messages.downloaded_at,
+    media_unavailable_at=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN messages.media_unavailable_at WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_unavailable_at WHEN COALESCE(excluded.direct_path,'') != '' AND excluded.direct_path != COALESCE(messages.direct_path,'') THEN NULL ELSE messages.media_unavailable_at END,
     revoked=CASE WHEN excluded.revoked != 0 THEN 1 ELSE messages.revoked END,
     deleted_for_me=CASE WHEN excluded.deleted_for_me != 0 THEN 1 ELSE messages.deleted_for_me END,
-    edited=CASE WHEN excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN 0 WHEN excluded.edited != 0 THEN 1 WHEN messages.edited != 0 THEN messages.edited ELSE 0 END,
-    edited_ts=CASE WHEN excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN 0 WHEN excluded.edited != 0 AND (messages.edited = 0 OR excluded.edited_ts > messages.edited_ts) THEN excluded.edited_ts WHEN messages.edited != 0 THEN messages.edited_ts ELSE 0 END,
-    buttons=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.buttons ELSE excluded.buttons END;
+    deleted_at=COALESCE(messages.deleted_at, excluded.deleted_at),
+    deletion_reason=CASE WHEN messages.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.deletion_reason,''), excluded.deletion_reason) ELSE excluded.deletion_reason END,
+    edited=CASE WHEN messages.deleted_at IS NOT NULL THEN messages.edited WHEN excluded.deleted_at IS NOT NULL THEN 0 WHEN excluded.edited != 0 THEN 1 WHEN messages.edited != 0 THEN messages.edited ELSE 0 END,
+    edited_ts=CASE WHEN messages.deleted_at IS NOT NULL THEN messages.edited_ts WHEN excluded.deleted_at IS NOT NULL THEN 0 WHEN excluded.edited != 0 AND (messages.edited = 0 OR excluded.edited_ts > messages.edited_ts) THEN excluded.edited_ts WHEN messages.edited != 0 THEN messages.edited_ts ELSE 0 END,
+    buttons=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(messages.buttons, excluded.buttons) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.buttons ELSE excluded.buttons END
+WHERE messages.payload_purged_at IS NULL;
 
 -- name: MarkMessageRevoked :execrows
 UPDATE messages
 SET revoked = 1,
-    text = NULL,
-    display_text = ?,
-    buttons = NULL,
-    quoted_msg_id = NULL,
-    quoted_sender_jid = NULL,
-    media_type = NULL,
-    media_caption = NULL,
-    filename = NULL,
-    mime_type = NULL,
-    direct_path = NULL,
-    media_key = NULL,
-    file_sha256 = NULL,
-    file_enc_sha256 = NULL,
-    file_length = NULL,
-    local_path = NULL,
-    downloaded_at = NULL,
+    deleted_at = COALESCE(deleted_at, ?),
+    deletion_reason = CASE WHEN deleted_at IS NULL THEN ? ELSE deletion_reason END,
     edited = 0,
     edited_ts = 0
 WHERE chat_jid = ? AND msg_id = ?;
@@ -241,22 +234,8 @@ WHERE chat_jid = ? AND msg_id = ?;
 -- name: MarkMessageDeletedForMe :execrows
 UPDATE messages
 SET deleted_for_me = 1,
-    text = NULL,
-    display_text = ?,
-    buttons = NULL,
-    quoted_msg_id = NULL,
-    quoted_sender_jid = NULL,
-    media_type = NULL,
-    media_caption = NULL,
-    filename = NULL,
-    mime_type = NULL,
-    direct_path = NULL,
-    media_key = NULL,
-    file_sha256 = NULL,
-    file_enc_sha256 = NULL,
-    file_length = NULL,
-    local_path = NULL,
-    downloaded_at = NULL,
+    deleted_at = COALESCE(deleted_at, ?),
+    deletion_reason = CASE WHEN deleted_at IS NULL THEN ? ELSE deletion_reason END,
     edited = 0,
     edited_ts = 0
 WHERE chat_jid = ? AND msg_id = ?;
@@ -264,11 +243,8 @@ WHERE chat_jid = ? AND msg_id = ?;
 -- name: MarkMessageDeletedForMePreserveMedia :execrows
 UPDATE messages
 SET deleted_for_me = 1,
-    text = NULL,
-    display_text = ?,
-    buttons = NULL,
-    quoted_msg_id = NULL,
-    quoted_sender_jid = NULL
+    deleted_at = COALESCE(deleted_at, ?),
+    deletion_reason = CASE WHEN deleted_at IS NULL THEN ? ELSE deletion_reason END
 WHERE chat_jid = ? AND msg_id = ?;
 
 -- name: UpdateMessageText :execrows
@@ -287,14 +263,12 @@ SET text = ?,
     file_length = NULL,
     local_path = NULL,
     downloaded_at = NULL,
-    revoked = 0,
-    deleted_for_me = 0,
     edited = 1,
     edited_ts = strftime('%s', 'now')
-WHERE chat_jid = ? AND msg_id = ?;
+WHERE chat_jid = ? AND msg_id = ? AND deleted_at IS NULL;
 
 -- name: GetMessage :one
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
@@ -318,20 +292,20 @@ ORDER BY m.ts DESC, m.rowid DESC
 LIMIT 1;
 
 -- name: MessageContextBefore :many
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
-WHERE m.chat_jid = ? AND m.revoked = 0 AND m.deleted_for_me = 0 AND (m.ts < ? OR (m.ts = ? AND m.rowid < ?))
+WHERE m.chat_jid = ? AND m.deleted_at IS NULL AND (m.ts < ? OR (m.ts = ? AND m.rowid < ?))
 ORDER BY m.ts DESC, m.rowid DESC
 LIMIT ?;
 
 -- name: MessageContextAfter :many
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
-WHERE m.chat_jid = ? AND m.revoked = 0 AND m.deleted_for_me = 0 AND (m.ts > ? OR (m.ts = ? AND m.rowid > ?))
+WHERE m.chat_jid = ? AND m.deleted_at IS NULL AND (m.ts > ? OR (m.ts = ? AND m.rowid > ?))
 ORDER BY m.ts ASC, m.rowid ASC
 LIMIT ?;
 
@@ -385,8 +359,7 @@ WHERE COALESCE(m.media_type,'') != ''
   AND COALESCE(m.direct_path,'') != ''
   AND m.media_key IS NOT NULL AND length(m.media_key) > 0
   AND COALESCE(m.local_path,'') = ''
-  AND m.revoked = 0
-  AND m.deleted_for_me = 0
+  AND m.deleted_at IS NULL
   AND m.media_unavailable_at IS NULL
   AND (sqlc.arg(chat_jid) = '' OR m.chat_jid = sqlc.arg(chat_jid));
 
@@ -397,8 +370,7 @@ WHERE COALESCE(m.media_type,'') != ''
   AND COALESCE(m.direct_path,'') != ''
   AND m.media_key IS NOT NULL AND length(m.media_key) > 0
   AND COALESCE(m.local_path,'') = ''
-  AND m.revoked = 0
-  AND m.deleted_for_me = 0
+  AND m.deleted_at IS NULL
   AND m.media_unavailable_at IS NULL
   AND (sqlc.arg(chat_jid) = '' OR m.chat_jid = sqlc.arg(chat_jid))
 ORDER BY m.ts DESC, m.rowid DESC
@@ -411,8 +383,7 @@ WHERE COALESCE(m.media_type,'') != ''
   AND COALESCE(m.direct_path,'') != ''
   AND m.media_key IS NOT NULL AND length(m.media_key) > 0
   AND COALESCE(m.local_path,'') = ''
-  AND m.revoked = 0
-  AND m.deleted_for_me = 0
+  AND m.deleted_at IS NULL
   AND m.media_unavailable_at IS NULL
   AND m.ts < sqlc.arg(before_ts)
   AND (sqlc.arg(chat_jid) = '' OR m.chat_jid = sqlc.arg(chat_jid))
@@ -421,7 +392,10 @@ LIMIT CASE WHEN sqlc.arg(limit_count) <= 0 THEN -1 ELSE sqlc.arg(limit_count) EN
 
 -- name: UpsertPoll :exec
 INSERT INTO polls (chat_jid, msg_id, sender_jid, question, options_json, selectable_count, created_ts)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+SELECT ?, ?, ?, ?, ?, ?, ?
+WHERE NOT EXISTS (
+    SELECT 1 FROM message_payload_purges p WHERE p.chat_jid = ? AND p.msg_id = ?
+)
 ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
     sender_jid = excluded.sender_jid,
     question = excluded.question,
@@ -434,14 +408,16 @@ SELECT p.chat_jid, p.msg_id, COALESCE(p.sender_jid,''), p.question, p.options_js
 FROM polls p
 LEFT JOIN messages m ON m.chat_jid = p.chat_jid AND m.msg_id = p.msg_id
 WHERE p.chat_jid = ? AND p.msg_id = ?
-  AND (m.msg_id IS NULL OR (m.revoked = 0 AND m.deleted_for_me = 0));
+  AND (m.msg_id IS NULL OR m.deleted_at IS NULL)
+  AND NOT EXISTS (SELECT 1 FROM message_payload_purges x WHERE x.chat_jid = p.chat_jid AND x.msg_id = p.msg_id);
 
 -- name: FindPollByMsgID :one
 SELECT p.chat_jid, p.msg_id, COALESCE(p.sender_jid,''), p.question, p.options_json, p.selectable_count, p.created_ts
 FROM polls p
 LEFT JOIN messages m ON m.chat_jid = p.chat_jid AND m.msg_id = p.msg_id
 WHERE p.msg_id = ?
-  AND (m.msg_id IS NULL OR (m.revoked = 0 AND m.deleted_for_me = 0))
+  AND (m.msg_id IS NULL OR m.deleted_at IS NULL)
+  AND NOT EXISTS (SELECT 1 FROM message_payload_purges x WHERE x.chat_jid = p.chat_jid AND x.msg_id = p.msg_id)
 ORDER BY p.created_ts DESC
 LIMIT 1;
 
@@ -449,7 +425,8 @@ LIMIT 1;
 SELECT p.chat_jid, p.msg_id, COALESCE(p.sender_jid,''), p.question, p.options_json, p.selectable_count, p.created_ts
 FROM polls p
 LEFT JOIN messages m ON m.chat_jid = p.chat_jid AND m.msg_id = p.msg_id
-WHERE (m.msg_id IS NULL OR (m.revoked = 0 AND m.deleted_for_me = 0))
+WHERE (m.msg_id IS NULL OR m.deleted_at IS NULL)
+  AND NOT EXISTS (SELECT 1 FROM message_payload_purges x WHERE x.chat_jid = p.chat_jid AND x.msg_id = p.msg_id)
   AND (? = '' OR p.chat_jid = ?)
 ORDER BY p.created_ts DESC, p.msg_id DESC
 LIMIT ? OFFSET ?;
@@ -459,7 +436,13 @@ SELECT options_json FROM polls WHERE chat_jid = ? AND msg_id = ?;
 
 -- name: UpsertPollVote :exec
 INSERT INTO poll_votes (chat_jid, poll_msg_id, voter_jid, vote_msg_id, selected_options_json, ts)
-VALUES (?, ?, ?, ?, ?, ?)
+SELECT ?, ?, ?, ?, ?, ?
+WHERE NOT EXISTS (
+    SELECT 1 FROM message_payload_purges p WHERE p.chat_jid = ? AND p.msg_id = ?
+)
+  AND NOT EXISTS (
+    SELECT 1 FROM message_payload_purges p WHERE p.chat_jid = ? AND p.msg_id = ?
+)
 ON CONFLICT(chat_jid, poll_msg_id, voter_jid) DO UPDATE SET
     vote_msg_id = excluded.vote_msg_id,
     selected_options_json = excluded.selected_options_json,
@@ -471,10 +454,15 @@ DELETE FROM poll_votes
 WHERE chat_jid = ? AND poll_msg_id = ? AND voter_jid = ? AND ts <= ?;
 
 -- name: ListPollVotes :many
-SELECT chat_jid, poll_msg_id, voter_jid, vote_msg_id, selected_options_json, ts
-FROM poll_votes
-WHERE chat_jid = ? AND poll_msg_id = ?
-ORDER BY ts ASC, voter_jid ASC;
+SELECT pv.chat_jid, pv.poll_msg_id, pv.voter_jid, pv.vote_msg_id, pv.selected_options_json, pv.ts
+FROM poll_votes pv
+WHERE pv.chat_jid = ? AND pv.poll_msg_id = ?
+  AND NOT EXISTS (
+      SELECT 1 FROM message_payload_purges p
+      WHERE p.chat_jid = pv.chat_jid
+        AND (p.msg_id = pv.poll_msg_id OR p.msg_id = pv.vote_msg_id)
+  )
+ORDER BY pv.ts ASC, pv.voter_jid ASC;
 
 -- name: DeletePollVotesForPoll :exec
 DELETE FROM poll_votes WHERE chat_jid = ? AND poll_msg_id = ?;

--- a/internal/store/starred.go
+++ b/internal/store/starred.go
@@ -60,7 +60,7 @@ func (d *DB) ListStarredMessages(p ListStarredMessagesParams) ([]Message, error)
 		FROM messages m
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
-		WHERE m.revoked = 0 AND m.deleted_for_me = 0`
+		WHERE m.deleted_at IS NULL`
 	var args []interface{}
 	query, args = appendStringFilter(query, args, "m.chat_jid", p.ChatJID, p.ChatJIDs)
 	if p.After != nil {

--- a/internal/store/storedb/models.go
+++ b/internal/store/storedb/models.go
@@ -112,9 +112,20 @@ type Message struct {
 	MediaUnavailableAt sql.NullInt64
 	Revoked            int64
 	DeletedForMe       int64
+	DeletedAt          sql.NullInt64
+	DeletionReason     sql.NullString
+	PayloadPurgedAt    sql.NullInt64
 	Edited             int64
 	EditedTs           int64
 	Buttons            sql.NullString
+}
+
+type MessagePayloadPurge struct {
+	ChatJid        string
+	MsgID          string
+	PurgedAt       int64
+	DeletedAt      int64
+	DeletionReason string
 }
 
 type MessagesFt struct {

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -101,8 +101,7 @@ WHERE COALESCE(m.media_type,'') != ''
   AND COALESCE(m.direct_path,'') != ''
   AND m.media_key IS NOT NULL AND length(m.media_key) > 0
   AND COALESCE(m.local_path,'') = ''
-  AND m.revoked = 0
-  AND m.deleted_for_me = 0
+  AND m.deleted_at IS NULL
   AND m.media_unavailable_at IS NULL
   AND (?1 = '' OR m.chat_jid = ?1)
 `
@@ -258,7 +257,8 @@ SELECT p.chat_jid, p.msg_id, COALESCE(p.sender_jid,''), p.question, p.options_js
 FROM polls p
 LEFT JOIN messages m ON m.chat_jid = p.chat_jid AND m.msg_id = p.msg_id
 WHERE p.msg_id = ?
-  AND (m.msg_id IS NULL OR (m.revoked = 0 AND m.deleted_for_me = 0))
+  AND (m.msg_id IS NULL OR m.deleted_at IS NULL)
+  AND NOT EXISTS (SELECT 1 FROM message_payload_purges x WHERE x.chat_jid = p.chat_jid AND x.msg_id = p.msg_id)
 ORDER BY p.created_ts DESC
 LIMIT 1
 `
@@ -451,7 +451,7 @@ func (q *Queries) GetMediaDownloadInfo(ctx context.Context, arg GetMediaDownload
 }
 
 const getMessage = `-- name: GetMessage :one
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
@@ -491,8 +491,11 @@ type GetMessageRow struct {
 	StarredAt       int64
 	Revoked         int64
 	DeletedForMe    int64
+	DeletedAt       int64
+	DeletionReason  string
+	PayloadPurgedAt int64
 	Buttons         string
-	Column29        string
+	Column32        string
 }
 
 func (q *Queries) GetMessage(ctx context.Context, arg GetMessageParams) (GetMessageRow, error) {
@@ -526,8 +529,11 @@ func (q *Queries) GetMessage(ctx context.Context, arg GetMessageParams) (GetMess
 		&i.StarredAt,
 		&i.Revoked,
 		&i.DeletedForMe,
+		&i.DeletedAt,
+		&i.DeletionReason,
+		&i.PayloadPurgedAt,
 		&i.Buttons,
-		&i.Column29,
+		&i.Column32,
 	)
 	return i, err
 }
@@ -568,7 +574,8 @@ SELECT p.chat_jid, p.msg_id, COALESCE(p.sender_jid,''), p.question, p.options_js
 FROM polls p
 LEFT JOIN messages m ON m.chat_jid = p.chat_jid AND m.msg_id = p.msg_id
 WHERE p.chat_jid = ? AND p.msg_id = ?
-  AND (m.msg_id IS NULL OR (m.revoked = 0 AND m.deleted_for_me = 0))
+  AND (m.msg_id IS NULL OR m.deleted_at IS NULL)
+  AND NOT EXISTS (SELECT 1 FROM message_payload_purges x WHERE x.chat_jid = p.chat_jid AND x.msg_id = p.msg_id)
 `
 
 type GetPollParams struct {
@@ -759,8 +766,7 @@ WHERE COALESCE(m.media_type,'') != ''
   AND COALESCE(m.direct_path,'') != ''
   AND m.media_key IS NOT NULL AND length(m.media_key) > 0
   AND COALESCE(m.local_path,'') = ''
-  AND m.revoked = 0
-  AND m.deleted_for_me = 0
+  AND m.deleted_at IS NULL
   AND m.media_unavailable_at IS NULL
   AND m.ts < ?1
   AND (?2 = '' OR m.chat_jid = ?2)
@@ -809,8 +815,7 @@ WHERE COALESCE(m.media_type,'') != ''
   AND COALESCE(m.direct_path,'') != ''
   AND m.media_key IS NOT NULL AND length(m.media_key) > 0
   AND COALESCE(m.local_path,'') = ''
-  AND m.revoked = 0
-  AND m.deleted_for_me = 0
+  AND m.deleted_at IS NULL
   AND m.media_unavailable_at IS NULL
   AND (?1 = '' OR m.chat_jid = ?1)
 ORDER BY m.ts DESC, m.rowid DESC
@@ -851,10 +856,15 @@ func (q *Queries) ListPendingMediaDownloads(ctx context.Context, arg ListPending
 }
 
 const listPollVotes = `-- name: ListPollVotes :many
-SELECT chat_jid, poll_msg_id, voter_jid, vote_msg_id, selected_options_json, ts
-FROM poll_votes
-WHERE chat_jid = ? AND poll_msg_id = ?
-ORDER BY ts ASC, voter_jid ASC
+SELECT pv.chat_jid, pv.poll_msg_id, pv.voter_jid, pv.vote_msg_id, pv.selected_options_json, pv.ts
+FROM poll_votes pv
+WHERE pv.chat_jid = ? AND pv.poll_msg_id = ?
+  AND NOT EXISTS (
+      SELECT 1 FROM message_payload_purges p
+      WHERE p.chat_jid = pv.chat_jid
+        AND (p.msg_id = pv.poll_msg_id OR p.msg_id = pv.vote_msg_id)
+  )
+ORDER BY pv.ts ASC, pv.voter_jid ASC
 `
 
 type ListPollVotesParams struct {
@@ -896,7 +906,8 @@ const listPolls = `-- name: ListPolls :many
 SELECT p.chat_jid, p.msg_id, COALESCE(p.sender_jid,''), p.question, p.options_json, p.selectable_count, p.created_ts
 FROM polls p
 LEFT JOIN messages m ON m.chat_jid = p.chat_jid AND m.msg_id = p.msg_id
-WHERE (m.msg_id IS NULL OR (m.revoked = 0 AND m.deleted_for_me = 0))
+WHERE (m.msg_id IS NULL OR m.deleted_at IS NULL)
+  AND NOT EXISTS (SELECT 1 FROM message_payload_purges x WHERE x.chat_jid = p.chat_jid AND x.msg_id = p.msg_id)
   AND (? = '' OR p.chat_jid = ?)
 ORDER BY p.created_ts DESC, p.msg_id DESC
 LIMIT ? OFFSET ?
@@ -1036,35 +1047,27 @@ func (q *Queries) MarkMediaUnavailable(ctx context.Context, arg MarkMediaUnavail
 const markMessageDeletedForMe = `-- name: MarkMessageDeletedForMe :execrows
 UPDATE messages
 SET deleted_for_me = 1,
-    text = NULL,
-    display_text = ?,
-    buttons = NULL,
-    quoted_msg_id = NULL,
-    quoted_sender_jid = NULL,
-    media_type = NULL,
-    media_caption = NULL,
-    filename = NULL,
-    mime_type = NULL,
-    direct_path = NULL,
-    media_key = NULL,
-    file_sha256 = NULL,
-    file_enc_sha256 = NULL,
-    file_length = NULL,
-    local_path = NULL,
-    downloaded_at = NULL,
+    deleted_at = COALESCE(deleted_at, ?),
+    deletion_reason = CASE WHEN deleted_at IS NULL THEN ? ELSE deletion_reason END,
     edited = 0,
     edited_ts = 0
 WHERE chat_jid = ? AND msg_id = ?
 `
 
 type MarkMessageDeletedForMeParams struct {
-	DisplayText sql.NullString
-	ChatJid     string
-	MsgID       string
+	DeletedAt      sql.NullInt64
+	DeletionReason sql.NullString
+	ChatJid        string
+	MsgID          string
 }
 
 func (q *Queries) MarkMessageDeletedForMe(ctx context.Context, arg MarkMessageDeletedForMeParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, markMessageDeletedForMe, arg.DisplayText, arg.ChatJid, arg.MsgID)
+	result, err := q.db.ExecContext(ctx, markMessageDeletedForMe,
+		arg.DeletedAt,
+		arg.DeletionReason,
+		arg.ChatJid,
+		arg.MsgID,
+	)
 	if err != nil {
 		return 0, err
 	}
@@ -1074,22 +1077,25 @@ func (q *Queries) MarkMessageDeletedForMe(ctx context.Context, arg MarkMessageDe
 const markMessageDeletedForMePreserveMedia = `-- name: MarkMessageDeletedForMePreserveMedia :execrows
 UPDATE messages
 SET deleted_for_me = 1,
-    text = NULL,
-    display_text = ?,
-    buttons = NULL,
-    quoted_msg_id = NULL,
-    quoted_sender_jid = NULL
+    deleted_at = COALESCE(deleted_at, ?),
+    deletion_reason = CASE WHEN deleted_at IS NULL THEN ? ELSE deletion_reason END
 WHERE chat_jid = ? AND msg_id = ?
 `
 
 type MarkMessageDeletedForMePreserveMediaParams struct {
-	DisplayText sql.NullString
-	ChatJid     string
-	MsgID       string
+	DeletedAt      sql.NullInt64
+	DeletionReason sql.NullString
+	ChatJid        string
+	MsgID          string
 }
 
 func (q *Queries) MarkMessageDeletedForMePreserveMedia(ctx context.Context, arg MarkMessageDeletedForMePreserveMediaParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, markMessageDeletedForMePreserveMedia, arg.DisplayText, arg.ChatJid, arg.MsgID)
+	result, err := q.db.ExecContext(ctx, markMessageDeletedForMePreserveMedia,
+		arg.DeletedAt,
+		arg.DeletionReason,
+		arg.ChatJid,
+		arg.MsgID,
+	)
 	if err != nil {
 		return 0, err
 	}
@@ -1099,35 +1105,27 @@ func (q *Queries) MarkMessageDeletedForMePreserveMedia(ctx context.Context, arg 
 const markMessageRevoked = `-- name: MarkMessageRevoked :execrows
 UPDATE messages
 SET revoked = 1,
-    text = NULL,
-    display_text = ?,
-    buttons = NULL,
-    quoted_msg_id = NULL,
-    quoted_sender_jid = NULL,
-    media_type = NULL,
-    media_caption = NULL,
-    filename = NULL,
-    mime_type = NULL,
-    direct_path = NULL,
-    media_key = NULL,
-    file_sha256 = NULL,
-    file_enc_sha256 = NULL,
-    file_length = NULL,
-    local_path = NULL,
-    downloaded_at = NULL,
+    deleted_at = COALESCE(deleted_at, ?),
+    deletion_reason = CASE WHEN deleted_at IS NULL THEN ? ELSE deletion_reason END,
     edited = 0,
     edited_ts = 0
 WHERE chat_jid = ? AND msg_id = ?
 `
 
 type MarkMessageRevokedParams struct {
-	DisplayText sql.NullString
-	ChatJid     string
-	MsgID       string
+	DeletedAt      sql.NullInt64
+	DeletionReason sql.NullString
+	ChatJid        string
+	MsgID          string
 }
 
 func (q *Queries) MarkMessageRevoked(ctx context.Context, arg MarkMessageRevokedParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, markMessageRevoked, arg.DisplayText, arg.ChatJid, arg.MsgID)
+	result, err := q.db.ExecContext(ctx, markMessageRevoked,
+		arg.DeletedAt,
+		arg.DeletionReason,
+		arg.ChatJid,
+		arg.MsgID,
+	)
 	if err != nil {
 		return 0, err
 	}
@@ -1135,11 +1133,11 @@ func (q *Queries) MarkMessageRevoked(ctx context.Context, arg MarkMessageRevoked
 }
 
 const messageContextAfter = `-- name: MessageContextAfter :many
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
-WHERE m.chat_jid = ? AND m.revoked = 0 AND m.deleted_for_me = 0 AND (m.ts > ? OR (m.ts = ? AND m.rowid > ?))
+WHERE m.chat_jid = ? AND m.deleted_at IS NULL AND (m.ts > ? OR (m.ts = ? AND m.rowid > ?))
 ORDER BY m.ts ASC, m.rowid ASC
 LIMIT ?
 `
@@ -1180,8 +1178,11 @@ type MessageContextAfterRow struct {
 	StarredAt       int64
 	Revoked         int64
 	DeletedForMe    int64
+	DeletedAt       int64
+	DeletionReason  string
+	PayloadPurgedAt int64
 	Buttons         string
-	Column29        string
+	Column32        string
 }
 
 func (q *Queries) MessageContextAfter(ctx context.Context, arg MessageContextAfterParams) ([]MessageContextAfterRow, error) {
@@ -1227,8 +1228,11 @@ func (q *Queries) MessageContextAfter(ctx context.Context, arg MessageContextAft
 			&i.StarredAt,
 			&i.Revoked,
 			&i.DeletedForMe,
+			&i.DeletedAt,
+			&i.DeletionReason,
+			&i.PayloadPurgedAt,
 			&i.Buttons,
-			&i.Column29,
+			&i.Column32,
 		); err != nil {
 			return nil, err
 		}
@@ -1244,11 +1248,11 @@ func (q *Queries) MessageContextAfter(ctx context.Context, arg MessageContextAft
 }
 
 const messageContextBefore = `-- name: MessageContextBefore :many
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
-WHERE m.chat_jid = ? AND m.revoked = 0 AND m.deleted_for_me = 0 AND (m.ts < ? OR (m.ts = ? AND m.rowid < ?))
+WHERE m.chat_jid = ? AND m.deleted_at IS NULL AND (m.ts < ? OR (m.ts = ? AND m.rowid < ?))
 ORDER BY m.ts DESC, m.rowid DESC
 LIMIT ?
 `
@@ -1289,8 +1293,11 @@ type MessageContextBeforeRow struct {
 	StarredAt       int64
 	Revoked         int64
 	DeletedForMe    int64
+	DeletedAt       int64
+	DeletionReason  string
+	PayloadPurgedAt int64
 	Buttons         string
-	Column29        string
+	Column32        string
 }
 
 func (q *Queries) MessageContextBefore(ctx context.Context, arg MessageContextBeforeParams) ([]MessageContextBeforeRow, error) {
@@ -1336,8 +1343,11 @@ func (q *Queries) MessageContextBefore(ctx context.Context, arg MessageContextBe
 			&i.StarredAt,
 			&i.Revoked,
 			&i.DeletedForMe,
+			&i.DeletedAt,
+			&i.DeletionReason,
+			&i.PayloadPurgedAt,
 			&i.Buttons,
-			&i.Column29,
+			&i.Column32,
 		); err != nil {
 			return nil, err
 		}
@@ -1578,11 +1588,9 @@ SET text = ?,
     file_length = NULL,
     local_path = NULL,
     downloaded_at = NULL,
-    revoked = 0,
-    deleted_for_me = 0,
     edited = 1,
     edited_ts = strftime('%s', 'now')
-WHERE chat_jid = ? AND msg_id = ?
+WHERE chat_jid = ? AND msg_id = ? AND deleted_at IS NULL
 `
 
 type UpdateMessageTextParams struct {
@@ -1738,47 +1746,54 @@ INSERT INTO messages(
     quoted_msg_id, quoted_sender_jid,
     is_forwarded, forwarding_score, reaction_to_id, reaction_emoji,
     media_type, media_caption, filename, mime_type, direct_path,
-    media_key, file_sha256, file_enc_sha256, file_length, revoked, deleted_for_me, edited, edited_ts, buttons
-) VALUES (
+    media_key, file_sha256, file_enc_sha256, file_length, revoked, deleted_for_me,
+    deleted_at, deletion_reason, edited, edited_ts, buttons
+) SELECT
     ?, ?, ?, ?, ?,
     ?, ?, ?, ?,
     ?, ?,
     ?, ?, ?, ?,
     ?, ?, ?, ?, ?,
     ?, ?, ?, ?,
-    ?, ?, ?, ?, ?
+    ?, ?, ?, ?,
+    ?, ?, ?
+WHERE NOT EXISTS (
+    SELECT 1 FROM message_payload_purges p WHERE p.chat_jid = ? AND p.msg_id = ?
 )
 ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
     chat_name=COALESCE(NULLIF(excluded.chat_name,''), messages.chat_name),
-    sender_jid=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.sender_jid ELSE excluded.sender_jid END,
-    sender_name=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.sender_name ELSE COALESCE(NULLIF(excluded.sender_name,''), messages.sender_name) END,
-    ts=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 THEN messages.ts WHEN excluded.edited != 0 THEN messages.ts WHEN messages.edited != 0 AND excluded.edited = 0 THEN excluded.ts WHEN excluded.ts < messages.ts AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.ts ELSE excluded.ts END,
-    from_me=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.from_me ELSE excluded.from_me END,
-    text=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.text ELSE excluded.text END,
-    display_text=CASE WHEN excluded.deleted_for_me != 0 THEN excluded.display_text WHEN messages.deleted_for_me != 0 THEN messages.display_text WHEN excluded.revoked != 0 THEN excluded.display_text WHEN messages.revoked != 0 THEN messages.display_text WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.display_text WHEN excluded.display_text IS NOT NULL AND excluded.display_text != '' THEN excluded.display_text ELSE messages.display_text END,
-    quoted_msg_id=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.quoted_msg_id ELSE COALESCE(NULLIF(excluded.quoted_msg_id,''), messages.quoted_msg_id) END,
-    quoted_sender_jid=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.quoted_sender_jid ELSE COALESCE(NULLIF(excluded.quoted_sender_jid,''), messages.quoted_sender_jid) END,
-    is_forwarded=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.is_forwarded ELSE excluded.is_forwarded END,
-    forwarding_score=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.forwarding_score ELSE excluded.forwarding_score END,
-    reaction_to_id=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.reaction_to_id ELSE COALESCE(NULLIF(excluded.reaction_to_id,''), messages.reaction_to_id) END,
-    reaction_emoji=CASE WHEN ((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.reaction_emoji ELSE COALESCE(NULLIF(excluded.reaction_emoji,''), messages.reaction_emoji) END,
-    media_type=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_type ELSE excluded.media_type END,
-    media_caption=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_caption ELSE excluded.media_caption END,
-    filename=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.filename ELSE COALESCE(NULLIF(excluded.filename,''), messages.filename) END,
-    mime_type=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.mime_type ELSE COALESCE(NULLIF(excluded.mime_type,''), messages.mime_type) END,
-    direct_path=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.direct_path ELSE COALESCE(NULLIF(excluded.direct_path,''), messages.direct_path) END,
-    media_key=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_key WHEN excluded.media_key IS NOT NULL AND length(excluded.media_key)>0 THEN excluded.media_key ELSE messages.media_key END,
-    file_sha256=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.file_sha256 WHEN excluded.file_sha256 IS NOT NULL AND length(excluded.file_sha256)>0 THEN excluded.file_sha256 ELSE messages.file_sha256 END,
-    file_enc_sha256=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.file_enc_sha256 WHEN excluded.file_enc_sha256 IS NOT NULL AND length(excluded.file_enc_sha256)>0 THEN excluded.file_enc_sha256 ELSE messages.file_enc_sha256 END,
-    file_length=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.file_length WHEN excluded.file_length>0 THEN excluded.file_length ELSE messages.file_length END,
-    local_path=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE messages.local_path END,
-    downloaded_at=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL ELSE messages.downloaded_at END,
-    media_unavailable_at=CASE WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_unavailable_at WHEN COALESCE(excluded.direct_path,'') != '' AND excluded.direct_path != COALESCE(messages.direct_path,'') THEN NULL ELSE messages.media_unavailable_at END,
+    sender_jid=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.sender_jid,''), excluded.sender_jid) WHEN (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.sender_jid ELSE excluded.sender_jid END,
+    sender_name=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.sender_name,''), excluded.sender_name) WHEN (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.sender_name ELSE COALESCE(NULLIF(excluded.sender_name,''), messages.sender_name) END,
+    ts=CASE WHEN messages.deleted_at IS NOT NULL AND excluded.deleted_at IS NULL AND COALESCE(messages.text,'') = '' AND COALESCE(NULLIF(NULLIF(messages.display_text, 'This message was deleted'), 'This message was deleted for me'),'') = '' AND COALESCE(messages.media_type,'') = '' AND COALESCE(messages.quoted_msg_id,'') = '' AND messages.buttons IS NULL THEN excluded.ts WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN messages.ts WHEN excluded.edited != 0 THEN messages.ts WHEN messages.edited != 0 AND excluded.edited = 0 THEN excluded.ts WHEN excluded.ts < messages.ts AND excluded.revoked = 0 AND excluded.deleted_for_me = 0 THEN messages.ts ELSE excluded.ts END,
+    from_me=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN CASE WHEN messages.from_me != 0 OR excluded.from_me != 0 THEN 1 ELSE 0 END WHEN (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.from_me ELSE excluded.from_me END,
+    text=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.text,''), excluded.text) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.text ELSE excluded.text END,
+    display_text=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(NULLIF(NULLIF(messages.display_text,''), 'This message was deleted'), 'This message was deleted for me'), excluded.display_text) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.display_text WHEN excluded.display_text IS NOT NULL AND excluded.display_text != '' THEN excluded.display_text ELSE messages.display_text END,
+    quoted_msg_id=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.quoted_msg_id,''), excluded.quoted_msg_id) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.quoted_msg_id ELSE COALESCE(NULLIF(excluded.quoted_msg_id,''), messages.quoted_msg_id) END,
+    quoted_sender_jid=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.quoted_sender_jid,''), excluded.quoted_sender_jid) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.quoted_sender_jid ELSE COALESCE(NULLIF(excluded.quoted_sender_jid,''), messages.quoted_sender_jid) END,
+    is_forwarded=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN CASE WHEN messages.is_forwarded != 0 OR excluded.is_forwarded != 0 THEN 1 ELSE 0 END WHEN (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.is_forwarded ELSE excluded.is_forwarded END,
+    forwarding_score=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN max(messages.forwarding_score, excluded.forwarding_score) WHEN (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.forwarding_score ELSE excluded.forwarding_score END,
+    reaction_to_id=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.reaction_to_id,''), excluded.reaction_to_id) WHEN (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.reaction_to_id ELSE COALESCE(NULLIF(excluded.reaction_to_id,''), messages.reaction_to_id) END,
+    reaction_emoji=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.reaction_emoji,''), excluded.reaction_emoji) WHEN (((messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts)) AND messages.revoked = 0 AND messages.deleted_for_me = 0 AND excluded.revoked = 0 AND excluded.deleted_for_me = 0) THEN messages.reaction_emoji ELSE COALESCE(NULLIF(excluded.reaction_emoji,''), messages.reaction_emoji) END,
+    media_type=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.media_type,''), excluded.media_type) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_type ELSE excluded.media_type END,
+    media_caption=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.media_caption,''), excluded.media_caption) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_caption ELSE excluded.media_caption END,
+    filename=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.filename,''), excluded.filename) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.filename ELSE COALESCE(NULLIF(excluded.filename,''), messages.filename) END,
+    mime_type=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.mime_type,''), excluded.mime_type) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.mime_type ELSE COALESCE(NULLIF(excluded.mime_type,''), messages.mime_type) END,
+    direct_path=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.direct_path,''), excluded.direct_path) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.direct_path ELSE COALESCE(NULLIF(excluded.direct_path,''), messages.direct_path) END,
+    media_key=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN CASE WHEN messages.media_key IS NOT NULL AND length(messages.media_key)>0 THEN messages.media_key ELSE excluded.media_key END WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_key WHEN excluded.media_key IS NOT NULL AND length(excluded.media_key)>0 THEN excluded.media_key ELSE messages.media_key END,
+    file_sha256=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN CASE WHEN messages.file_sha256 IS NOT NULL AND length(messages.file_sha256)>0 THEN messages.file_sha256 ELSE excluded.file_sha256 END WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.file_sha256 WHEN excluded.file_sha256 IS NOT NULL AND length(excluded.file_sha256)>0 THEN excluded.file_sha256 ELSE messages.file_sha256 END,
+    file_enc_sha256=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN CASE WHEN messages.file_enc_sha256 IS NOT NULL AND length(messages.file_enc_sha256)>0 THEN messages.file_enc_sha256 ELSE excluded.file_enc_sha256 END WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.file_enc_sha256 WHEN excluded.file_enc_sha256 IS NOT NULL AND length(excluded.file_enc_sha256)>0 THEN excluded.file_enc_sha256 ELSE messages.file_enc_sha256 END,
+    file_length=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN CASE WHEN messages.file_length IS NOT NULL AND messages.file_length>0 THEN messages.file_length ELSE excluded.file_length END WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.file_length WHEN excluded.file_length>0 THEN excluded.file_length ELSE messages.file_length END,
+    local_path=messages.local_path,
+    downloaded_at=messages.downloaded_at,
+    media_unavailable_at=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN messages.media_unavailable_at WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.media_unavailable_at WHEN COALESCE(excluded.direct_path,'') != '' AND excluded.direct_path != COALESCE(messages.direct_path,'') THEN NULL ELSE messages.media_unavailable_at END,
     revoked=CASE WHEN excluded.revoked != 0 THEN 1 ELSE messages.revoked END,
     deleted_for_me=CASE WHEN excluded.deleted_for_me != 0 THEN 1 ELSE messages.deleted_for_me END,
-    edited=CASE WHEN excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN 0 WHEN excluded.edited != 0 THEN 1 WHEN messages.edited != 0 THEN messages.edited ELSE 0 END,
-    edited_ts=CASE WHEN excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN 0 WHEN excluded.edited != 0 AND (messages.edited = 0 OR excluded.edited_ts > messages.edited_ts) THEN excluded.edited_ts WHEN messages.edited != 0 THEN messages.edited_ts ELSE 0 END,
-    buttons=CASE WHEN messages.revoked != 0 OR messages.deleted_for_me != 0 OR excluded.revoked != 0 OR excluded.deleted_for_me != 0 THEN NULL WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.buttons ELSE excluded.buttons END
+    deleted_at=COALESCE(messages.deleted_at, excluded.deleted_at),
+    deletion_reason=CASE WHEN messages.deleted_at IS NOT NULL THEN COALESCE(NULLIF(messages.deletion_reason,''), excluded.deletion_reason) ELSE excluded.deletion_reason END,
+    edited=CASE WHEN messages.deleted_at IS NOT NULL THEN messages.edited WHEN excluded.deleted_at IS NOT NULL THEN 0 WHEN excluded.edited != 0 THEN 1 WHEN messages.edited != 0 THEN messages.edited ELSE 0 END,
+    edited_ts=CASE WHEN messages.deleted_at IS NOT NULL THEN messages.edited_ts WHEN excluded.deleted_at IS NOT NULL THEN 0 WHEN excluded.edited != 0 AND (messages.edited = 0 OR excluded.edited_ts > messages.edited_ts) THEN excluded.edited_ts WHEN messages.edited != 0 THEN messages.edited_ts ELSE 0 END,
+    buttons=CASE WHEN messages.deleted_at IS NOT NULL OR excluded.deleted_at IS NOT NULL THEN COALESCE(messages.buttons, excluded.buttons) WHEN (messages.edited != 0 AND excluded.edited = 0) OR (messages.edited != 0 AND excluded.edited != 0 AND excluded.edited_ts < messages.edited_ts) OR (messages.edited = 0 AND excluded.edited = 0 AND excluded.ts < messages.ts) THEN messages.buttons ELSE excluded.buttons END
+WHERE messages.payload_purged_at IS NULL
 `
 
 type UpsertMessageParams struct {
@@ -1808,9 +1823,13 @@ type UpsertMessageParams struct {
 	FileLength      sql.NullInt64
 	Revoked         int64
 	DeletedForMe    int64
+	DeletedAt       sql.NullInt64
+	DeletionReason  sql.NullString
 	Edited          int64
 	EditedTs        int64
 	Buttons         sql.NullString
+	ChatJid_2       string
+	MsgID_2         string
 }
 
 func (q *Queries) UpsertMessage(ctx context.Context, arg UpsertMessageParams) error {
@@ -1841,16 +1860,23 @@ func (q *Queries) UpsertMessage(ctx context.Context, arg UpsertMessageParams) er
 		arg.FileLength,
 		arg.Revoked,
 		arg.DeletedForMe,
+		arg.DeletedAt,
+		arg.DeletionReason,
 		arg.Edited,
 		arg.EditedTs,
 		arg.Buttons,
+		arg.ChatJid_2,
+		arg.MsgID_2,
 	)
 	return err
 }
 
 const upsertPoll = `-- name: UpsertPoll :exec
 INSERT INTO polls (chat_jid, msg_id, sender_jid, question, options_json, selectable_count, created_ts)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+SELECT ?, ?, ?, ?, ?, ?, ?
+WHERE NOT EXISTS (
+    SELECT 1 FROM message_payload_purges p WHERE p.chat_jid = ? AND p.msg_id = ?
+)
 ON CONFLICT(chat_jid, msg_id) DO UPDATE SET
     sender_jid = excluded.sender_jid,
     question = excluded.question,
@@ -1867,6 +1893,8 @@ type UpsertPollParams struct {
 	OptionsJson     string
 	SelectableCount int64
 	CreatedTs       int64
+	ChatJid_2       string
+	MsgID_2         string
 }
 
 func (q *Queries) UpsertPoll(ctx context.Context, arg UpsertPollParams) error {
@@ -1878,13 +1906,21 @@ func (q *Queries) UpsertPoll(ctx context.Context, arg UpsertPollParams) error {
 		arg.OptionsJson,
 		arg.SelectableCount,
 		arg.CreatedTs,
+		arg.ChatJid_2,
+		arg.MsgID_2,
 	)
 	return err
 }
 
 const upsertPollVote = `-- name: UpsertPollVote :exec
 INSERT INTO poll_votes (chat_jid, poll_msg_id, voter_jid, vote_msg_id, selected_options_json, ts)
-VALUES (?, ?, ?, ?, ?, ?)
+SELECT ?, ?, ?, ?, ?, ?
+WHERE NOT EXISTS (
+    SELECT 1 FROM message_payload_purges p WHERE p.chat_jid = ? AND p.msg_id = ?
+)
+  AND NOT EXISTS (
+    SELECT 1 FROM message_payload_purges p WHERE p.chat_jid = ? AND p.msg_id = ?
+)
 ON CONFLICT(chat_jid, poll_msg_id, voter_jid) DO UPDATE SET
     vote_msg_id = excluded.vote_msg_id,
     selected_options_json = excluded.selected_options_json,
@@ -1899,6 +1935,10 @@ type UpsertPollVoteParams struct {
 	VoteMsgID           string
 	SelectedOptionsJson string
 	Ts                  int64
+	ChatJid_2           string
+	MsgID               string
+	ChatJid_3           string
+	MsgID_2             string
 }
 
 func (q *Queries) UpsertPollVote(ctx context.Context, arg UpsertPollVoteParams) error {
@@ -1909,6 +1949,10 @@ func (q *Queries) UpsertPollVote(ctx context.Context, arg UpsertPollVoteParams) 
 		arg.VoteMsgID,
 		arg.SelectedOptionsJson,
 		arg.Ts,
+		arg.ChatJid_2,
+		arg.MsgID,
+		arg.ChatJid_3,
+		arg.MsgID_2,
 	)
 	return err
 }

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -97,6 +97,9 @@ type Message struct {
 	StarredAt       time.Time
 	Revoked         bool
 	DeletedForMe    bool
+	DeletedAt       *time.Time `json:"deleted_at,omitempty"`
+	DeletionReason  string     `json:"deletion_reason,omitempty"`
+	PayloadPurgedAt *time.Time `json:"payload_purged_at,omitempty"`
 	Snippet         string
 	rowID           int64
 }
@@ -235,3 +238,6 @@ func (d *DB) HasFTS() bool { return d.ftsEnabled }
 
 const DeletedMessageDisplayText = "This message was deleted"
 const DeletedForMeMessageDisplayText = "This message was deleted for me"
+const MessageDeletionReasonWhatsAppRevoke = "whatsapp-revoke"
+const MessageDeletionReasonWhatsAppDeleteForMe = "whatsapp-delete-for-me"
+const MessageDeletionReasonExplicit = "explicit-message-delete"


### PR DESCRIPTION
## Summary

- retain deleted message text, reply, interactive, and media payload behind explicit `deleted_at` and `deletion_reason` tombstones
- keep sync/history ingestion merge-only: an omitted row is never a deletion signal, tombstones remain sticky, and tombstone-first imports can still enrich missing payload
- add confirmation-gated `messages purge`, which removes downloaded bytes, scrubs retained payload, and keeps a durable non-cascading suppression ledger
- carry tombstones, purge keys, polls, votes, and alias-media cleanup through LID-to-phone identity migration
- migrate legacy revoked/delete-for-me rows losslessly and exclude tombstones from normal list/search/starred/poll/FTS surfaces

## Why

The previous delete paths retained a row but erased its payload fields, while auxiliary poll state and later history imports could reintroduce data. The M-tier family contract requires explicit deletion metadata, merge-by-default imports, and a deliberate irreversible payload purge without allowing later imports or identity aliases to restore erased content.

## Proof

- `gofmt -l .`
- `go vet ./...`
- `go test ./...`
- `go test -tags sqlite_fts5 ./...`
- Windows lock test cross-compile
- CGO-required fail-closed build check
- `node --test scripts/*.test.mjs` (41 passed)
- production FTS5 binary build
- docs-site build
- `git diff --check`
- iterative AutoReview to no accepted/actionable findings

The real `dist/wacli` binary was run against a scratch legacy store containing a revoked document with text, quote metadata, interactive buttons, remote media metadata, and a downloaded local file. Opening the store migrated it to schema 21 without payload loss; normal listing returned no row; direct show returned the retained payload and legacy deletion reason. `messages purge --confirm` removed the local file, left one zero-byte payload tombstone, and recorded one durable purge-ledger key.
