### PR TITLE
fix(sync): include chat names in webhooks

### DIFF
--- a/docs/sync.md
+++ b/docs/sync.md
@@ -22,7 +22,7 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-t
 - `--refresh-contacts` imports contacts from the session store.
 - `--refresh-groups` fetches joined groups live and updates the local DB.
 - `--refresh-channels` fetches subscribed WhatsApp Channels live and updates local chat rows.
-- `--webhook URL` posts successfully stored live message events as JSON on a bounded background worker.
+- `--webhook URL` posts successfully stored live message events as JSON on a bounded background worker. The payload includes `ChatName` when a locally resolved chat name is available.
 - `--webhook-secret SECRET` signs webhook payloads with `X-Wacli-Signature: sha256=<hmac>`.
 - Webhook delivery is best-effort: failures, request timeouts, and full-queue drops are logged as warnings and do not stop sync. Retries/backoff are intentionally out of scope for this flag.
 - If neither storage cap is configured, sync prints one warning because WhatsApp history can grow the local database substantially.

--- a/internal/app/webhook.go
+++ b/internal/app/webhook.go
@@ -32,6 +32,11 @@ var syncWebhookSafeHTTPClient = newSyncWebhookSafeHTTPClient()
 
 var syncWebhookRequestTimeout = 5 * time.Second
 
+type syncWebhookPayload struct {
+	wa.ParsedMessage
+	ChatName string `json:"ChatName,omitempty"`
+}
+
 func newSyncWebhookSafeHTTPClient() *http.Client {
 	client := linkpreview.NewSafeHTTPClient()
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
@@ -114,7 +119,7 @@ func (a *App) postSyncWebhook(ctx context.Context, opts SyncOptions, pm wa.Parse
 	}
 	ctx, cancel := context.WithTimeout(ctx, syncWebhookRequestTimeout)
 	defer cancel()
-	payload, err := json.Marshal(pm)
+	payload, err := json.Marshal(a.newSyncWebhookPayload(ctx, pm))
 	if err != nil {
 		return fmt.Errorf("marshal webhook payload: %w", err)
 	}
@@ -136,6 +141,22 @@ func (a *App) postSyncWebhook(ctx context.Context, opts SyncOptions, pm wa.Parse
 		return fmt.Errorf("post webhook: %s", resp.Status)
 	}
 	return nil
+}
+
+func (a *App) newSyncWebhookPayload(ctx context.Context, pm wa.ParsedMessage) syncWebhookPayload {
+	payload := syncWebhookPayload{ParsedMessage: pm}
+	chatJID := canonicalJIDString(pm.Chat)
+	if a.wa != nil {
+		chatJID = canonicalJIDString(a.canonicalStoreJID(ctx, pm.Chat))
+	}
+	if chatJID != "" && a.db != nil {
+		chat, err := a.db.GetChat(chatJID)
+		if err != nil {
+			return payload
+		}
+		payload.ChatName = chat.Name
+	}
+	return payload
 }
 
 func newSyncWebhookRequest(ctx context.Context, webhookURL, secret, version string, payload []byte) (*http.Request, error) {

--- a/internal/app/webhook_test.go
+++ b/internal/app/webhook_test.go
@@ -24,7 +24,7 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
-func TestHandleLiveSyncMessagePostsSignedWebhook(t *testing.T) {
+func TestHandleLiveSyncMessagePostsSignedWebhookWithGroupName(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()
 	a.wa = f
@@ -49,18 +49,22 @@ func TestHandleLiveSyncMessagePostsSignedWebhook(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	chat := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+	chat := types.JID{User: "120363000000000000", Server: types.GroupServer}
+	f.groups[chat] = &types.GroupInfo{
+		JID:       chat,
+		GroupName: types.GroupName{Name: "test1"},
+	}
 	evt := &events.Message{
 		Info: types.MessageInfo{
 			MessageSource: types.MessageSource{
 				Chat:     chat,
-				Sender:   chat,
+				Sender:   types.JID{User: "15551234567", Server: types.DefaultUserServer},
 				IsFromMe: false,
-				IsGroup:  false,
+				IsGroup:  true,
 			},
 			ID:        "m-live",
 			Timestamp: time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC),
-			PushName:  "Alice",
+			PushName:  "",
 		},
 		Message: &waProto.Message{Conversation: proto.String("hello")},
 	}
@@ -98,7 +102,11 @@ func TestHandleLiveSyncMessagePostsSignedWebhook(t *testing.T) {
 	if got.signature != syncWebhookSignature("supersecret", got.body) {
 		t.Fatalf("signature = %q, want %q", got.signature, syncWebhookSignature("supersecret", got.body))
 	}
-	for _, want := range [][]byte{[]byte(`"ID":"m-live"`), []byte(`"Text":"hello"`)} {
+	for _, want := range [][]byte{
+		[]byte(`"ChatName":"test1"`),
+		[]byte(`"ID":"m-live"`),
+		[]byte(`"Text":"hello"`),
+	} {
 		if !bytes.Contains(got.body, want) {
 			t.Fatalf("webhook body missing %s: %s", want, got.body)
 		}


### PR DESCRIPTION
## Summary

- add the locally resolved chat name to sync webhook payloads as `ChatName`
- read the name from the chat row written before webhook enqueueing, avoiding another WhatsApp metadata request
- document the additive field and cover group-name delivery in the signed webhook regression test

## Problem

Sync persists resolved names in the local `chats` table, but webhook payloads only marshal `wa.ParsedMessage`. Group webhook consumers therefore receive the group JID and sender push name, but not the group name.

## Testing

- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `git diff --check`

The full gate passed with Node 24.13.0 and pnpm 10.34.4.

## Compatibility and privacy

`ChatName` is an optional additive JSON field, so existing webhook consumers remain compatible. It exposes the locally resolved chat name to the configured webhook endpoint, which already receives the complete message payload; no additional network lookup, dependency, configuration, or database migration is introduced.
