### PR TITLE
feat(sync): forward receipts and chat presence over the webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.15.1 - Unreleased
 
+### Added
+
+- Sync: add opt-in receipt and chat-presence webhook events while keeping legacy message payloads unchanged. (#315 - thanks @Jaime-data)
+
 ### Chore
 
 - Build: migrate `sqlc` code generator to Go 1.24+ `go tool` directive and bump project toolchain requirement to Go 1.26.5. (#313 - thanks @thedavidweng)

--- a/cmd/wacli/sync.go
+++ b/cmd/wacli/sync.go
@@ -25,6 +25,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var webhookURL string
 	var webhookSecret string
 	var webhookAllowPrivate bool
+	var webhookEventsFlag string
 	var storage syncStorageLimitFlags
 
 	cmd := &cobra.Command{
@@ -41,6 +42,13 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 			}
 			if webhookSecret != "" && webhookURL == "" {
 				return fmt.Errorf("--webhook-secret requires --webhook")
+			}
+			if cmd.Flags().Changed("webhook-events") && webhookURL == "" {
+				return fmt.Errorf("--webhook-events requires --webhook")
+			}
+			webhookEvents, err := appPkg.ParseSyncWebhookEvents(webhookEventsFlag)
+			if err != nil {
+				return err
 			}
 			if staleThreshold != 0 && staleThreshold < time.Second {
 				return fmt.Errorf("--stale-threshold must be at least 1s, got %s", staleThreshold)
@@ -110,6 +118,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 				WebhookURL:          webhookURL,
 				WebhookSecret:       webhookSecret,
 				WebhookAllowPrivate: webhookAllowPrivate,
+				WebhookEvents:       webhookEvents,
 			})
 			if err != nil {
 				return err
@@ -139,6 +148,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&webhookURL, "webhook", "", "URL to POST live message JSON")
 	cmd.Flags().StringVar(&webhookSecret, "webhook-secret", "", "HMAC-SHA256 secret for X-Wacli-Signature header")
 	cmd.Flags().BoolVar(&webhookAllowPrivate, "webhook-allow-private", false, "allow webhook URLs that resolve to localhost or private networks")
+	cmd.Flags().StringVar(&webhookEventsFlag, "webhook-events", string(appPkg.SyncWebhookEventMessage), "comma-separated event types to POST: message, receipt, chat_presence")
 	cmd.Flags().Int64Var(&storage.maxMessages, "max-messages", 0, "maximum total messages to keep in the local DB before sync stops (0 = unlimited, or WACLI_SYNC_MAX_MESSAGES)")
 	cmd.Flags().StringVar(&storage.maxDBSize, "max-db-size", "", "maximum wacli.db disk usage before sync stops, e.g. 500MB or 2GB (default: WACLI_SYNC_MAX_DB_SIZE or unlimited)")
 	return cmd

--- a/cmd/wacli/sync_test.go
+++ b/cmd/wacli/sync_test.go
@@ -7,10 +7,41 @@ import (
 
 func TestSyncCommandExposesWebhookFlags(t *testing.T) {
 	cmd := newSyncCmd(&rootFlags{})
-	for _, name := range []string{"webhook", "webhook-secret", "webhook-allow-private"} {
+	for _, name := range []string{"webhook", "webhook-secret", "webhook-allow-private", "webhook-events"} {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Fatalf("missing --%s flag", name)
 		}
+	}
+}
+
+func TestSyncCommandWebhookEventsDefaultsToMessage(t *testing.T) {
+	cmd := newSyncCmd(&rootFlags{})
+	flag := cmd.Flags().Lookup("webhook-events")
+	if flag == nil {
+		t.Fatal("missing --webhook-events flag")
+	}
+	if flag.DefValue != "message" {
+		t.Fatalf("--webhook-events default = %q, want \"message\"", flag.DefValue)
+	}
+}
+
+func TestSyncCommandRejectsUnknownWebhookEvent(t *testing.T) {
+	cmd := newSyncCmd(&rootFlags{})
+	cmd.SetArgs([]string{"--webhook", "https://example.test/hook", "--webhook-events", "message,presence"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--webhook-events must be a comma-separated list of") {
+		t.Fatalf("expected webhook-events validation error, got %v", err)
+	}
+}
+
+func TestSyncCommandRequiresWebhookForEvents(t *testing.T) {
+	cmd := newSyncCmd(&rootFlags{})
+	cmd.SetArgs([]string{"--webhook-events", "receipt"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--webhook-events requires --webhook") {
+		t.Fatalf("expected webhook-events validation error, got %v", err)
 	}
 }
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -175,7 +175,7 @@ combined with `--account`.
 
 ### Sync
 
-- `wacli sync [--once] [--follow] [--stale-threshold DURATION] [--download-media] [--webhook URL] [--webhook-secret SECRET]`
+- `wacli sync [--once] [--follow] [--stale-threshold DURATION] [--download-media] [--webhook URL] [--webhook-secret SECRET] [--webhook-events LIST]`
 
 Notes:
 
@@ -183,6 +183,7 @@ Notes:
 - `--download-media` runs a bounded/concurrent media downloader for messages that contain downloadable media metadata.
 - `--webhook` posts live message JSON after successful local storage on a bounded background worker.
 - `--webhook-secret` adds an HMAC-SHA256 `X-Wacli-Signature` header and requires `--webhook`.
+- `--webhook-events` selects which event types are posted (`message`, `receipt`, `chat_presence`; default `message`) and requires `--webhook`. Receipt and chat-presence payloads carry a flat `EventType` discriminator; legacy message payloads omit it.
 - Webhook failures and full-queue drops emit warnings but do not fail sync.
 
 ### History backfill (best-effort)

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -7,7 +7,7 @@ Read when: running continuous capture, one-shot sync, contact/group refresh, or 
 ## Command
 
 ```bash
-wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-threshold DURATION] [--presence-mode normal|quiet] [--max-messages N] [--max-db-size SIZE] [--download-media] [--refresh-contacts] [--refresh-groups] [--refresh-channels] [--events] [--webhook URL] [--webhook-secret SECRET]
+wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-threshold DURATION] [--presence-mode normal|quiet] [--max-messages N] [--max-db-size SIZE] [--download-media] [--refresh-contacts] [--refresh-groups] [--refresh-channels] [--events] [--webhook URL] [--webhook-secret SECRET] [--webhook-events LIST]
 ```
 
 ## Modes
@@ -24,6 +24,7 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-t
 - `--refresh-channels` fetches subscribed WhatsApp Channels live and updates local chat rows.
 - `--webhook URL` posts successfully stored live message events as JSON on a bounded background worker. The payload includes `ChatName` when a locally resolved chat name is available.
 - `--webhook-secret SECRET` signs webhook payloads with `X-Wacli-Signature: sha256=<hmac>`.
+- `--webhook-events LIST` selects which event types are posted, as a comma-separated list of `message`, `receipt`, and `chat_presence`. The default is `message`, which posts exactly what earlier versions posted. A list that omits `message` stops message posts, so `--webhook-events receipt` posts receipts only. `chat_presence` needs `--presence-mode normal` (the default): WhatsApp only sends typing notifications to devices that mark themselves available. See [Webhook payloads](#webhook-payloads).
 - Webhook delivery is best-effort: failures, request timeouts, and full-queue drops are logged as warnings and do not stop sync. Retries/backoff are intentionally out of scope for this flag.
 - If neither storage cap is configured, sync prints one warning because WhatsApp history can grow the local database substantially.
 - `WACLI_SYNC_MAX_MESSAGES` and `WACLI_SYNC_MAX_DB_SIZE` apply the same caps to `auth` bootstrap sync and `sync`.
@@ -40,6 +41,40 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-t
 - While `sync --follow` is running, a `HEARTBEAT` file is written to the store directory (at most once per minute) with the last observed follow activity timestamp in RFC 3339 format. External watchdogs or `wacli doctor` can read this as an activity marker; quiet healthy sessions may not update it because successful keepalives are silent, and keepalive health is reported separately through `stale` events.
 - `--events` emits one NDJSON lifecycle event per stderr line for machine consumers. Routine human progress/status lines, interrupt prompts, and command errors are emitted as events while events are enabled.
 
+## Webhook payloads
+
+Webhook payloads remain flat JSON objects. Receipt and chat-presence payloads carry
+an `EventType` discriminator. Message payloads deliberately omit it so existing
+consumers receive the same signed body as before; a missing `EventType` means
+`message`.
+
+Messages use the stored live message payload documented above, unchanged:
+
+```json
+{"Chat":"15551234567@s.whatsapp.net","ID":"3EB0…","SenderJID":"15551234567@s.whatsapp.net","Timestamp":"2026-07-25T10:00:00Z","FromMe":false,"Text":"hi","ChatName":"Alice"}
+```
+
+`EventType: "receipt"` reports delivery and read state for messages you sent. Only
+`delivered`, `read`, and `played` cross the webhook; the protocol bookkeeping types
+(`sender`, `retry`, `read-self`, `played-self`, `inactive`, `server-error`, `peer_msg`,
+`hist_sync`) are dropped at the source so they cannot crowd out real messages. The
+`delivered` type is spelled out explicitly, even though WhatsApp sends it as an empty
+string on the wire. `MessageIDs` keeps WhatsApp's batching (one POST per receipt, not per message,
+minus any blank IDs), and in groups `Sender` is the participant the receipt came
+from:
+
+```json
+{"EventType":"receipt","Chat":"120363000000000000@g.us","Sender":"15551234567@s.whatsapp.net","MessageIDs":["3EB0…"],"Timestamp":"2026-07-25T10:00:01Z","Type":"delivered","IsFromMe":false}
+```
+
+`EventType: "chat_presence"` reports per-chat typing state. `Media` is `audio` while the
+contact records a voice message and empty otherwise. Global presence (`online` / last
+seen) is deliberately not forwarded:
+
+```json
+{"EventType":"chat_presence","Chat":"15551234567@s.whatsapp.net","Sender":"15551234567@s.whatsapp.net","State":"composing","Media":""}
+```
+
 ## Examples
 
 ```bash
@@ -53,4 +88,5 @@ wacli sync --follow --download-media
 wacli sync --once --events 2>events.ndjson
 wacli sync --follow --stale-threshold 2m --events 2>events.ndjson
 wacli sync --follow --webhook https://example.com/wacli --webhook-secret "$WACLI_WEBHOOK_SECRET"
+wacli sync --follow --webhook https://example.com/wacli --webhook-events message,receipt,chat_presence
 ```

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -77,7 +77,8 @@ type SyncOptions struct {
 	WebhookURL          string
 	WebhookSecret       string
 	WebhookAllowPrivate bool
-	Verbosity           int // future
+	WebhookEvents       SyncWebhookEventSet // nil = messages only
+	Verbosity           int                 // future
 }
 
 type SyncResult struct {
@@ -162,10 +163,10 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 	}
 
 	var stopWebhook func()
-	var webhookJobs chan wa.ParsedMessage
-	enqueueWebhook := func(wa.ParsedMessage) {}
+	var webhookJobs chan syncWebhookEvent
+	enqueueWebhook := func(syncWebhookEvent) {}
 	if syncWebhookEnabled(opts) {
-		webhookJobs = make(chan wa.ParsedMessage, 512)
+		webhookJobs = make(chan syncWebhookEvent, 512)
 		enqueueWebhook = a.newSyncWebhookEnqueuer(syncCtx, webhookJobs)
 		stopWebhook = a.runSyncWebhookWorker(syncCtx, opts, webhookJobs)
 		defer stopWebhook()

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -46,9 +46,16 @@ type syncPresence struct {
 	cleanupStarted bool
 }
 
-func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, messagesStored, lastEvent *atomic.Int64, disconnected chan<- struct{}, staleReconnect chan<- staleReconnectRequest, enqueueMedia func(string, string), enqueueWebhook func(wa.ParsedMessage), limits *syncStorageLimits, ps *syncPresence, mediaQ *mediaQueue) uint32 {
+func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, messagesStored, lastEvent *atomic.Int64, disconnected chan<- struct{}, staleReconnect chan<- staleReconnectRequest, enqueueMedia func(string, string), enqueueWebhook func(syncWebhookEvent), limits *syncStorageLimits, ps *syncPresence, mediaQ *mediaQueue) uint32 {
 	var panicCount atomic.Int64
 	var appStateRecoveries sync.Map
+	if enqueueWebhook == nil {
+		enqueueWebhook = func(syncWebhookEvent) {}
+	}
+	enqueueWebhookMessage := newSyncWebhookMessageEnqueuer(enqueueWebhook)
+	if !opts.WebhookEvents.Enabled(SyncWebhookEventMessage) {
+		enqueueWebhookMessage = func(wa.ParsedMessage) {}
+	}
 	return a.wa.AddEventHandler(func(evt interface{}) {
 		if mediaQ != nil {
 			if !mediaQ.beginProducer() {
@@ -88,7 +95,7 @@ func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, message
 				a.downloadAndHandleHistorySync(ctx, opts, notif, messagesStored, lastEvent, enqueueMedia, limits)
 				return
 			}
-			a.handleLiveSyncMessage(ctx, opts, v, messagesStored, enqueueMedia, enqueueWebhook, limits)
+			a.handleLiveSyncMessage(ctx, opts, v, messagesStored, enqueueMedia, enqueueWebhookMessage, limits)
 		case *events.CallOffer, *events.CallAccept, *events.CallPreAccept, *events.CallTransport,
 			*events.CallOfferNotice, *events.CallRelayLatency, *events.CallTerminate, *events.CallReject:
 			lastEvent.Store(nowUTC().UnixNano())
@@ -103,6 +110,19 @@ func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, message
 		case *events.Receipt:
 			lastEvent.Store(nowUTC().UnixNano())
 			a.handleReceiptPersistenceEvent(ctx, v)
+			if opts.WebhookEvents.Enabled(SyncWebhookEventReceipt) {
+				if job, ok := newSyncWebhookReceiptEvent(v); ok {
+					enqueueWebhook(job)
+				}
+			}
+		case *events.ChatPresence:
+			// Deliberately does not touch lastEvent: typing notifications must
+			// not keep an idle-exit sync alive.
+			if opts.WebhookEvents.Enabled(SyncWebhookEventChatPresence) {
+				if job, ok := newSyncWebhookChatPresenceEvent(v); ok {
+					enqueueWebhook(job)
+				}
+			}
 		case *events.Connected:
 			a.emitOrPrint("connected", nil, "\nConnected.\n")
 			ps.mu.Lock()

--- a/internal/app/webhook.go
+++ b/internal/app/webhook.go
@@ -15,6 +15,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/openclaw/wacli/internal/linkpreview"
@@ -37,6 +38,16 @@ type syncWebhookPayload struct {
 	ChatName string `json:"ChatName,omitempty"`
 }
 
+type syncWebhookReceiptPayload struct {
+	EventType SyncWebhookEventKind `json:"EventType"`
+	syncWebhookReceipt
+}
+
+type syncWebhookChatPresencePayload struct {
+	EventType SyncWebhookEventKind `json:"EventType"`
+	syncWebhookChatPresence
+}
+
 func newSyncWebhookSafeHTTPClient() *http.Client {
 	client := linkpreview.NewSafeHTTPClient()
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
@@ -49,25 +60,43 @@ func syncWebhookEnabled(opts SyncOptions) bool {
 	return strings.TrimSpace(opts.WebhookURL) != ""
 }
 
-func (a *App) newSyncWebhookEnqueuer(ctx context.Context, jobs chan<- wa.ParsedMessage) func(wa.ParsedMessage) {
-	return func(pm wa.ParsedMessage) {
-		if strings.TrimSpace(pm.ID) == "" {
+func (a *App) newSyncWebhookEnqueuer(ctx context.Context, jobs chan<- syncWebhookEvent) func(syncWebhookEvent) {
+	var dropped atomic.Int64
+	return func(evt syncWebhookEvent) {
+		if evt.Kind == "" {
+			evt.Kind = SyncWebhookEventMessage
+		}
+		if evt.Kind == SyncWebhookEventMessage && strings.TrimSpace(evt.Message.ID) == "" {
 			return
 		}
 		select {
-		case jobs <- pm:
+		case jobs <- evt:
 		case <-ctx.Done():
 		default:
+			// A dropped message is caught by reconciliation, but a dropped
+			// receipt is a tick that never advances and leaves no trace, so
+			// report the kind and a running total.
+			total := dropped.Add(1)
+			fields := evt.logFields()
+			fields["dropped"] = total
 			a.emitWarning(
 				"sync_webhook_dropped",
-				fmt.Sprintf("warning: sync webhook queue full; dropping message %s", pm.ID),
-				map[string]any{"message_id": pm.ID},
+				fmt.Sprintf("warning: sync webhook queue full; dropping %s %s (dropped=%d)", evt.Kind, evt.id(), total),
+				fields,
 			)
 		}
 	}
 }
 
-func (a *App) runSyncWebhookWorker(ctx context.Context, opts SyncOptions, jobs <-chan wa.ParsedMessage) func() {
+// newSyncWebhookMessageEnqueuer adapts the event enqueuer to the message-only
+// signature used by the live message path.
+func newSyncWebhookMessageEnqueuer(enqueue func(syncWebhookEvent)) func(wa.ParsedMessage) {
+	return func(pm wa.ParsedMessage) {
+		enqueue(syncWebhookEvent{Kind: SyncWebhookEventMessage, Message: pm})
+	}
+}
+
+func (a *App) runSyncWebhookWorker(ctx context.Context, opts SyncOptions, jobs <-chan syncWebhookEvent) func() {
 	if jobs == nil {
 		return func() {}
 	}
@@ -80,7 +109,7 @@ func (a *App) runSyncWebhookWorker(ctx context.Context, opts SyncOptions, jobs <
 			select {
 			case <-ctx.Done():
 				return
-			case pm, ok := <-jobs:
+			case evt, ok := <-jobs:
 				if !ok {
 					return
 				}
@@ -88,18 +117,23 @@ func (a *App) runSyncWebhookWorker(ctx context.Context, opts SyncOptions, jobs <
 					defer func() {
 						if r := recover(); r != nil {
 							stack := debug.Stack()
+							fields := evt.logFields()
+							fields["panic"] = fmt.Sprint(r)
+							fields["stack"] = string(stack)
 							a.emitWarning(
 								"sync_webhook_panic",
-								fmt.Sprintf("sync webhook worker panic (recovered) for %s: %v\n%s", pm.ID, r, stack),
-								map[string]any{"message_id": pm.ID, "panic": fmt.Sprint(r), "stack": string(stack)},
+								fmt.Sprintf("sync webhook worker panic (recovered) for %s: %v\n%s", evt.id(), r, stack),
+								fields,
 							)
 						}
 					}()
-					if err := a.postSyncWebhook(ctx, opts, pm); err != nil {
+					if err := a.postSyncWebhookEvent(ctx, opts, evt); err != nil {
+						fields := evt.logFields()
+						fields["error"] = err.Error()
 						a.emitWarning(
 							"sync_webhook_failed",
-							fmt.Sprintf("warning: sync webhook failed for message %s: %v", pm.ID, err),
-							map[string]any{"message_id": pm.ID, "error": err.Error()},
+							fmt.Sprintf("warning: sync webhook failed for %s %s: %v", evt.Kind, evt.id(), err),
+							fields,
 						)
 					}
 				}()
@@ -112,14 +146,14 @@ func (a *App) runSyncWebhookWorker(ctx context.Context, opts SyncOptions, jobs <
 	}
 }
 
-func (a *App) postSyncWebhook(ctx context.Context, opts SyncOptions, pm wa.ParsedMessage) error {
+func (a *App) postSyncWebhookEvent(ctx context.Context, opts SyncOptions, evt syncWebhookEvent) error {
 	webhookURL := strings.TrimSpace(opts.WebhookURL)
 	if webhookURL == "" {
 		return nil
 	}
 	ctx, cancel := context.WithTimeout(ctx, syncWebhookRequestTimeout)
 	defer cancel()
-	payload, err := json.Marshal(a.newSyncWebhookPayload(ctx, pm))
+	payload, err := json.Marshal(a.newSyncWebhookEventPayload(ctx, evt))
 	if err != nil {
 		return fmt.Errorf("marshal webhook payload: %w", err)
 	}
@@ -141,6 +175,17 @@ func (a *App) postSyncWebhook(ctx context.Context, opts SyncOptions, pm wa.Parse
 		return fmt.Errorf("post webhook: %s", resp.Status)
 	}
 	return nil
+}
+
+func (a *App) newSyncWebhookEventPayload(ctx context.Context, evt syncWebhookEvent) any {
+	switch evt.Kind {
+	case SyncWebhookEventReceipt:
+		return syncWebhookReceiptPayload{EventType: SyncWebhookEventReceipt, syncWebhookReceipt: evt.Receipt}
+	case SyncWebhookEventChatPresence:
+		return syncWebhookChatPresencePayload{EventType: SyncWebhookEventChatPresence, syncWebhookChatPresence: evt.Presence}
+	default:
+		return a.newSyncWebhookPayload(ctx, evt.Message)
+	}
 }
 
 func (a *App) newSyncWebhookPayload(ctx context.Context, pm wa.ParsedMessage) syncWebhookPayload {

--- a/internal/app/webhook_events.go
+++ b/internal/app/webhook_events.go
@@ -1,0 +1,189 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openclaw/wacli/internal/wa"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+// SyncWebhookEventKind identifies the selected webhook event kind. New event
+// payloads carry it as "EventType"; message payloads deliberately omit it to
+// preserve the established webhook body byte-for-byte.
+type SyncWebhookEventKind string
+
+const (
+	SyncWebhookEventMessage      SyncWebhookEventKind = "message"
+	SyncWebhookEventReceipt      SyncWebhookEventKind = "receipt"
+	SyncWebhookEventChatPresence SyncWebhookEventKind = "chat_presence"
+)
+
+var syncWebhookEventKinds = []SyncWebhookEventKind{
+	SyncWebhookEventMessage,
+	SyncWebhookEventReceipt,
+	SyncWebhookEventChatPresence,
+}
+
+// SyncWebhookEventSet is the set of event kinds the webhook forwards. The zero
+// value forwards messages only.
+type SyncWebhookEventSet map[SyncWebhookEventKind]bool
+
+// ParseSyncWebhookEvents parses a comma-separated --webhook-events value. An
+// empty value means the default: messages only.
+func ParseSyncWebhookEvents(raw string) (SyncWebhookEventSet, error) {
+	set := SyncWebhookEventSet{}
+	for _, part := range strings.Split(raw, ",") {
+		kind := SyncWebhookEventKind(strings.ToLower(strings.TrimSpace(part)))
+		if kind == "" {
+			continue
+		}
+		if !kind.valid() {
+			return nil, fmt.Errorf("--webhook-events must be a comma-separated list of: %s (got %q)", strings.Join(syncWebhookEventNames(), ", "), strings.TrimSpace(part))
+		}
+		set[kind] = true
+	}
+	if len(set) == 0 {
+		set[SyncWebhookEventMessage] = true
+	}
+	return set, nil
+}
+
+func (k SyncWebhookEventKind) valid() bool {
+	for _, known := range syncWebhookEventKinds {
+		if k == known {
+			return true
+		}
+	}
+	return false
+}
+
+func syncWebhookEventNames() []string {
+	names := make([]string, 0, len(syncWebhookEventKinds))
+	for _, kind := range syncWebhookEventKinds {
+		names = append(names, string(kind))
+	}
+	return names
+}
+
+// Enabled reports whether the kind should be forwarded. A nil or empty set
+// behaves like the default (messages only).
+func (s SyncWebhookEventSet) Enabled(kind SyncWebhookEventKind) bool {
+	if len(s) == 0 {
+		return kind == SyncWebhookEventMessage
+	}
+	return s[kind]
+}
+
+// syncWebhookEvent is one queued webhook delivery. Exactly one of the payload
+// fields is set, selected by Kind.
+type syncWebhookEvent struct {
+	Kind     SyncWebhookEventKind
+	Message  wa.ParsedMessage
+	Receipt  syncWebhookReceipt
+	Presence syncWebhookChatPresence
+}
+
+// id is only used for log lines; receipts carry a batch of message IDs and
+// presence carries none, so it identifies the chat instead.
+func (e syncWebhookEvent) id() string {
+	switch e.Kind {
+	case SyncWebhookEventReceipt:
+		return strings.Join(e.Receipt.MessageIDs, ",")
+	case SyncWebhookEventChatPresence:
+		return e.Presence.Chat.String()
+	default:
+		return e.Message.ID
+	}
+}
+
+// logFields identifies the event in a warning. message_id is only set for
+// messages: the other kinds have no single message ID, and publishing a chat
+// JID under that key would mislead machine consumers of the NDJSON events.
+func (e syncWebhookEvent) logFields() map[string]any {
+	fields := map[string]any{"event_type": string(e.Kind), "event_id": e.id()}
+	if e.Kind == SyncWebhookEventMessage {
+		fields["message_id"] = e.Message.ID
+	}
+	return fields
+}
+
+type syncWebhookReceipt struct {
+	Chat       types.JID `json:"Chat"`
+	Sender     types.JID `json:"Sender"`
+	MessageIDs []string  `json:"MessageIDs"`
+	Timestamp  time.Time `json:"Timestamp"`
+	Type       string    `json:"Type"`
+	IsFromMe   bool      `json:"IsFromMe"`
+}
+
+type syncWebhookChatPresence struct {
+	Chat   types.JID `json:"Chat"`
+	Sender types.JID `json:"Sender"`
+	State  string    `json:"State"`
+	Media  string    `json:"Media"`
+}
+
+// forwardedReceiptTypes are the only receipt types that cross the webhook. The
+// rest (sender, retry, inactive, read-self, played-self, server-error,
+// peer_msg, hist_sync) are protocol bookkeeping that would compete with real
+// messages for the bounded queue, multiplied by participant in groups.
+var forwardedReceiptTypes = map[types.ReceiptType]string{
+	types.ReceiptTypeDelivered: "delivered",
+	types.ReceiptTypeRead:      "read",
+	types.ReceiptTypePlayed:    "played",
+}
+
+// newSyncWebhookReceiptEvent converts a receipt event into a webhook event,
+// reporting false when the receipt type is not forwarded. The empty wire value
+// for "delivered" is spelled out so consumers never have to switch on "".
+func newSyncWebhookReceiptEvent(evt *events.Receipt) (syncWebhookEvent, bool) {
+	if evt == nil || evt.Chat.IsEmpty() || len(evt.MessageIDs) == 0 {
+		return syncWebhookEvent{}, false
+	}
+	receiptType, ok := forwardedReceiptTypes[evt.Type]
+	if !ok {
+		return syncWebhookEvent{}, false
+	}
+	ids := make([]string, 0, len(evt.MessageIDs))
+	for _, id := range evt.MessageIDs {
+		if strings.TrimSpace(id) == "" {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return syncWebhookEvent{}, false
+	}
+	return syncWebhookEvent{
+		Kind: SyncWebhookEventReceipt,
+		Receipt: syncWebhookReceipt{
+			Chat:       evt.Chat,
+			Sender:     evt.Sender,
+			MessageIDs: ids,
+			Timestamp:  evt.Timestamp,
+			Type:       receiptType,
+			IsFromMe:   evt.IsFromMe,
+		},
+	}, true
+}
+
+func newSyncWebhookChatPresenceEvent(evt *events.ChatPresence) (syncWebhookEvent, bool) {
+	if evt == nil || evt.Chat.IsEmpty() {
+		return syncWebhookEvent{}, false
+	}
+	if evt.State != types.ChatPresenceComposing && evt.State != types.ChatPresencePaused {
+		return syncWebhookEvent{}, false
+	}
+	return syncWebhookEvent{
+		Kind: SyncWebhookEventChatPresence,
+		Presence: syncWebhookChatPresence{
+			Chat:   evt.Chat,
+			Sender: evt.Sender,
+			State:  string(evt.State),
+			Media:  string(evt.Media),
+		},
+	}, true
+}

--- a/internal/app/webhook_events_test.go
+++ b/internal/app/webhook_events_test.go
@@ -1,0 +1,483 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openclaw/wacli/internal/wa"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestParseSyncWebhookEvents(t *testing.T) {
+	t.Run("default is message only", func(t *testing.T) {
+		set, err := ParseSyncWebhookEvents("message")
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if !set.Enabled(SyncWebhookEventMessage) {
+			t.Fatal("message should be enabled")
+		}
+		for _, kind := range []SyncWebhookEventKind{SyncWebhookEventReceipt, SyncWebhookEventChatPresence} {
+			if set.Enabled(kind) {
+				t.Fatalf("%s should be disabled by default", kind)
+			}
+		}
+	})
+
+	t.Run("empty value falls back to message", func(t *testing.T) {
+		set, err := ParseSyncWebhookEvents("")
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if !set.Enabled(SyncWebhookEventMessage) || set.Enabled(SyncWebhookEventReceipt) {
+			t.Fatalf("unexpected set %v", set)
+		}
+	})
+
+	t.Run("zero value behaves like the default", func(t *testing.T) {
+		var set SyncWebhookEventSet
+		if !set.Enabled(SyncWebhookEventMessage) || set.Enabled(SyncWebhookEventChatPresence) {
+			t.Fatal("nil set must forward messages only")
+		}
+	})
+
+	t.Run("all three kinds", func(t *testing.T) {
+		set, err := ParseSyncWebhookEvents(" message , receipt ,chat_presence")
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		for _, kind := range []SyncWebhookEventKind{SyncWebhookEventMessage, SyncWebhookEventReceipt, SyncWebhookEventChatPresence} {
+			if !set.Enabled(kind) {
+				t.Fatalf("%s should be enabled", kind)
+			}
+		}
+	})
+
+	t.Run("receipts without messages", func(t *testing.T) {
+		set, err := ParseSyncWebhookEvents("receipt")
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if set.Enabled(SyncWebhookEventMessage) {
+			t.Fatal("message should not be implied")
+		}
+	})
+
+	t.Run("unknown kind is rejected", func(t *testing.T) {
+		if _, err := ParseSyncWebhookEvents("message,presence"); err == nil {
+			t.Fatal("expected error for unknown event kind")
+		}
+	})
+}
+
+func TestNewSyncWebhookReceiptEventFiltersNoise(t *testing.T) {
+	chat := types.JID{User: "120363000000000000", Server: types.GroupServer}
+	sender := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+	base := func(receiptType types.ReceiptType) *events.Receipt {
+		return &events.Receipt{
+			MessageSource: types.MessageSource{Chat: chat, Sender: sender, IsGroup: true},
+			MessageIDs:    []types.MessageID{"m-1"},
+			Timestamp:     time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC),
+			Type:          receiptType,
+		}
+	}
+
+	for _, receiptType := range []types.ReceiptType{
+		types.ReceiptTypeSender,
+		types.ReceiptTypeRetry,
+		types.ReceiptTypeReadSelf,
+		types.ReceiptTypePlayedSelf,
+		types.ReceiptTypeInactive,
+		types.ReceiptTypeServerError,
+		types.ReceiptTypePeerMsg,
+		types.ReceiptTypeHistorySync,
+	} {
+		if _, ok := newSyncWebhookReceiptEvent(base(receiptType)); ok {
+			t.Fatalf("receipt type %q should not cross the webhook", receiptType)
+		}
+	}
+
+	for receiptType, want := range map[types.ReceiptType]string{
+		types.ReceiptTypeDelivered: "delivered",
+		types.ReceiptTypeRead:      "read",
+		types.ReceiptTypePlayed:    "played",
+	} {
+		evt, ok := newSyncWebhookReceiptEvent(base(receiptType))
+		if !ok {
+			t.Fatalf("receipt type %q should be forwarded", receiptType)
+		}
+		if evt.Receipt.Type != want {
+			t.Fatalf("receipt type = %q, want %q", evt.Receipt.Type, want)
+		}
+		if evt.Receipt.Sender != sender {
+			t.Fatalf("receipt sender = %s, want the group participant %s", evt.Receipt.Sender, sender)
+		}
+	}
+
+	if _, ok := newSyncWebhookReceiptEvent(&events.Receipt{
+		MessageSource: types.MessageSource{Chat: chat},
+		Type:          types.ReceiptTypeRead,
+	}); ok {
+		t.Fatal("receipt without message IDs should be dropped")
+	}
+}
+
+func TestNewSyncWebhookReceiptEventKeepsBatches(t *testing.T) {
+	evt, ok := newSyncWebhookReceiptEvent(&events.Receipt{
+		MessageSource: types.MessageSource{Chat: types.JID{User: "15551234567", Server: types.DefaultUserServer}},
+		MessageIDs:    []types.MessageID{"m-1", "", "m-2"},
+		Type:          types.ReceiptTypeRead,
+	})
+	if !ok {
+		t.Fatal("receipt should be forwarded")
+	}
+	if len(evt.Receipt.MessageIDs) != 2 {
+		t.Fatalf("message IDs = %v, want the batch intact minus blanks", evt.Receipt.MessageIDs)
+	}
+}
+
+func TestSyncWebhookPayloadShapes(t *testing.T) {
+	a := newTestApp(t)
+	ctx := context.Background()
+
+	receipt, ok := newSyncWebhookReceiptEvent(&events.Receipt{
+		MessageSource: types.MessageSource{
+			Chat:     types.JID{User: "120363000000000000", Server: types.GroupServer},
+			Sender:   types.JID{User: "15551234567", Server: types.DefaultUserServer},
+			IsFromMe: false,
+			IsGroup:  true,
+		},
+		MessageIDs: []types.MessageID{"m-1"},
+		Timestamp:  time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC),
+		Type:       types.ReceiptTypeDelivered,
+	})
+	if !ok {
+		t.Fatal("receipt should be forwarded")
+	}
+	body, err := json.Marshal(a.newSyncWebhookEventPayload(ctx, receipt))
+	if err != nil {
+		t.Fatalf("marshal receipt: %v", err)
+	}
+	for _, want := range []string{
+		`"EventType":"receipt"`,
+		`"Chat":"120363000000000000@g.us"`,
+		`"Sender":"15551234567@s.whatsapp.net"`,
+		`"MessageIDs":["m-1"]`,
+		`"Type":"delivered"`,
+		`"IsFromMe":false`,
+	} {
+		if !bytes.Contains(body, []byte(want)) {
+			t.Fatalf("receipt payload missing %s: %s", want, body)
+		}
+	}
+
+	presence, ok := newSyncWebhookChatPresenceEvent(&events.ChatPresence{
+		MessageSource: types.MessageSource{
+			Chat:   types.JID{User: "120363000000000000", Server: types.GroupServer},
+			Sender: types.JID{User: "15551234567", Server: types.DefaultUserServer},
+		},
+		State: types.ChatPresenceComposing,
+		Media: types.ChatPresenceMediaAudio,
+	})
+	if !ok {
+		t.Fatal("chat presence should be forwarded")
+	}
+	body, err = json.Marshal(a.newSyncWebhookEventPayload(ctx, presence))
+	if err != nil {
+		t.Fatalf("marshal chat presence: %v", err)
+	}
+	for _, want := range []string{
+		`"EventType":"chat_presence"`,
+		`"State":"composing"`,
+		`"Media":"audio"`,
+	} {
+		if !bytes.Contains(body, []byte(want)) {
+			t.Fatalf("chat presence payload missing %s: %s", want, body)
+		}
+	}
+}
+
+func TestMessageWebhookPayloadMatchesLegacyBody(t *testing.T) {
+	a := newTestApp(t)
+	message := wa.ParsedMessage{ID: "m-legacy", Text: "hello"}
+
+	got, err := json.Marshal(a.newSyncWebhookEventPayload(context.Background(), syncWebhookEvent{
+		Kind:    SyncWebhookEventMessage,
+		Message: message,
+	}))
+	if err != nil {
+		t.Fatalf("marshal message event: %v", err)
+	}
+	legacy, err := json.Marshal(struct {
+		wa.ParsedMessage
+		ChatName string `json:"ChatName,omitempty"`
+	}{ParsedMessage: message})
+	if err != nil {
+		t.Fatalf("marshal legacy message: %v", err)
+	}
+	if !bytes.Equal(got, legacy) {
+		t.Fatalf("message payload changed\ngot:  %s\nwant: %s", got, legacy)
+	}
+}
+
+func TestPostSyncWebhookEventSignsNewEventKinds(t *testing.T) {
+	events := []syncWebhookEvent{
+		{
+			Kind: SyncWebhookEventReceipt,
+			Receipt: syncWebhookReceipt{
+				Chat:       types.JID{User: "120363000000000000", Server: types.GroupServer},
+				MessageIDs: []string{"m-1"},
+				Type:       "read",
+			},
+		},
+		{
+			Kind: SyncWebhookEventChatPresence,
+			Presence: syncWebhookChatPresence{
+				Chat:  types.JID{User: "15551234567", Server: types.DefaultUserServer},
+				State: "composing",
+			},
+		},
+	}
+
+	for _, event := range events {
+		event := event
+		t.Run(string(event.Kind), func(t *testing.T) {
+			var body []byte
+			var signature string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var err error
+				body, err = io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("read body: %v", err)
+				}
+				signature = r.Header.Get("X-Wacli-Signature")
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer server.Close()
+
+			a := newTestApp(t)
+			err := a.postSyncWebhookEvent(context.Background(), SyncOptions{
+				WebhookURL:          server.URL,
+				WebhookSecret:       "test-secret",
+				WebhookAllowPrivate: true,
+			}, event)
+			if err != nil {
+				t.Fatalf("post event: %v", err)
+			}
+			if want := syncWebhookSignature("test-secret", body); signature != want {
+				t.Fatalf("signature = %q, want %q", signature, want)
+			}
+		})
+	}
+}
+
+// syncWebhookRecorder collects webhook bodies for the handler-level tests.
+type syncWebhookRecorder struct {
+	srv    *httptest.Server
+	bodies chan []byte
+}
+
+func newSyncWebhookRecorder(t *testing.T) *syncWebhookRecorder {
+	t.Helper()
+	rec := &syncWebhookRecorder{bodies: make(chan []byte, 8)}
+	rec.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("ReadAll: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		rec.bodies <- body
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(rec.srv.Close)
+	return rec
+}
+
+func (r *syncWebhookRecorder) next(t *testing.T) []byte {
+	t.Helper()
+	select {
+	case body := <-r.bodies:
+		return body
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook request")
+		return nil
+	}
+}
+
+func (r *syncWebhookRecorder) expectSilence(t *testing.T) {
+	t.Helper()
+	select {
+	case body := <-r.bodies:
+		t.Fatalf("unexpected webhook request: %s", body)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func emitWebhookEvents(t *testing.T, webhookEvents string, emit func(f *fakeWA)) *syncWebhookRecorder {
+	t.Helper()
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	rec := newSyncWebhookRecorder(t)
+	set, err := ParseSyncWebhookEvents(webhookEvents)
+	if err != nil {
+		t.Fatalf("parse webhook events: %v", err)
+	}
+	opts := SyncOptions{
+		Mode:                SyncModeFollow,
+		WebhookURL:          rec.srv.URL,
+		WebhookAllowPrivate: true,
+		WebhookEvents:       set,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	jobs := make(chan syncWebhookEvent, 8)
+	stopWebhook := a.runSyncWebhookWorker(ctx, opts, jobs)
+	t.Cleanup(stopWebhook)
+
+	var messagesStored, lastEvent atomic.Int64
+	handlerID := a.addSyncEventHandler(
+		ctx,
+		opts,
+		&messagesStored,
+		&lastEvent,
+		make(chan struct{}, 1),
+		make(chan staleReconnectRequest, 1),
+		func(string, string) {},
+		a.newSyncWebhookEnqueuer(ctx, jobs),
+		nil,
+		&syncPresence{},
+		nil,
+	)
+	t.Cleanup(func() { f.RemoveEventHandler(handlerID) })
+
+	emit(f)
+	return rec
+}
+
+func testReceiptEvent() *events.Receipt {
+	return &events.Receipt{
+		MessageSource: types.MessageSource{
+			Chat:   types.JID{User: "15551234567", Server: types.DefaultUserServer},
+			Sender: types.JID{User: "15551234567", Server: types.DefaultUserServer},
+		},
+		MessageIDs: []types.MessageID{"m-1"},
+		Timestamp:  time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC),
+		Type:       types.ReceiptTypeRead,
+	}
+}
+
+func testChatPresenceEvent() *events.ChatPresence {
+	return &events.ChatPresence{
+		MessageSource: types.MessageSource{
+			Chat:   types.JID{User: "15551234567", Server: types.DefaultUserServer},
+			Sender: types.JID{User: "15551234567", Server: types.DefaultUserServer},
+		},
+		State: types.ChatPresenceComposing,
+	}
+}
+
+func testLiveMessageEvent() *events.Message {
+	return &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:   types.JID{User: "15551234567", Server: types.DefaultUserServer},
+				Sender: types.JID{User: "15551234567", Server: types.DefaultUserServer},
+			},
+			ID:        "m-live",
+			Timestamp: time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC),
+		},
+		Message: &waProto.Message{Conversation: proto.String("hello")},
+	}
+}
+
+func TestDefaultWebhookEventsForwardMessagesOnly(t *testing.T) {
+	rec := emitWebhookEvents(t, "message", func(f *fakeWA) {
+		f.emit(testReceiptEvent())
+		f.emit(testChatPresenceEvent())
+	})
+	rec.expectSilence(t)
+
+	rec = emitWebhookEvents(t, "message", func(f *fakeWA) {
+		f.emit(testLiveMessageEvent())
+	})
+	body := rec.next(t)
+	if bytes.Contains(body, []byte(`"EventType"`)) {
+		t.Fatalf("legacy message payload gained EventType: %s", body)
+	}
+	for _, want := range []string{`"ID":"m-live"`, `"Text":"hello"`} {
+		if !bytes.Contains(body, []byte(want)) {
+			t.Fatalf("message payload missing %s: %s", want, body)
+		}
+	}
+}
+
+func TestWebhookEventsOptInDeliversAllThreeKinds(t *testing.T) {
+	rec := emitWebhookEvents(t, "message,receipt,chat_presence", func(f *fakeWA) {
+		f.emit(testLiveMessageEvent())
+		f.emit(testReceiptEvent())
+		f.emit(testChatPresenceEvent())
+	})
+
+	seen := map[string]bool{}
+	for i := 0; i < 3; i++ {
+		var payload struct {
+			EventType string
+		}
+		body := rec.next(t)
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("unmarshal %s: %v", body, err)
+		}
+		kind := payload.EventType
+		if kind == "" {
+			if !bytes.Contains(body, []byte(`"ID":"m-live"`)) {
+				t.Fatalf("payload without EventType is not a message: %s", body)
+			}
+			kind = string(SyncWebhookEventMessage)
+		}
+		seen[kind] = true
+	}
+	for _, want := range []string{"message", "receipt", "chat_presence"} {
+		if !seen[want] {
+			t.Fatalf("missing %s event, saw %v", want, seen)
+		}
+	}
+}
+
+func TestWebhookEventsWithoutMessageStopsForwardingMessages(t *testing.T) {
+	rec := emitWebhookEvents(t, "receipt", func(f *fakeWA) {
+		f.emit(testLiveMessageEvent())
+		f.emit(testReceiptEvent())
+	})
+
+	body := rec.next(t)
+	if !bytes.Contains(body, []byte(`"EventType":"receipt"`)) {
+		t.Fatalf("first payload should be the receipt, got %s", body)
+	}
+	rec.expectSilence(t)
+}
+
+// events.Presence (online / last seen) is deliberately out of scope: only
+// per-chat typing state is forwarded.
+func TestGlobalPresenceIsNeverForwarded(t *testing.T) {
+	rec := emitWebhookEvents(t, "message,receipt,chat_presence", func(f *fakeWA) {
+		f.emit(&events.Presence{
+			From:        types.JID{User: "15551234567", Server: types.DefaultUserServer},
+			Unavailable: false,
+		})
+	})
+	rec.expectSilence(t)
+}

--- a/internal/app/webhook_test.go
+++ b/internal/app/webhook_test.go
@@ -70,7 +70,7 @@ func TestHandleLiveSyncMessagePostsSignedWebhookWithGroupName(t *testing.T) {
 	}
 
 	var messagesStored atomic.Int64
-	jobs := make(chan wa.ParsedMessage, 1)
+	jobs := make(chan syncWebhookEvent, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	stopWebhook := a.runSyncWebhookWorker(ctx, SyncOptions{
@@ -84,7 +84,7 @@ func TestHandleLiveSyncMessagePostsSignedWebhookWithGroupName(t *testing.T) {
 		WebhookURL:          srv.URL,
 		WebhookSecret:       "supersecret",
 		WebhookAllowPrivate: true,
-	}, evt, &messagesStored, func(string, string) {}, a.newSyncWebhookEnqueuer(ctx, jobs))
+	}, evt, &messagesStored, func(string, string) {}, newSyncWebhookMessageEnqueuer(a.newSyncWebhookEnqueuer(ctx, jobs)))
 
 	if messagesStored.Load() != 1 {
 		t.Fatalf("messages stored = %d, want 1", messagesStored.Load())
@@ -101,6 +101,9 @@ func TestHandleLiveSyncMessagePostsSignedWebhookWithGroupName(t *testing.T) {
 	}
 	if got.signature != syncWebhookSignature("supersecret", got.body) {
 		t.Fatalf("signature = %q, want %q", got.signature, syncWebhookSignature("supersecret", got.body))
+	}
+	if bytes.Contains(got.body, []byte(`"EventType"`)) {
+		t.Fatalf("legacy message payload gained EventType: %s", got.body)
 	}
 	for _, want := range [][]byte{
 		[]byte(`"ChatName":"test1"`),
@@ -127,7 +130,7 @@ func TestHandleLiveSyncMessageDoesNotBlockOnWebhookDelivery(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	jobs := make(chan wa.ParsedMessage, 1)
+	jobs := make(chan syncWebhookEvent, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	stopWebhook := a.runSyncWebhookWorker(ctx, SyncOptions{WebhookURL: srv.URL, WebhookAllowPrivate: true}, jobs)
@@ -146,7 +149,7 @@ func TestHandleLiveSyncMessageDoesNotBlockOnWebhookDelivery(t *testing.T) {
 	var messagesStored atomic.Int64
 	returned := make(chan struct{})
 	go func() {
-		a.handleLiveSyncMessage(context.Background(), SyncOptions{WebhookURL: srv.URL, WebhookAllowPrivate: true}, evt, &messagesStored, func(string, string) {}, a.newSyncWebhookEnqueuer(ctx, jobs))
+		a.handleLiveSyncMessage(context.Background(), SyncOptions{WebhookURL: srv.URL, WebhookAllowPrivate: true}, evt, &messagesStored, func(string, string) {}, newSyncWebhookMessageEnqueuer(a.newSyncWebhookEnqueuer(ctx, jobs)))
 		close(returned)
 	}()
 
@@ -175,7 +178,10 @@ func TestPostSyncWebhookRejectsLocalhostByDefault(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	err := a.postSyncWebhook(context.Background(), SyncOptions{WebhookURL: srv.URL}, wa.ParsedMessage{ID: "m-local"})
+	err := a.postSyncWebhookEvent(context.Background(), SyncOptions{WebhookURL: srv.URL}, syncWebhookEvent{
+		Kind:    SyncWebhookEventMessage,
+		Message: wa.ParsedMessage{ID: "m-local"},
+	})
 	if err == nil {
 		t.Fatal("expected localhost webhook to be rejected")
 	}
@@ -207,10 +213,10 @@ func TestPostSyncWebhookUsesRequestTimeout(t *testing.T) {
 	}
 
 	start := time.Now()
-	err := a.postSyncWebhook(context.Background(), SyncOptions{
+	err := a.postSyncWebhookEvent(context.Background(), SyncOptions{
 		WebhookURL:          "https://example.test/hook",
 		WebhookAllowPrivate: true,
-	}, wa.ParsedMessage{ID: "m-timeout"})
+	}, syncWebhookEvent{Kind: SyncWebhookEventMessage, Message: wa.ParsedMessage{ID: "m-timeout"}})
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}


### PR DESCRIPTION
## Problem

The sync webhook only forwards messages. Delivery/read receipts and typing
notifications never leave the runtime, so a consumer building a WhatsApp-like UI
on top of `wacli sync --follow` cannot show message ticks or "typing…" at all —
the data is there in `whatsmeow`, it just has no way out.

## What this adds

`--webhook-events`, a comma-separated opt-in list (`message`, `receipt`,
`chat_presence`) that defaults to `message`. With the default, the payload stream
is what it has always been, plus one additive field.

Every webhook body now carries a flat `EventType` discriminator:

```json
{"EventType":"message","Chat":"…","ID":"3EB0…","Text":"hi","ChatName":"Alice"}
{"EventType":"receipt","Chat":"…@g.us","Sender":"…@s.whatsapp.net","MessageIDs":["3EB0…"],"Timestamp":"…","Type":"delivered","IsFromMe":false}
{"EventType":"chat_presence","Chat":"…","Sender":"…","State":"composing","Media":""}
```

Flat and additive rather than a `{type, data}` envelope on purpose: re-nesting the
message would break every existing consumer, and the discriminator alone is enough
to switch on.

### Design notes

- **Receipts are filtered at the source** to `delivered`, `read` and `played`. The
  bookkeeping types (`sender`, `retry`, `read-self`, `played-self`, `inactive`,
  `server-error`, `peer_msg`, `hist_sync`) are dropped before enqueuing: in groups
  they multiply by participant and would compete with real messages for the bounded
  queue. Happy to reverse this and forward `Type` verbatim if you would rather the
  webhook not have an opinion.
- **`delivered` is spelled out**, even though WhatsApp sends it as an empty string.
  A consumer switching on `"delivered"` silently never matches otherwise.
- `MessageIDs` keeps WhatsApp's batching (one POST per receipt, not per message),
  and in groups `Sender` is the participant the receipt came from.
- **`events.Presence` (online / last seen) is not forwarded** — out of scope here,
  and it would need `SubscribePresence` anyway.
- **The queue stays at 512 with one worker.** The full-queue warning now reports the
  dropped event kind and a running total: a dropped message is recoverable by
  reconciliation, a dropped `delivered` is a tick that never advances and today
  leaves no trace.
- `chat_presence` only produces events under `--presence-mode normal`, since
  WhatsApp only sends typing notifications to devices that mark themselves
  available. Documented on the flag.

## Docs and tests

`docs/sync.md` documents the flag and all three payload shapes, next to the
existing webhook docs. Tests cover flag parsing and validation, the receipt-type
filter and the empty-string translation, batch preservation, the JSON shape of
each payload, that the default forwards messages only, that the opt-in delivers
all three kinds, and that `events.Presence` never reaches the webhook.

`pnpm test`, `pnpm lint`, `pnpm format:check` and the `deadcode` gate are green
locally.
