### PR TITLE
send: delegate messages edit through running sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Send: delegate `messages edit` through a running `sync --follow` process like other send commands, so edits no longer always fail with `store is locked` while continuous sync owns the store.
 - Send: allow text replies to quote stored documents and other supported media by rebuilding their saved message content. (#307 - thanks @suifatt7799-oss)
 
 ## 0.13.0 - 2026-07-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Fixed
 
-- Send: delegate `messages edit` through a running `sync --follow` process like other send commands, so edits no longer always fail with `store is locked` while continuous sync owns the store.
+- Send: delegate `messages edit` through a running `sync --follow` process like other send commands, so edits no longer always fail with `store is locked` while continuous sync owns the store. (#310 - thanks @Umair444)
 - Send: allow text replies to quote stored documents and other supported media by rebuilding their saved message content. (#307 - thanks @suifatt7799-oss)
 
 ## 0.13.0 - 2026-07-17

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -693,6 +693,29 @@ func newMessagesEditCmd(flags *rootFlags) *cobra.Command {
 
 			a, lk, err := newApp(ctx, flags, true, false)
 			if err != nil {
+				resp, delegated, delegateErr := tryDelegateSend(ctx, flags, err, sendDelegateRequest{
+					Kind:           "edit",
+					To:             chat,
+					ID:             id,
+					Message:        message,
+					PostSendWaitMS: durationMillis(postSendWait),
+				})
+				if delegated {
+					if delegateErr != nil {
+						return delegateErr
+					}
+					if flags.asJSON {
+						return out.WriteJSON(os.Stdout, map[string]any{
+							"edited":  true,
+							"to":      resp.To,
+							"id":      resp.ID,
+							"target":  resp.Target,
+							"message": message,
+						})
+					}
+					fmt.Fprintf(os.Stdout, "Edited message %s in %s (id %s)\n", resp.Target, resp.To, resp.ID)
+					return nil
+				}
 				return err
 			}
 			defer closeApp(a, lk)

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -215,6 +215,8 @@ func executeDelegatedSend(parent context.Context, a *app.App, req sendDelegateRe
 		return executeDelegatedButtonListSelect(ctx, a, req)
 	case "presence":
 		return executeDelegatedPresence(ctx, a, req)
+	case "edit":
+		return executeDelegatedEdit(ctx, a, req)
 	default:
 		return sendDelegateResponse{}, fmt.Errorf("unsupported send kind %q", req.Kind)
 	}
@@ -240,6 +242,30 @@ func executeDelegatedPresence(ctx context.Context, a *app.App, req sendDelegateR
 		return sendDelegateResponse{}, err
 	}
 	return sendDelegateResponse{OK: true, Sent: true, To: toJID.String()}, nil
+}
+
+func executeDelegatedEdit(ctx context.Context, a *app.App, req sendDelegateRequest) (sendDelegateResponse, error) {
+	msg, chatJID, err := loadMessageMutationTarget(ctx, a, req.To, req.ID)
+	if err != nil {
+		return sendDelegateResponse{}, err
+	}
+	if err := validateMessageCanEdit(msg, time.Now().UTC()); err != nil {
+		return sendDelegateResponse{}, err
+	}
+	if err := warnRapidSendIfNeeded(a.StoreDir(), time.Now().UTC(), os.Stderr); err != nil {
+		return sendDelegateResponse{}, err
+	}
+	sentID, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (types.MessageID, error) {
+		return a.WA().EditMessage(ctx, chatJID, types.MessageID(msg.MsgID), req.Message)
+	})
+	if err != nil {
+		return sendDelegateResponse{}, err
+	}
+	if err := a.DB().UpdateMessageText(msg.ChatJID, msg.MsgID, req.Message); err != nil {
+		return sendDelegateResponse{}, fmt.Errorf("store edited message text: %w", err)
+	}
+	waitForPostSendRetryReceipts(ctx, millisDuration(req.PostSendWaitMS, 0))
+	return sendDelegateResponse{OK: true, Sent: true, To: chatJID.String(), ID: string(sentID), Target: msg.MsgID}, nil
 }
 
 func executeDelegatedText(ctx context.Context, a *app.App, req sendDelegateRequest) (sendDelegateResponse, error) {

--- a/cmd/wacli/send_ipc_test.go
+++ b/cmd/wacli/send_ipc_test.go
@@ -153,3 +153,19 @@ func TestRemoveStaleSendDelegateSocketRefusesRegularFile(t *testing.T) {
 		t.Fatalf("error = %v, want not a socket", err)
 	}
 }
+
+func TestExecuteDelegatedSendAcceptsEditKind(t *testing.T) {
+	// "edit" must route past the kind switch (reaching app use), not be
+	// rejected as an unsupported kind like unknown values are.
+	defer func() { _ = recover() }() // nil app panics after routing; that is fine
+	_, err := executeDelegatedSend(context.Background(), nil, sendDelegateRequest{
+		Version: sendDelegateVersion,
+		Kind:    "edit",
+		To:      "123@s.whatsapp.net",
+		ID:      "ABC",
+		Message: "edited",
+	})
+	if err != nil && strings.Contains(err.Error(), "unsupported send kind") {
+		t.Fatalf("edit rejected as unsupported kind: %v", err)
+	}
+}

--- a/cmd/wacli/send_ipc_test.go
+++ b/cmd/wacli/send_ipc_test.go
@@ -154,10 +154,54 @@ func TestRemoveStaleSendDelegateSocketRefusesRegularFile(t *testing.T) {
 	}
 }
 
+func TestMessagesEditDelegatesThroughSendSocketWhenStoreLocked(t *testing.T) {
+	skipPresenceDelegateSocketTestOnUnsupportedOS(t)
+	storeDir := shortPresenceDelegateStoreDir(t)
+	lk, err := lock.Acquire(storeDir)
+	if err != nil {
+		t.Fatalf("lock store: %v", err)
+	}
+	defer lk.Release()
+
+	server := startPresenceDelegateTestSocket(t, storeDir, func(req sendDelegateRequest) sendDelegateResponse {
+		return sendDelegateResponse{
+			OK: true, Sent: true, To: "123@s.whatsapp.net", ID: "sent-id", Target: req.ID,
+		}
+	})
+	defer server.stop()
+
+	stdout, stderr, err := runPresenceDelegateHelper(t, []string{
+		"--store", storeDir, "--json", "--timeout", "750ms",
+		"messages", "edit", "--chat", "123@s.whatsapp.net", "--id", "ABC",
+		"--message", "edited", "--post-send-wait", "25ms",
+	})
+	if err != nil {
+		t.Fatalf("messages edit failed: %v stdout=%q stderr=%q", err, stdout, stderr)
+	}
+
+	req := server.nextRequest(t)
+	if req.Version != sendDelegateVersion || req.Kind != "edit" {
+		t.Fatalf("delegate version/kind = %d/%q", req.Version, req.Kind)
+	}
+	if req.To != "123@s.whatsapp.net" || req.ID != "ABC" || req.Message != "edited" {
+		t.Fatalf("delegate mutation target = %+v", req)
+	}
+	if req.TimeoutMS != 750 || req.PostSendWaitMS != 25 {
+		t.Fatalf("delegate timeouts = command %dms post-send %dms", req.TimeoutMS, req.PostSendWaitMS)
+	}
+	if strings.Contains(stderr, "store is locked") {
+		t.Fatalf("delegated command tried the direct store path: stderr=%q", stderr)
+	}
+	for _, want := range []string{`"edited":true`, `"id":"sent-id"`, `"target":"ABC"`} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout %q missing %s", stdout, want)
+		}
+	}
+}
+
 func TestExecuteDelegatedSendAcceptsEditKind(t *testing.T) {
-	// "edit" must route past the kind switch (reaching app use), not be
-	// rejected as an unsupported kind like unknown values are.
-	defer func() { _ = recover() }() // nil app panics after routing; that is fine
+	// Reaching app use proves the daemon dispatcher recognized the edit kind.
+	defer func() { _ = recover() }()
 	_, err := executeDelegatedSend(context.Background(), nil, sendDelegateRequest{
 		Version: sendDelegateVersion,
 		Kind:    "edit",

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -27,7 +27,7 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-t
 - Webhook delivery is best-effort: failures, request timeouts, and full-queue drops are logged as warnings and do not stop sync. Retries/backoff are intentionally out of scope for this flag.
 - If neither storage cap is configured, sync prints one warning because WhatsApp history can grow the local database substantially.
 - `WACLI_SYNC_MAX_MESSAGES` and `WACLI_SYNC_MAX_DB_SIZE` apply the same caps to `auth` bootstrap sync and `sync`.
-- While `sync --follow` is running, `send text`, `send file`, `send sticker`, `send voice`, and `send react` commands for the same store are delegated to the running sync process so they do not fail on the store lock.
+- While `sync --follow` is running, `send text`, `send file`, `send sticker`, `send voice`, `send react`, and `messages edit` commands for the same store are delegated to the running sync process so they do not fail on the store lock.
 - After connecting, sync fetches WhatsApp chat app-state deltas (`regular_high` and `regular_low`) so starred, delete-for-me, mute, archive, pin, and mark-read changes made while `wacli` was offline are caught up instead of relying only on live push notifications.
 - Sync imports messages sent from your other linked devices into the destination chat with `from_me=true`, so local history covers both incoming and outgoing conversation sides.
 - If whatsmeow reports an app-state LTHash mismatch, sync asks the primary device for the official recovery snapshot once for that app-state collection. If recovery also fails, the warning is printed and sync keeps handling normal message/history events.


### PR DESCRIPTION
## Problem

While `sync --follow` holds the store lock (the documented always-on deployment), send commands delegate to the running sync process over the `.send.sock` IPC and work fine — but `messages edit` was never added to the delegate list, so it fails 100% of the time with `store is locked` whenever continuous sync is running:

```
$ wacli messages edit --chat <jid> --id <id> --message "new text"
store is locked (another wacli is running?): store locked: resource temporarily unavailable
```

This makes scripted edits impossible in exactly the mode the sync docs recommend ("send commands ... are delegated to the running sync process so they do not fail on the store lock" — edit is the missing case of that sentence).

## Fix

Teach the send delegate an `edit` kind, mirroring the existing `react` executor:

- daemon side: `executeDelegatedEdit` loads the mutation target, validates the edit window (`validateMessageCanEdit`), sends the edit on the live connection via `runSendOperation`, and updates the stored text with the same `UpdateMessageText` the direct path uses
- client side: `newMessagesEditCmd` falls back to `tryDelegateSend` on the lock error, exactly like `send text`
- no new request fields needed (`To`, `ID`, `Message` already exist on `sendDelegateRequest`)
- docs/sync.md delegate list and CHANGELOG updated; routing test added

Tested against a live `sync --follow` session: edits that previously always failed now apply in place.

If the exclusion of `edit` from the delegate was deliberate, happy to hear the reasoning and adjust — but from the code and docs it reads as an omission.