### PR TITLE
feat(send): add --as to force the media type regardless of MIME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `send file`: add `--as document|audio|image|video|auto` to force the message type regardless of the detected MIME. Lets you deliver an audio file as a downloadable document (`--mime audio/mpeg --as document`) instead of an inline audio bubble, matching how the mobile app attaches files. Plumbed through the `sync --follow` send delegate so it works while the sync process owns the store lock.
+- Send: add `send file --as auto|document|audio|image|video` to choose the WhatsApp media type independently of MIME, including downloadable MP3 documents. (thanks @DiegoDAF)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `send file`: add `--as document|audio|image|video|auto` to force the message type regardless of the detected MIME. Lets you deliver an audio file as a downloadable document (`--mime audio/mpeg --as document`) instead of an inline audio bubble, matching how the mobile app attaches files. Plumbed through the `sync --follow` send delegate so it works while the sync process owns the store lock.
+
 ### Fixed
 
 - Sync: include locally resolved chat names in webhook payloads when available. (#312 - thanks @g1e2x87)

--- a/cmd/wacli/send_file.go
+++ b/cmd/wacli/send_file.go
@@ -39,6 +39,7 @@ type sendFileOptions struct {
 	filename      string
 	caption       string
 	mimeOverride  string
+	mediaAs       string
 	replyTo       string
 	replyToSender string
 	ptt           bool
@@ -67,18 +68,9 @@ func sendFile(ctx context.Context, a interface {
 		return "", nil, fmt.Errorf("voice notes require OGG Opus audio; got %s", mimeType)
 	}
 
-	mediaType := "document"
-	uploadType, _ := wa.MediaTypeFromString("document")
-	switch {
-	case strings.HasPrefix(mimeType, "image/"):
-		mediaType = "image"
-		uploadType, _ = wa.MediaTypeFromString("image")
-	case strings.HasPrefix(mimeType, "video/"):
-		mediaType = "video"
-		uploadType, _ = wa.MediaTypeFromString("video")
-	case strings.HasPrefix(mimeType, "audio/"):
-		mediaType = "audio"
-		uploadType, _ = wa.MediaTypeFromString("audio")
+	mediaType, uploadType, err := resolveSendMediaType(mimeType, opts.mediaAs)
+	if err != nil {
+		return "", nil, err
 	}
 
 	isNewsletter := to.Server == types.NewsletterServer
@@ -207,6 +199,37 @@ func sendFile(ctx context.Context, a interface {
 		"media":     mediaType,
 		"ptt":       strconv.FormatBool(opts.ptt),
 	}, nil
+}
+
+// resolveSendMediaType decides the WhatsApp message type (and matching upload
+// type) for an outbound file. By default it derives the type from the MIME
+// prefix. A non-empty override other than "auto" (from --as) forces the type,
+// so a caller can, e.g., send an mp3 as a downloadable document instead of an
+// inline audio bubble — WhatsApp derives the bubble from the message type, not
+// the MIME. Only document/audio/image/video may be forced.
+func resolveSendMediaType(mimeType, override string) (string, whatsmeow.MediaType, error) {
+	if as := strings.ToLower(strings.TrimSpace(override)); as != "" && as != "auto" {
+		switch as {
+		case "document", "audio", "image", "video":
+			ut, _ := wa.MediaTypeFromString(as)
+			return as, ut, nil
+		default:
+			return "", "", fmt.Errorf("invalid --as %q (want document|audio|image|video|auto)", override)
+		}
+	}
+	switch {
+	case strings.HasPrefix(mimeType, "image/"):
+		ut, _ := wa.MediaTypeFromString("image")
+		return "image", ut, nil
+	case strings.HasPrefix(mimeType, "video/"):
+		ut, _ := wa.MediaTypeFromString("video")
+		return "video", ut, nil
+	case strings.HasPrefix(mimeType, "audio/"):
+		ut, _ := wa.MediaTypeFromString("audio")
+		return "audio", ut, nil
+	}
+	ut, _ := wa.MediaTypeFromString("document")
+	return "document", ut, nil
 }
 
 func newImageMessage(up whatsmeow.UploadResponse, mimeType, caption string, data []byte) (*waProto.ImageMessage, error) {

--- a/cmd/wacli/send_file.go
+++ b/cmd/wacli/send_file.go
@@ -35,6 +35,8 @@ const imageThumbnailMaxPixels = 40_000_000
 const voiceWaveformSamples = 64
 const voiceWaveformMax = 100
 
+const sendMediaTypeAuto = "auto"
+
 type sendFileOptions struct {
 	filename      string
 	caption       string
@@ -54,6 +56,12 @@ func sendFile(ctx context.Context, a interface {
 	WA() app.WAClient
 	DB() *store.DB
 }, to types.JID, filePath string, opts sendFileOptions) (string, map[string]string, error) {
+	mediaAs, err := validateSendFileMediaOptions(opts.mediaAs, opts.ptt)
+	if err != nil {
+		return "", nil, err
+	}
+	opts.mediaAs = mediaAs
+
 	data, err := readSendFileData(filePath)
 	if err != nil {
 		return "", nil, err
@@ -208,14 +216,13 @@ func sendFile(ctx context.Context, a interface {
 // inline audio bubble — WhatsApp derives the bubble from the message type, not
 // the MIME. Only document/audio/image/video may be forced.
 func resolveSendMediaType(mimeType, override string) (string, whatsmeow.MediaType, error) {
-	if as := strings.ToLower(strings.TrimSpace(override)); as != "" && as != "auto" {
-		switch as {
-		case "document", "audio", "image", "video":
-			ut, _ := wa.MediaTypeFromString(as)
-			return as, ut, nil
-		default:
-			return "", "", fmt.Errorf("invalid --as %q (want document|audio|image|video|auto)", override)
-		}
+	as, err := normalizeSendMediaTypeOverride(override)
+	if err != nil {
+		return "", "", err
+	}
+	if as != sendMediaTypeAuto {
+		ut, _ := wa.MediaTypeFromString(as)
+		return as, ut, nil
 	}
 	switch {
 	case strings.HasPrefix(mimeType, "image/"):
@@ -230,6 +237,28 @@ func resolveSendMediaType(mimeType, override string) (string, whatsmeow.MediaTyp
 	}
 	ut, _ := wa.MediaTypeFromString("document")
 	return "document", ut, nil
+}
+
+func validateSendFileMediaOptions(override string, ptt bool) (string, error) {
+	as, err := normalizeSendMediaTypeOverride(override)
+	if err != nil {
+		return "", err
+	}
+	if ptt && as != sendMediaTypeAuto && as != "audio" {
+		return "", fmt.Errorf("--ptt may only be used with --as auto or --as audio")
+	}
+	return as, nil
+}
+
+func normalizeSendMediaTypeOverride(override string) (string, error) {
+	switch as := strings.ToLower(strings.TrimSpace(override)); as {
+	case "", sendMediaTypeAuto:
+		return sendMediaTypeAuto, nil
+	case "document", "audio", "image", "video":
+		return as, nil
+	default:
+		return "", fmt.Errorf("invalid --as %q (want auto|document|audio|image|video)", override)
+	}
 }
 
 func newImageMessage(up whatsmeow.UploadResponse, mimeType, caption string, data []byte) (*waProto.ImageMessage, error) {

--- a/cmd/wacli/send_file_cmd.go
+++ b/cmd/wacli/send_file_cmd.go
@@ -31,6 +31,10 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 			if to == "" || filePath == "" {
 				return fmt.Errorf("--to and --file are required")
 			}
+			mediaAs, err := validateSendFileMediaOptions(mediaAs, ptt)
+			if err != nil {
+				return err
+			}
 			if err := flags.requireWritable(); err != nil {
 				return err
 			}
@@ -129,7 +133,7 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&filename, "filename", "", "display name for the file (defaults to basename of --file)")
 	cmd.Flags().StringVar(&caption, "caption", "", "caption (images/videos/documents)")
 	cmd.Flags().StringVar(&mimeOverride, "mime", "", "override detected mime type")
-	cmd.Flags().StringVar(&mediaAs, "as", "", "force media type regardless of MIME: document|audio|image|video|auto (default auto)")
+	cmd.Flags().StringVar(&mediaAs, "as", sendMediaTypeAuto, "force WhatsApp media type (auto|document|audio|image|video)")
 	cmd.Flags().StringVar(&replyTo, "reply-to", "", "message ID to quote/reply to")
 	cmd.Flags().StringVar(&replyToSender, "reply-to-sender", "", "sender JID of the quoted message (required for unsynced group replies)")
 	cmd.Flags().BoolVar(&ptt, "ptt", false, "send OGG/Opus audio as a WhatsApp voice note")

--- a/cmd/wacli/send_file_cmd.go
+++ b/cmd/wacli/send_file_cmd.go
@@ -18,6 +18,7 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 	var filename string
 	var caption string
 	var mimeOverride string
+	var mediaAs string
 	var replyTo string
 	var replyToSender string
 	var ptt bool
@@ -51,6 +52,7 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 					Filename:       filename,
 					Caption:        caption,
 					MIME:           mimeOverride,
+					As:             mediaAs,
 					ReplyTo:        replyTo,
 					ReplyToSender:  replyToSender,
 					PTT:            ptt,
@@ -91,6 +93,7 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 					filename:      filename,
 					caption:       caption,
 					mimeOverride:  mimeOverride,
+					mediaAs:       mediaAs,
 					replyTo:       replyTo,
 					replyToSender: replyToSender,
 					ptt:           ptt,
@@ -126,6 +129,7 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&filename, "filename", "", "display name for the file (defaults to basename of --file)")
 	cmd.Flags().StringVar(&caption, "caption", "", "caption (images/videos/documents)")
 	cmd.Flags().StringVar(&mimeOverride, "mime", "", "override detected mime type")
+	cmd.Flags().StringVar(&mediaAs, "as", "", "force media type regardless of MIME: document|audio|image|video|auto (default auto)")
 	cmd.Flags().StringVar(&replyTo, "reply-to", "", "message ID to quote/reply to")
 	cmd.Flags().StringVar(&replyToSender, "reply-to-sender", "", "sender JID of the quoted message (required for unsynced group replies)")
 	cmd.Flags().BoolVar(&ptt, "ptt", false, "send OGG/Opus audio as a WhatsApp voice note")

--- a/cmd/wacli/send_file_test.go
+++ b/cmd/wacli/send_file_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/openclaw/wacli/internal/fsutil"
+	"github.com/openclaw/wacli/internal/wa"
 	"go.mau.fi/whatsmeow"
 	waProto "go.mau.fi/whatsmeow/binary/proto"
 	"google.golang.org/protobuf/proto"
@@ -58,10 +59,51 @@ func TestReadSendFileDataRejectsOversizedFile(t *testing.T) {
 
 func TestSendFileCommandExposesReplyFlags(t *testing.T) {
 	cmd := newSendFileCmd(&rootFlags{})
-	for _, name := range []string{"reply-to", "reply-to-sender", "ptt"} {
+	for _, name := range []string{"reply-to", "reply-to-sender", "ptt", "as"} {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Fatalf("missing --%s flag", name)
 		}
+	}
+}
+
+func TestResolveSendMediaType(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		mime     string
+		override string
+		want     string
+		wantErr  bool
+	}{
+		{name: "mp3 defaults to audio bubble", mime: "audio/mpeg", override: "", want: "audio"},
+		{name: "mp3 forced to document", mime: "audio/mpeg", override: "document", want: "document"},
+		{name: "auto keeps mime detection", mime: "audio/mpeg", override: "auto", want: "audio"},
+		{name: "override is case-insensitive", mime: "audio/mpeg", override: "Document", want: "document"},
+		{name: "image detected from mime", mime: "image/png", override: "", want: "image"},
+		{name: "video detected from mime", mime: "video/mp4", override: "", want: "video"},
+		{name: "unknown mime falls back to document", mime: "application/octet-stream", override: "", want: "document"},
+		{name: "force audio for a document mime", mime: "application/octet-stream", override: "audio", want: "audio"},
+		{name: "invalid override rejected", mime: "audio/mpeg", override: "banana", wantErr: true},
+		{name: "sticker override rejected", mime: "image/webp", override: "sticker", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mediaType, uploadType, err := resolveSendMediaType(tc.mime, tc.override)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("resolveSendMediaType(%q, %q) = %q, want error", tc.mime, tc.override, mediaType)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveSendMediaType(%q, %q) unexpected error: %v", tc.mime, tc.override, err)
+			}
+			if mediaType != tc.want {
+				t.Fatalf("resolveSendMediaType(%q, %q) mediaType = %q, want %q", tc.mime, tc.override, mediaType, tc.want)
+			}
+			wantUpload, _ := wa.MediaTypeFromString(tc.want)
+			if uploadType != wantUpload {
+				t.Fatalf("resolveSendMediaType(%q, %q) uploadType = %v, want %v", tc.mime, tc.override, uploadType, wantUpload)
+			}
+		})
 	}
 }
 

--- a/cmd/wacli/send_file_test.go
+++ b/cmd/wacli/send_file_test.go
@@ -64,6 +64,13 @@ func TestSendFileCommandExposesReplyFlags(t *testing.T) {
 			t.Fatalf("missing --%s flag", name)
 		}
 	}
+	as := cmd.Flags().Lookup("as")
+	if as.DefValue != sendMediaTypeAuto {
+		t.Fatalf("--as default = %q, want %q", as.DefValue, sendMediaTypeAuto)
+	}
+	if as.Usage != "force WhatsApp media type (auto|document|audio|image|video)" {
+		t.Fatalf("--as help = %q", as.Usage)
+	}
 }
 
 func TestResolveSendMediaType(t *testing.T) {
@@ -102,6 +109,68 @@ func TestResolveSendMediaType(t *testing.T) {
 			wantUpload, _ := wa.MediaTypeFromString(tc.want)
 			if uploadType != wantUpload {
 				t.Fatalf("resolveSendMediaType(%q, %q) uploadType = %v, want %v", tc.mime, tc.override, uploadType, wantUpload)
+			}
+		})
+	}
+}
+
+func TestValidateSendFileMediaOptions(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		override string
+		ptt      bool
+		want     string
+		wantErr  string
+	}{
+		{name: "default is auto", want: "auto"},
+		{name: "override is normalized", override: " Document ", want: "document"},
+		{name: "voice note allows auto", override: "auto", ptt: true, want: "auto"},
+		{name: "voice note allows audio", override: "audio", ptt: true, want: "audio"},
+		{name: "voice note rejects document", override: "document", ptt: true, wantErr: "--ptt may only"},
+		{name: "voice note rejects image", override: "image", ptt: true, wantErr: "--ptt may only"},
+		{name: "unknown override", override: "banana", wantErr: "invalid --as"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateSendFileMediaOptions(tc.override, tc.ptt)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("validateSendFileMediaOptions(%q, %t) error = %v, want %q", tc.override, tc.ptt, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateSendFileMediaOptions(%q, %t): %v", tc.override, tc.ptt, err)
+			}
+			if got != tc.want {
+				t.Fatalf("validateSendFileMediaOptions(%q, %t) = %q, want %q", tc.override, tc.ptt, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSendFileCommandValidatesMediaOptionsBeforeStore(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "unknown override", args: []string{"--as", "banana"}, want: "invalid --as"},
+		{name: "voice note conflict", args: []string{"--ptt", "--as", "document"}, want: "--ptt may only"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			storeDir := t.TempDir()
+			cmd := newSendFileCmd(&rootFlags{storeDir: storeDir})
+			cmd.SetArgs(append([]string{"--to", "15551234567", "--file", "missing.bin"}, tc.args...))
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("command error = %v, want %q", err, tc.want)
+			}
+			entries, err := os.ReadDir(storeDir)
+			if err != nil {
+				t.Fatalf("read store directory: %v", err)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("invalid command opened store: %v", entries)
 			}
 		})
 	}

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -42,6 +42,7 @@ type sendDelegateRequest struct {
 	Filename             string   `json:"filename,omitempty"`
 	Caption              string   `json:"caption,omitempty"`
 	MIME                 string   `json:"mime,omitempty"`
+	As                   string   `json:"as,omitempty"`
 	PTT                  bool     `json:"ptt,omitempty"`
 	ID                   string   `json:"id,omitempty"`
 	Reaction             string   `json:"reaction,omitempty"`
@@ -316,6 +317,7 @@ func executeDelegatedFile(ctx context.Context, a *app.App, req sendDelegateReque
 			filename:      req.Filename,
 			caption:       req.Caption,
 			mimeOverride:  req.MIME,
+			mediaAs:       req.As,
 			replyTo:       req.ReplyTo,
 			replyToSender: req.ReplyToSender,
 			ptt:           req.PTT || req.Kind == "voice",

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -304,6 +304,10 @@ func executeDelegatedText(ctx context.Context, a *app.App, req sendDelegateReque
 }
 
 func executeDelegatedFile(ctx context.Context, a *app.App, req sendDelegateRequest) (sendDelegateResponse, error) {
+	mediaAs, err := validateSendFileMediaOptions(req.As, req.PTT || req.Kind == "voice")
+	if err != nil {
+		return sendDelegateResponse{}, err
+	}
 	toJID, err := resolveRecipient(a, req.To, recipientOptions{pick: req.Pick, asJSON: true})
 	if err != nil {
 		return sendDelegateResponse{}, err
@@ -317,7 +321,7 @@ func executeDelegatedFile(ctx context.Context, a *app.App, req sendDelegateReque
 			filename:      req.Filename,
 			caption:       req.Caption,
 			mimeOverride:  req.MIME,
-			mediaAs:       req.As,
+			mediaAs:       mediaAs,
 			replyTo:       req.ReplyTo,
 			replyToSender: req.ReplyToSender,
 			ptt:           req.PTT || req.Kind == "voice",

--- a/cmd/wacli/send_ipc_test.go
+++ b/cmd/wacli/send_ipc_test.go
@@ -199,6 +199,51 @@ func TestMessagesEditDelegatesThroughSendSocketWhenStoreLocked(t *testing.T) {
 	}
 }
 
+func TestSendFileDelegatesMediaAsThroughSendSocketWhenStoreLocked(t *testing.T) {
+	skipPresenceDelegateSocketTestOnUnsupportedOS(t)
+	storeDir := shortPresenceDelegateStoreDir(t)
+	lk, err := lock.Acquire(storeDir)
+	if err != nil {
+		t.Fatalf("lock store: %v", err)
+	}
+	defer lk.Release()
+
+	server := startPresenceDelegateTestSocket(t, storeDir, func(req sendDelegateRequest) sendDelegateResponse {
+		return sendDelegateResponse{
+			OK: true, Sent: true, To: "123@s.whatsapp.net", ID: "sent-id", File: map[string]string{"name": "song.mp3"},
+		}
+	})
+	defer server.stop()
+
+	stdout, stderr, err := runPresenceDelegateHelper(t, []string{
+		"--store", storeDir, "--json", "--timeout", "750ms",
+		"send", "file", "--to", "123@s.whatsapp.net", "--file", "song.mp3",
+		"--mime", "audio/mpeg", "--as", "document", "--post-send-wait", "25ms",
+	})
+	if err != nil {
+		t.Fatalf("send file failed: %v stdout=%q stderr=%q", err, stdout, stderr)
+	}
+
+	req := server.nextRequest(t)
+	if req.Version != sendDelegateVersion || req.Kind != "file" {
+		t.Fatalf("delegate version/kind = %d/%q", req.Version, req.Kind)
+	}
+	if req.To != "123@s.whatsapp.net" || req.MIME != "audio/mpeg" || req.As != "document" {
+		t.Fatalf("delegate media options = %+v", req)
+	}
+	if req.TimeoutMS != 750 || req.PostSendWaitMS != 25 {
+		t.Fatalf("delegate timeouts = command %dms post-send %dms", req.TimeoutMS, req.PostSendWaitMS)
+	}
+	if strings.Contains(stderr, "store is locked") || strings.Contains(stderr, "not authenticated") || strings.Contains(stderr, "not connected") {
+		t.Fatalf("delegated command tried the direct store/client path: stderr=%q", stderr)
+	}
+	for _, want := range []string{`"sent":true`, `"id":"sent-id"`, `"name":"song.mp3"`} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout %q missing %s", stdout, want)
+		}
+	}
+}
+
 func TestExecuteDelegatedSendAcceptsEditKind(t *testing.T) {
 	// Reaching app use proves the daemon dispatcher recognized the edit kind.
 	defer func() { _ = recover() }()

--- a/docs/send.md
+++ b/docs/send.md
@@ -10,7 +10,7 @@ When `sync --follow` is already running for the same store, send commands delega
 
 ```bash
 wacli send text --to RECIPIENT --message TEXT [--message-escapes] [--pick N] [--mention USER] [--no-preview] [--ephemeral] [--ephemeral-duration DURATION] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
-wacli send file --to RECIPIENT --file PATH [--pick N] [--caption TEXT] [--filename NAME] [--mime TYPE] [--as TYPE] [--ptt] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
+wacli send file --to RECIPIENT --file PATH [--pick N] [--caption TEXT] [--filename NAME] [--mime TYPE] [--as auto|document|audio|image|video] [--ptt] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send sticker --to RECIPIENT --file PATH [--pick N] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send voice --to RECIPIENT --file PATH [--pick N] [--mime TYPE] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send react --to PHONE_OR_JID --id MSG_ID [--reaction TEXT] [--sender JID] [--post-send-wait 2s]
@@ -87,7 +87,7 @@ wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 
 - File uploads are capped at 100 MiB.
 - MIME type is detected automatically unless `--mime` is set.
-- WhatsApp derives the message bubble (image, video, audio, or document) from the message type, which wacli picks from the MIME by default. Use `--as document|audio|image|video|auto` to force it. For example, `--mime audio/mpeg --as document` delivers an mp3 as a downloadable document instead of an inline audio bubble, matching how the mobile app attaches files. `--as auto` (the default) keeps MIME-based detection.
+- WhatsApp derives the message bubble (image, video, audio, or document) from the message type, which wacli picks from the MIME by default. Use `--as auto|document|audio|image|video` to force it. For example, `--mime audio/mpeg --as document` delivers an mp3 as a downloadable document instead of an inline audio bubble, matching how the mobile app attaches files. `--as auto` (the default) keeps MIME-based detection. `--ptt` only accepts `--as auto` or `--as audio`.
 - `--filename` changes the displayed document name.
 - Captions apply to images, videos, and documents.
 - Files sent to channels use WhatsApp's unencrypted newsletter media upload path and include the upstream media handle required by `whatsmeow`.

--- a/docs/send.md
+++ b/docs/send.md
@@ -10,7 +10,7 @@ When `sync --follow` is already running for the same store, send commands delega
 
 ```bash
 wacli send text --to RECIPIENT --message TEXT [--message-escapes] [--pick N] [--mention USER] [--no-preview] [--ephemeral] [--ephemeral-duration DURATION] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
-wacli send file --to RECIPIENT --file PATH [--pick N] [--caption TEXT] [--filename NAME] [--mime TYPE] [--ptt] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
+wacli send file --to RECIPIENT --file PATH [--pick N] [--caption TEXT] [--filename NAME] [--mime TYPE] [--as TYPE] [--ptt] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send sticker --to RECIPIENT --file PATH [--pick N] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send voice --to RECIPIENT --file PATH [--pick N] [--mime TYPE] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send react --to PHONE_OR_JID --id MSG_ID [--reaction TEXT] [--sender JID] [--post-send-wait 2s]
@@ -87,6 +87,7 @@ wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 
 - File uploads are capped at 100 MiB.
 - MIME type is detected automatically unless `--mime` is set.
+- WhatsApp derives the message bubble (image, video, audio, or document) from the message type, which wacli picks from the MIME by default. Use `--as document|audio|image|video|auto` to force it. For example, `--mime audio/mpeg --as document` delivers an mp3 as a downloadable document instead of an inline audio bubble, matching how the mobile app attaches files. `--as auto` (the default) keeps MIME-based detection.
 - `--filename` changes the displayed document name.
 - Captions apply to images, videos, and documents.
 - Files sent to channels use WhatsApp's unencrypted newsletter media upload path and include the upstream media handle required by `whatsmeow`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -209,7 +209,7 @@ WhatsApp Web history is best-effort. If you want to try fetching *older* message
 ### Send
 
 - `wacli send text --to RECIPIENT --message TEXT [--message-escapes] [--pick N] [--no-preview] [--reply-to MSG_ID] [--reply-to-sender JID]`
-- `wacli send file --to RECIPIENT --file PATH [--caption TEXT] [--mime TYPE] [--as TYPE] [--pick N] [--ptt] [--reply-to MSG_ID] [--reply-to-sender JID]`
+- `wacli send file --to RECIPIENT --file PATH [--caption TEXT] [--mime TYPE] [--as auto|document|audio|image|video] [--pick N] [--ptt] [--reply-to MSG_ID] [--reply-to-sender JID]`
 - `wacli send sticker --to RECIPIENT --file PATH [--pick N] [--reply-to MSG_ID] [--reply-to-sender JID]`
 - `wacli send voice --to RECIPIENT --file PATH [--mime TYPE] [--pick N] [--reply-to MSG_ID] [--reply-to-sender JID]`
 - `wacli send react --to PHONE_OR_JID --id MSG_ID [--reaction TEXT] [--sender JID]`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -209,7 +209,7 @@ WhatsApp Web history is best-effort. If you want to try fetching *older* message
 ### Send
 
 - `wacli send text --to RECIPIENT --message TEXT [--message-escapes] [--pick N] [--no-preview] [--reply-to MSG_ID] [--reply-to-sender JID]`
-- `wacli send file --to RECIPIENT --file PATH [--caption TEXT] [--mime TYPE] [--pick N] [--ptt] [--reply-to MSG_ID] [--reply-to-sender JID]`
+- `wacli send file --to RECIPIENT --file PATH [--caption TEXT] [--mime TYPE] [--as TYPE] [--pick N] [--ptt] [--reply-to MSG_ID] [--reply-to-sender JID]`
 - `wacli send sticker --to RECIPIENT --file PATH [--pick N] [--reply-to MSG_ID] [--reply-to-sender JID]`
 - `wacli send voice --to RECIPIENT --file PATH [--mime TYPE] [--pick N] [--reply-to MSG_ID] [--reply-to-sender JID]`
 - `wacli send react --to PHONE_OR_JID --id MSG_ID [--reaction TEXT] [--sender JID]`


### PR DESCRIPTION
## Problem

WhatsApp decides how a media message renders (image, video, inline **audio** bubble, or downloadable **document**) from the WhatsApp *message type*, not from the MIME string. `send file` picks that message type purely from the MIME prefix:

- `--mime audio/mpeg` → `AudioMessage` → an inline, playable audio bubble.
- `--mime application/octet-stream` → `DocumentMessage`, but the receiving client shows a generic **BIN** file (no MP3 icon, and some clients won't hand it to the audio player).

There is no way to send an mp3 the way the mobile app does when you *attach a file*: a `DocumentMessage` that still carries `audio/mpeg`, so it shows the MP3 icon and downloads to the phone's storage. `--mime` alone can't express this, because the type is derived before the MIME reaches the wire.

## Change

Add `send file --as document|audio|image|video|auto` to force the message type independently of the detected MIME (`auto`, the default, keeps today's MIME-based behavior).

```bash
# mp3 as a downloadable document, like the mobile app's "attach file"
wacli send file --to me --file song.mp3 --mime audio/mpeg --as document
```

- Classification is extracted into a pure `resolveSendMediaType(mime, override)` and unit-tested.
- Plumbed through the `sync --follow` send delegate (`--as` survives IPC delegation, so it works while the sync process owns the store lock).
- `gif`/`sticker` are intentionally rejected as override values (they need their own dedicated paths).
- Docs updated (`docs/send.md`, `docs/spec.md`) and a changelog entry added.

## Testing

- `go test -tags sqlite_fts5 ./...` — all packages pass.
- New `TestResolveSendMediaType` covers MIME detection, forced overrides, `auto`, case-insensitivity, and invalid values.
- Manually verified end-to-end: an mp3 sent with `--mime audio/mpeg --as document` is stored and delivered as `media_type=document` / `mime=audio/mpeg`, matching a file attached from the official mobile app (renders as a downloadable MP3 rather than an inline audio bubble).
