### PR TITLE
feat: add opt-in --send-spacing to pace delegated sends

### DIFF
--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -140,6 +140,11 @@ func startSendDelegateServer(ctx context.Context, a *app.App, spacing sendSpacin
 
 	done := make(chan struct{})
 	var sendMu sync.Mutex
+	var pacedSendSlot chan struct{}
+	if spacing.enabled() {
+		pacedSendSlot = make(chan struct{}, 1)
+		pacedSendSlot <- struct{}{}
+	}
 	// One pacer shared across connections: it spaces the serialized delegated
 	// sends so a burst of `wacli send` processes delegating to this daemon
 	// leaves the wire paced instead of back-to-back. Disabled = no-op.
@@ -151,7 +156,7 @@ func startSendDelegateServer(ctx context.Context, a *app.App, spacing sendSpacin
 			if err != nil {
 				return
 			}
-			go handleSendDelegateConn(ctx, conn, a, &sendMu, pacer)
+			go handleSendDelegateConn(ctx, conn, a, &sendMu, pacedSendSlot, pacer)
 		}
 	}()
 
@@ -177,7 +182,7 @@ func removeStaleSendDelegateSocket(path string) error {
 	return os.Remove(path)
 }
 
-func handleSendDelegateConn(ctx context.Context, conn net.Conn, a *app.App, sendMu *sync.Mutex, pacer *sendPacer) {
+func handleSendDelegateConn(ctx context.Context, conn net.Conn, a *app.App, sendMu *sync.Mutex, pacedSendSlot chan struct{}, pacer *sendPacer) {
 	defer conn.Close()
 	_ = conn.SetDeadline(time.Now().Add(5 * time.Minute))
 
@@ -193,8 +198,23 @@ func handleSendDelegateConn(ctx context.Context, conn net.Conn, a *app.App, send
 		defer cancel()
 	}
 
-	sendMu.Lock()
-	defer sendMu.Unlock()
+	if pacer.enabled() {
+		select {
+		case <-requestCtx.Done():
+			_ = json.NewEncoder(conn).Encode(sendDelegateResponse{
+				OK:    false,
+				Error: "send spacing exceeded request timeout before dispatch",
+			})
+			return
+		case <-pacedSendSlot:
+			defer func() { pacedSendSlot <- struct{}{} }()
+		}
+	} else {
+		// Preserve the original unpaced serialization path exactly when the
+		// opt-in flag is unset.
+		sendMu.Lock()
+		defer sendMu.Unlock()
+	}
 
 	// Space this send from the previous one while serialized. Bound the wait by
 	// the caller's request timeout, including time spent waiting for earlier

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -59,6 +59,7 @@ type sendDelegateRequest struct {
 	PresenceMedia        string   `json:"presence_media,omitempty"`
 	PostSendWaitMS       int64    `json:"post_send_wait_ms,omitempty"`
 	TimeoutMS            int64    `json:"timeout_ms,omitempty"`
+	DeadlineUnixMS       int64    `json:"deadline_unix_ms,omitempty"`
 }
 
 type sendDelegateResponse struct {
@@ -96,7 +97,9 @@ func delegateSend(ctx context.Context, flags *rootFlags, req sendDelegateRequest
 	}
 	defer conn.Close()
 
-	_ = conn.SetDeadline(time.Now().Add(commandTimeout(flags)))
+	deadline := time.Now().Add(commandTimeout(flags))
+	req.DeadlineUnixMS = deadline.UnixMilli()
+	_ = conn.SetDeadline(deadline)
 	if err := json.NewEncoder(conn).Encode(req); err != nil {
 		return sendDelegateResponse{}, err
 	}
@@ -194,14 +197,21 @@ func handleSendDelegateConn(ctx context.Context, conn net.Conn, a *app.App, send
 	}
 	requestCtx := ctx
 	if pacer.enabled() {
+		deadline := time.Now().Add(millisDuration(req.TimeoutMS, 5*time.Minute))
+		if req.DeadlineUnixMS > 0 {
+			callerDeadline := time.UnixMilli(req.DeadlineUnixMS)
+			if callerDeadline.Before(deadline) {
+				deadline = callerDeadline
+			}
+		}
 		var cancel context.CancelFunc
-		requestCtx, cancel = context.WithTimeout(ctx, millisDuration(req.TimeoutMS, 5*time.Minute))
+		requestCtx, cancel = context.WithDeadline(ctx, deadline)
 		defer cancel()
-		if deadline, ok := requestCtx.Deadline(); ok {
+		if requestDeadline, ok := requestCtx.Deadline(); ok {
 			// The fixed initial deadline only protects request decoding. A paced
 			// request may intentionally run longer than five minutes, so keep the
 			// transport alive through its budget and the final response write.
-			_ = conn.SetDeadline(deadline.Add(sendDelegateResponseGrace))
+			_ = conn.SetDeadline(requestDeadline.Add(sendDelegateResponseGrace))
 		}
 	}
 

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -186,28 +186,37 @@ func handleSendDelegateConn(ctx context.Context, conn net.Conn, a *app.App, send
 		_ = json.NewEncoder(conn).Encode(sendDelegateResponse{OK: false, Error: err.Error()})
 		return
 	}
+	requestCtx := ctx
+	if pacer.enabled() {
+		var cancel context.CancelFunc
+		requestCtx, cancel = context.WithTimeout(ctx, millisDuration(req.TimeoutMS, 5*time.Minute))
+		defer cancel()
+	}
+
 	sendMu.Lock()
 	defer sendMu.Unlock()
 
 	// Space this send from the previous one while serialized. Bound the wait by
-	// the caller's request timeout and have pacing + send share that one
-	// deadline, so a long spacing interval can never dispatch a send after the
-	// caller has already timed out. Disabled spacing leaves the path untouched.
+	// the caller's request timeout, including time spent waiting for earlier
+	// delegated sends, and have pacing + send share that one deadline. Disabled
+	// spacing leaves the path untouched.
 	if pacer.enabled() {
-		reqCtx, cancel := context.WithTimeout(ctx, millisDuration(req.TimeoutMS, 5*time.Minute))
-		defer cancel()
-		if !pacer.wait(reqCtx) {
+		if !pacer.wait(requestCtx) {
 			_ = json.NewEncoder(conn).Encode(sendDelegateResponse{
 				OK:    false,
 				Error: "send spacing exceeded request timeout before dispatch",
 			})
 			return
 		}
-		pacer.record()
-		ctx = reqCtx
 	}
 
-	resp, err := executeDelegatedSend(ctx, a, req)
+	resp, err := executeDelegatedSend(requestCtx, a, req)
+	if pacer.enabled() {
+		// Record completion, not handler entry: recipient resolution, media
+		// preparation, and the actual wire send all happen inside execute.
+		// Starting the gap here prevents a slow operation from consuming it.
+		pacer.record()
+	}
 	if err != nil {
 		resp = sendDelegateResponse{OK: false, Error: err.Error()}
 	}

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -123,7 +123,7 @@ func tryDelegateSend(ctx context.Context, flags *rootFlags, lockErr error, req s
 	return resp, true, nil
 }
 
-func startSendDelegateServer(ctx context.Context, a *app.App) (func(), error) {
+func startSendDelegateServer(ctx context.Context, a *app.App, spacing sendSpacing) (func(), error) {
 	path := sendDelegateSocketPath(a.StoreDir())
 	if err := removeStaleSendDelegateSocket(path); err != nil {
 		return nil, err
@@ -140,6 +140,10 @@ func startSendDelegateServer(ctx context.Context, a *app.App) (func(), error) {
 
 	done := make(chan struct{})
 	var sendMu sync.Mutex
+	// One pacer shared across connections: it spaces the serialized delegated
+	// sends so a burst of `wacli send` processes delegating to this daemon
+	// leaves the wire paced instead of back-to-back. Disabled = no-op.
+	pacer := newSendPacer(spacing)
 	go func() {
 		defer close(done)
 		for {
@@ -147,7 +151,7 @@ func startSendDelegateServer(ctx context.Context, a *app.App) (func(), error) {
 			if err != nil {
 				return
 			}
-			go handleSendDelegateConn(ctx, conn, a, &sendMu)
+			go handleSendDelegateConn(ctx, conn, a, &sendMu, pacer)
 		}
 	}()
 
@@ -173,7 +177,7 @@ func removeStaleSendDelegateSocket(path string) error {
 	return os.Remove(path)
 }
 
-func handleSendDelegateConn(ctx context.Context, conn net.Conn, a *app.App, sendMu *sync.Mutex) {
+func handleSendDelegateConn(ctx context.Context, conn net.Conn, a *app.App, sendMu *sync.Mutex, pacer *sendPacer) {
 	defer conn.Close()
 	_ = conn.SetDeadline(time.Now().Add(5 * time.Minute))
 
@@ -184,6 +188,10 @@ func handleSendDelegateConn(ctx context.Context, conn net.Conn, a *app.App, send
 	}
 	sendMu.Lock()
 	defer sendMu.Unlock()
+
+	// Space this send from the previous one while serialized (no-op if
+	// --send-spacing is unset).
+	pacer.pace(ctx)
 
 	resp, err := executeDelegatedSend(ctx, a, req)
 	if err != nil {

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	sendDelegateVersion    = 1
-	sendDelegateSocketName = ".send.sock"
+	sendDelegateVersion       = 1
+	sendDelegateSocketName    = ".send.sock"
+	sendDelegateResponseGrace = 5 * time.Second
 )
 
 var errSendDelegateUnavailable = errors.New("send delegate unavailable")
@@ -196,6 +197,12 @@ func handleSendDelegateConn(ctx context.Context, conn net.Conn, a *app.App, send
 		var cancel context.CancelFunc
 		requestCtx, cancel = context.WithTimeout(ctx, millisDuration(req.TimeoutMS, 5*time.Minute))
 		defer cancel()
+		if deadline, ok := requestCtx.Deadline(); ok {
+			// The fixed initial deadline only protects request decoding. A paced
+			// request may intentionally run longer than five minutes, so keep the
+			// transport alive through its budget and the final response write.
+			_ = conn.SetDeadline(deadline.Add(sendDelegateResponseGrace))
+		}
 	}
 
 	if pacer.enabled() {

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -189,9 +189,23 @@ func handleSendDelegateConn(ctx context.Context, conn net.Conn, a *app.App, send
 	sendMu.Lock()
 	defer sendMu.Unlock()
 
-	// Space this send from the previous one while serialized (no-op if
-	// --send-spacing is unset).
-	pacer.pace(ctx)
+	// Space this send from the previous one while serialized. Bound the wait by
+	// the caller's request timeout and have pacing + send share that one
+	// deadline, so a long spacing interval can never dispatch a send after the
+	// caller has already timed out. Disabled spacing leaves the path untouched.
+	if pacer.enabled() {
+		reqCtx, cancel := context.WithTimeout(ctx, millisDuration(req.TimeoutMS, 5*time.Minute))
+		defer cancel()
+		if !pacer.wait(reqCtx) {
+			_ = json.NewEncoder(conn).Encode(sendDelegateResponse{
+				OK:    false,
+				Error: "send spacing exceeded request timeout before dispatch",
+			})
+			return
+		}
+		pacer.record()
+		ctx = reqCtx
+	}
 
 	resp, err := executeDelegatedSend(ctx, a, req)
 	if err != nil {

--- a/cmd/wacli/send_ipc_test.go
+++ b/cmd/wacli/send_ipc_test.go
@@ -189,6 +189,9 @@ func TestMessagesEditDelegatesThroughSendSocketWhenStoreLocked(t *testing.T) {
 	if req.TimeoutMS != 750 || req.PostSendWaitMS != 25 {
 		t.Fatalf("delegate timeouts = command %dms post-send %dms", req.TimeoutMS, req.PostSendWaitMS)
 	}
+	if req.DeadlineUnixMS == 0 {
+		t.Fatal("delegated request missing absolute command deadline")
+	}
 	if strings.Contains(stderr, "store is locked") {
 		t.Fatalf("delegated command tried the direct store path: stderr=%q", stderr)
 	}

--- a/cmd/wacli/send_spacing.go
+++ b/cmd/wacli/send_spacing.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+)
+
+// sendSpacing is an optional minimum gap enforced between consecutive sends on
+// a session. A range [min,max] draws a fresh random gap per send (jitter, which
+// is what actually avoids a detectable automated cadence); min==max is a fixed
+// gap. The zero value is disabled and preserves the default warn-only behavior.
+type sendSpacing struct {
+	min time.Duration
+	max time.Duration
+}
+
+func (s sendSpacing) enabled() bool { return s.max > 0 }
+
+// parseSendSpacing parses the --send-spacing value: "" (disabled), a single
+// duration ("2s") for a fixed gap, or a "min-max" range ("500ms-5s") for a
+// random gap per send. Bounds must be non-negative with min <= max.
+func parseSendSpacing(raw string) (sendSpacing, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return sendSpacing{}, nil
+	}
+	lo, hi, isRange := strings.Cut(raw, "-")
+	minD, err := time.ParseDuration(strings.TrimSpace(lo))
+	if err != nil {
+		return sendSpacing{}, fmt.Errorf("invalid --send-spacing %q: %w", raw, err)
+	}
+	maxD := minD
+	if isRange {
+		maxD, err = time.ParseDuration(strings.TrimSpace(hi))
+		if err != nil {
+			return sendSpacing{}, fmt.Errorf("invalid --send-spacing %q: %w", raw, err)
+		}
+	}
+	if minD < 0 || maxD < 0 {
+		return sendSpacing{}, fmt.Errorf("invalid --send-spacing %q: durations must be non-negative", raw)
+	}
+	if maxD < minD {
+		return sendSpacing{}, fmt.Errorf("invalid --send-spacing %q: max must be >= min", raw)
+	}
+	return sendSpacing{min: minD, max: maxD}, nil
+}
+
+// sendPacer enforces sendSpacing across the daemon's serialized delegated
+// sends. It is NOT safe for concurrent use: callers invoke pace() while holding
+// the send mutex, so sends are already serialized and the pacer just adds the
+// gap between them. The clock, sleeper, and RNG are injectable for tests.
+type sendPacer struct {
+	spacing sendSpacing
+	last    time.Time
+	hasLast bool
+
+	now   func() time.Time
+	sleep func(context.Context, time.Duration)
+	rng   func(n int64) int64
+}
+
+func newSendPacer(spacing sendSpacing) *sendPacer {
+	src := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return &sendPacer{
+		spacing: spacing,
+		now:     time.Now,
+		sleep:   sleepWithContext,
+		rng:     src.Int63n,
+	}
+}
+
+// pace blocks until at least a freshly-chosen gap has elapsed since the
+// previous send started, then records this send's start time. It is a no-op
+// when spacing is disabled or for the first send of the session. Call it inside
+// the send critical section, immediately before dispatching the send.
+func (p *sendPacer) pace(ctx context.Context) {
+	if p == nil || !p.spacing.enabled() {
+		return
+	}
+	if p.hasLast {
+		gap := p.pick()
+		if remaining := gap - p.now().Sub(p.last); remaining > 0 {
+			p.sleep(ctx, remaining)
+		}
+	}
+	p.last = p.now()
+	p.hasLast = true
+}
+
+func (p *sendPacer) pick() time.Duration {
+	if p.spacing.max <= p.spacing.min {
+		return p.spacing.min
+	}
+	span := int64(p.spacing.max - p.spacing.min)
+	return p.spacing.min + time.Duration(p.rng(span+1))
+}
+
+// sleepWithContext waits for d, returning early if ctx is cancelled.
+func sleepWithContext(ctx context.Context, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+	case <-ctx.Done():
+	}
+}

--- a/cmd/wacli/send_spacing.go
+++ b/cmd/wacli/send_spacing.go
@@ -49,9 +49,9 @@ func parseSendSpacing(raw string) (sendSpacing, error) {
 }
 
 // sendPacer enforces sendSpacing across the daemon's serialized delegated
-// sends. It is NOT safe for concurrent use: callers invoke pace() while holding
-// the send mutex, so sends are already serialized and the pacer just adds the
-// gap between them. The clock, sleeper, and RNG are injectable for tests.
+// sends. It is NOT safe for concurrent use: callers invoke wait and record while
+// holding the send mutex, so sends are already serialized and the pacer just
+// adds the gap between them. The clock, sleeper, and RNG are injectable for tests.
 type sendPacer struct {
 	spacing sendSpacing
 	last    time.Time
@@ -75,13 +75,14 @@ func newSendPacer(spacing sendSpacing) *sendPacer {
 func (p *sendPacer) enabled() bool { return p != nil && p.spacing.enabled() }
 
 // wait blocks until at least a freshly-chosen gap has elapsed since the
-// previous send started. It reports whether the caller may proceed with the
-// send: false means the context was cancelled (the caller's request timeout
-// elapsed) before the gap was satisfied, so the send MUST NOT be dispatched —
+// previous serialized send attempt completed. It reports whether the caller
+// may proceed with the send: false means the context was cancelled (the
+// caller's request timeout elapsed) before the gap was satisfied, so the send
+// MUST NOT be dispatched —
 // otherwise pacing could push a send past the caller's timeout and deliver it
 // after the caller has already reported failure. The first send of the session
-// waits for nothing. Call inside the send critical section; on true, call
-// record() and dispatch.
+// waits for nothing. Call inside the send critical section; on true, dispatch
+// and call record() after the attempt completes.
 func (p *sendPacer) wait(ctx context.Context) bool {
 	if p == nil || !p.spacing.enabled() || !p.hasLast {
 		return ctx.Err() == nil
@@ -93,9 +94,9 @@ func (p *sendPacer) wait(ctx context.Context) bool {
 	return ctx.Err() == nil
 }
 
-// record marks a send's start time. Call it only once a send is actually being
-// dispatched (after wait() returned true), so an aborted, un-dispatched send
-// never shifts the spacing baseline.
+// record marks the completion of a serialized send attempt. Call it after
+// wait() returned true and the attempt finishes, so time spent preparing or
+// sending cannot consume the gap before the next attempt.
 func (p *sendPacer) record() {
 	if p == nil || !p.spacing.enabled() {
 		return
@@ -109,6 +110,12 @@ func (p *sendPacer) pick() time.Duration {
 		return p.spacing.min
 	}
 	span := int64(p.spacing.max - p.spacing.min)
+	// span+1 overflows only for the full non-negative time.Duration range.
+	// Omitting that range's single upper endpoint keeps an otherwise valid CLI
+	// value from panicking the daemon.
+	if span == int64(time.Duration(1<<63-1)) {
+		return p.spacing.min + time.Duration(p.rng(span))
+	}
 	return p.spacing.min + time.Duration(p.rng(span+1))
 }
 

--- a/cmd/wacli/send_spacing.go
+++ b/cmd/wacli/send_spacing.go
@@ -72,19 +72,33 @@ func newSendPacer(spacing sendSpacing) *sendPacer {
 	}
 }
 
-// pace blocks until at least a freshly-chosen gap has elapsed since the
-// previous send started, then records this send's start time. It is a no-op
-// when spacing is disabled or for the first send of the session. Call it inside
-// the send critical section, immediately before dispatching the send.
-func (p *sendPacer) pace(ctx context.Context) {
+func (p *sendPacer) enabled() bool { return p != nil && p.spacing.enabled() }
+
+// wait blocks until at least a freshly-chosen gap has elapsed since the
+// previous send started. It reports whether the caller may proceed with the
+// send: false means the context was cancelled (the caller's request timeout
+// elapsed) before the gap was satisfied, so the send MUST NOT be dispatched —
+// otherwise pacing could push a send past the caller's timeout and deliver it
+// after the caller has already reported failure. The first send of the session
+// waits for nothing. Call inside the send critical section; on true, call
+// record() and dispatch.
+func (p *sendPacer) wait(ctx context.Context) bool {
+	if p == nil || !p.spacing.enabled() || !p.hasLast {
+		return ctx.Err() == nil
+	}
+	gap := p.pick()
+	if remaining := gap - p.now().Sub(p.last); remaining > 0 {
+		p.sleep(ctx, remaining)
+	}
+	return ctx.Err() == nil
+}
+
+// record marks a send's start time. Call it only once a send is actually being
+// dispatched (after wait() returned true), so an aborted, un-dispatched send
+// never shifts the spacing baseline.
+func (p *sendPacer) record() {
 	if p == nil || !p.spacing.enabled() {
 		return
-	}
-	if p.hasLast {
-		gap := p.pick()
-		if remaining := gap - p.now().Sub(p.last); remaining > 0 {
-			p.sleep(ctx, remaining)
-		}
 	}
 	p.last = p.now()
 	p.hasLast = true

--- a/cmd/wacli/send_spacing_test.go
+++ b/cmd/wacli/send_spacing_test.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"net"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -63,9 +67,8 @@ func fakePacer(spacing sendSpacing, rng func(int64) int64) (*sendPacer, *[]time.
 	return p, &slept
 }
 
-// paceOnce mirrors handleSendDelegateConn's use of the pacer: wait bounded by
-// ctx, and only dispatch (record) if the wait was satisfied. Returns whether
-// the send would be dispatched.
+// paceOnce models a zero-duration delegated send: wait within ctx, then record
+// completion if the send would be dispatched.
 func paceOnce(p *sendPacer, ctx context.Context) bool {
 	if !p.enabled() {
 		return true
@@ -136,9 +139,25 @@ func TestSendPacerRandomGapWithinBounds(t *testing.T) {
 	}
 }
 
-func TestSendPacerSkipsWaitWhenElapsedExceedsGap(t *testing.T) {
-	// A slow send: advance the clock past the gap before the next send, so no
-	// additional wait is needed.
+func TestSendPacerFullDurationRangeDoesNotPanic(t *testing.T) {
+	const maxDuration = time.Duration(1<<63 - 1)
+	p := &sendPacer{
+		spacing: sendSpacing{max: maxDuration},
+		rng: func(n int64) int64 {
+			if n <= 0 {
+				t.Fatalf("rng bound = %d, want positive", n)
+			}
+			return n - 1
+		},
+	}
+	if gap := p.pick(); gap < 0 || gap > maxDuration {
+		t.Fatalf("gap = %s, want within [0,%s]", gap, maxDuration)
+	}
+}
+
+func TestSendPacerSkipsWaitAfterIdlePeriodExceedsGap(t *testing.T) {
+	// Advance the clock after the previous send completed. Existing idle time
+	// counts toward the gap, so no additional wait is needed.
 	clock := time.Unix(1000, 0)
 	slept := []time.Duration{}
 	p := &sendPacer{
@@ -150,11 +169,37 @@ func TestSendPacerSkipsWaitWhenElapsedExceedsGap(t *testing.T) {
 		},
 		rng: func(int64) int64 { return 0 },
 	}
-	paceOnce(p, context.Background()) // first: records start, no wait
+	paceOnce(p, context.Background()) // first: records completion, no wait
 	clock = clock.Add(3 * time.Second)
 	paceOnce(p, context.Background()) // elapsed 3s > 1s gap: no wait
 	if len(slept) != 0 {
 		t.Fatalf("expected no wait when elapsed exceeds gap, slept %v", slept)
+	}
+}
+
+func TestSendPacerStartsGapAfterSendCompletion(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	var slept []time.Duration
+	p := &sendPacer{
+		spacing: sendSpacing{min: time.Second, max: time.Second},
+		now:     func() time.Time { return clock },
+		sleep: func(_ context.Context, d time.Duration) {
+			slept = append(slept, d)
+			clock = clock.Add(d)
+		},
+		rng: func(int64) int64 { return 0 },
+	}
+
+	if !p.wait(context.Background()) {
+		t.Fatal("first send unexpectedly blocked")
+	}
+	clock = clock.Add(3 * time.Second) // slow preparation and wire send
+	p.record()                         // handler records only after completion
+	if !p.wait(context.Background()) {
+		t.Fatal("second send unexpectedly blocked")
+	}
+	if len(slept) != 1 || slept[0] != time.Second {
+		t.Fatalf("slept = %v, want one full gap after completion", slept)
 	}
 }
 
@@ -197,4 +242,40 @@ func TestSendPacerFirstSendRespectsAlreadyExpiredContext(t *testing.T) {
 	if paceOnce(p, ctx) {
 		t.Fatalf("first send dispatched despite an already-cancelled context")
 	}
+}
+
+func TestSendPacingTimeoutIncludesMutexQueueWait(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	var sendMu sync.Mutex
+	sendMu.Lock()
+	pacer := newSendPacer(sendSpacing{min: time.Second, max: time.Second})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleSendDelegateConn(context.Background(), serverConn, nil, &sendMu, pacer)
+	}()
+
+	req := sendDelegateRequest{
+		Version:   sendDelegateVersion + 1,
+		Kind:      "text",
+		TimeoutMS: 10,
+	}
+	if err := json.NewEncoder(clientConn).Encode(req); err != nil {
+		t.Fatalf("encode request: %v", err)
+	}
+	// The server has consumed the request and is queued on sendMu. Its request
+	// deadline must elapse there, before pacing or dispatch can begin.
+	time.Sleep(50 * time.Millisecond)
+	sendMu.Unlock()
+
+	var resp sendDelegateResponse
+	if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.OK || !strings.Contains(resp.Error, "send spacing exceeded request timeout") {
+		t.Fatalf("response = %+v, want pre-dispatch spacing timeout", resp)
+	}
+	<-done
 }

--- a/cmd/wacli/send_spacing_test.go
+++ b/cmd/wacli/send_spacing_test.go
@@ -244,17 +244,20 @@ func TestSendPacerFirstSendRespectsAlreadyExpiredContext(t *testing.T) {
 	}
 }
 
-func TestSendPacingTimeoutIncludesMutexQueueWait(t *testing.T) {
+func TestSendPacingTimeoutCancelsQueueWait(t *testing.T) {
 	serverConn, clientConn := net.Pipe()
 	defer clientConn.Close()
+	if err := clientConn.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set client deadline: %v", err)
+	}
 
 	var sendMu sync.Mutex
-	sendMu.Lock()
+	pacedSendSlot := make(chan struct{}, 1) // empty means an earlier send owns it
 	pacer := newSendPacer(sendSpacing{min: time.Second, max: time.Second})
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		handleSendDelegateConn(context.Background(), serverConn, nil, &sendMu, pacer)
+		handleSendDelegateConn(context.Background(), serverConn, nil, &sendMu, pacedSendSlot, pacer)
 	}()
 
 	req := sendDelegateRequest{
@@ -265,11 +268,6 @@ func TestSendPacingTimeoutIncludesMutexQueueWait(t *testing.T) {
 	if err := json.NewEncoder(clientConn).Encode(req); err != nil {
 		t.Fatalf("encode request: %v", err)
 	}
-	// The server has consumed the request and is queued on sendMu. Its request
-	// deadline must elapse there, before pacing or dispatch can begin.
-	time.Sleep(50 * time.Millisecond)
-	sendMu.Unlock()
-
 	var resp sendDelegateResponse
 	if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
 		t.Fatalf("decode response: %v", err)

--- a/cmd/wacli/send_spacing_test.go
+++ b/cmd/wacli/send_spacing_test.go
@@ -327,3 +327,39 @@ func TestSendPacingExtendsIPCDeadlineThroughResponse(t *testing.T) {
 		t.Fatalf("paced connection deadline = %s, want at least %s", got, wantAtLeast)
 	}
 }
+
+func TestSendPacingHonorsAbsoluteCallerDeadline(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+	if err := clientConn.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set client deadline: %v", err)
+	}
+
+	var sendMu sync.Mutex
+	pacedSendSlot := make(chan struct{}, 1)
+	pacedSendSlot <- struct{}{}
+	pacer := newSendPacer(sendSpacing{min: time.Second, max: time.Second})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleSendDelegateConn(context.Background(), serverConn, nil, &sendMu, pacedSendSlot, pacer)
+	}()
+
+	req := sendDelegateRequest{
+		Version:        sendDelegateVersion + 1,
+		Kind:           "text",
+		TimeoutMS:      durationMillis(10 * time.Minute),
+		DeadlineUnixMS: time.Now().Add(-time.Second).UnixMilli(),
+	}
+	if err := json.NewEncoder(clientConn).Encode(req); err != nil {
+		t.Fatalf("encode request: %v", err)
+	}
+	var resp sendDelegateResponse
+	if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.OK || !strings.Contains(resp.Error, "send spacing exceeded request timeout") {
+		t.Fatalf("response = %+v, want expired caller deadline to block dispatch", resp)
+	}
+	<-done
+}

--- a/cmd/wacli/send_spacing_test.go
+++ b/cmd/wacli/send_spacing_test.go
@@ -47,7 +47,7 @@ func TestParseSendSpacing(t *testing.T) {
 }
 
 // fakePacer builds a pacer with a controllable clock: sleeping advances the
-// clock, so successive paces observe elapsed time deterministically.
+// clock, so successive sends observe elapsed time deterministically.
 func fakePacer(spacing sendSpacing, rng func(int64) int64) (*sendPacer, *[]time.Duration) {
 	clock := time.Unix(1000, 0)
 	slept := []time.Duration{}
@@ -63,10 +63,26 @@ func fakePacer(spacing sendSpacing, rng func(int64) int64) (*sendPacer, *[]time.
 	return p, &slept
 }
 
+// paceOnce mirrors handleSendDelegateConn's use of the pacer: wait bounded by
+// ctx, and only dispatch (record) if the wait was satisfied. Returns whether
+// the send would be dispatched.
+func paceOnce(p *sendPacer, ctx context.Context) bool {
+	if !p.enabled() {
+		return true
+	}
+	if !p.wait(ctx) {
+		return false
+	}
+	p.record()
+	return true
+}
+
 func TestSendPacerDisabledNeverSleeps(t *testing.T) {
 	p, slept := fakePacer(sendSpacing{}, func(int64) int64 { return 0 })
 	for i := 0; i < 3; i++ {
-		p.pace(context.Background())
+		if !paceOnce(p, context.Background()) {
+			t.Fatalf("disabled pacer blocked a send")
+		}
 	}
 	if len(*slept) != 0 {
 		t.Fatalf("disabled pacer slept: %v", *slept)
@@ -74,11 +90,13 @@ func TestSendPacerDisabledNeverSleeps(t *testing.T) {
 }
 
 func TestSendPacerSpacesConsecutiveSends(t *testing.T) {
-	// Fixed 1s gap; no wall time elapses between paces (sends are instantaneous
-	// in the fake), so every send after the first waits the full gap.
+	// Fixed 1s gap; no wall time elapses between sends (instantaneous in the
+	// fake), so every send after the first waits the full gap.
 	p, slept := fakePacer(sendSpacing{min: time.Second, max: time.Second}, func(int64) int64 { return 0 })
 	for i := 0; i < 3; i++ {
-		p.pace(context.Background())
+		if !paceOnce(p, context.Background()) {
+			t.Fatalf("send %d unexpectedly blocked", i)
+		}
 	}
 	want := []time.Duration{time.Second, time.Second}
 	if len(*slept) != len(want) || (*slept)[0] != want[0] || (*slept)[1] != want[1] {
@@ -101,7 +119,9 @@ func TestSendPacerRandomGapWithinBounds(t *testing.T) {
 		return v
 	})
 	for k := 0; k < 3; k++ {
-		p.pace(context.Background())
+		if !paceOnce(p, context.Background()) {
+			t.Fatalf("send %d unexpectedly blocked", k)
+		}
 	}
 	if len(*slept) != 2 {
 		t.Fatalf("expected 2 waits, got %v", *slept)
@@ -111,14 +131,13 @@ func TestSendPacerRandomGapWithinBounds(t *testing.T) {
 			t.Fatalf("gap %s out of bounds [%s,%s]", d, spacing.min, spacing.max)
 		}
 	}
-	// First waited gap should be the minimum (rng=0).
 	if (*slept)[0] != spacing.min {
 		t.Fatalf("first gap = %s, want min %s", (*slept)[0], spacing.min)
 	}
 }
 
 func TestSendPacerSkipsWaitWhenElapsedExceedsGap(t *testing.T) {
-	// A slow send: advance the clock past the gap before the next pace, so no
+	// A slow send: advance the clock past the gap before the next send, so no
 	// additional wait is needed.
 	clock := time.Unix(1000, 0)
 	slept := []time.Duration{}
@@ -131,10 +150,51 @@ func TestSendPacerSkipsWaitWhenElapsedExceedsGap(t *testing.T) {
 		},
 		rng: func(int64) int64 { return 0 },
 	}
-	p.pace(context.Background()) // first: records start, no wait
+	paceOnce(p, context.Background()) // first: records start, no wait
 	clock = clock.Add(3 * time.Second)
-	p.pace(context.Background()) // elapsed 3s > 1s gap: no wait
+	paceOnce(p, context.Background()) // elapsed 3s > 1s gap: no wait
 	if len(slept) != 0 {
 		t.Fatalf("expected no wait when elapsed exceeds gap, slept %v", slept)
+	}
+}
+
+// Regression for the ClawSweeper P1 finding: if the caller's request timeout
+// elapses while the pacer is waiting, the send must be aborted (not dispatched)
+// and the spacing baseline must not move, so a paced send can never leave the
+// wire after the caller has already reported failure.
+func TestSendPacerAbortsWhenTimeoutElapsesDuringWait(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p := &sendPacer{
+		spacing: sendSpacing{min: time.Second, max: time.Second},
+		now:     func() time.Time { return clock },
+		// The wait outlives the request budget: cancelling mid-sleep models the
+		// caller's timeout firing before the gap is satisfied.
+		sleep: func(_ context.Context, _ time.Duration) { cancel() },
+		rng:   func(int64) int64 { return 0 },
+	}
+
+	if !paceOnce(p, ctx) { // first send dispatches immediately
+		t.Fatalf("first send should dispatch")
+	}
+	baseline := p.last
+
+	if dispatched := paceOnce(p, ctx); dispatched {
+		t.Fatalf("second send dispatched after its wait was cut short by the request timeout")
+	}
+	if p.last != baseline {
+		t.Fatalf("spacing baseline advanced for an un-dispatched send: last=%v baseline=%v", p.last, baseline)
+	}
+}
+
+// An already-expired context must block even the first send: the caller has
+// given up before we ever reach the wire.
+func TestSendPacerFirstSendRespectsAlreadyExpiredContext(t *testing.T) {
+	p, _ := fakePacer(sendSpacing{min: time.Second, max: time.Second}, func(int64) int64 { return 0 })
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if paceOnce(p, ctx) {
+		t.Fatalf("first send dispatched despite an already-cancelled context")
 	}
 }

--- a/cmd/wacli/send_spacing_test.go
+++ b/cmd/wacli/send_spacing_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestParseSendSpacing(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		wantMin time.Duration
+		wantMax time.Duration
+		wantErr bool
+	}{
+		{name: "empty disables", raw: "", wantMin: 0, wantMax: 0},
+		{name: "fixed gap", raw: "2s", wantMin: 2 * time.Second, wantMax: 2 * time.Second},
+		{name: "range", raw: "500ms-5s", wantMin: 500 * time.Millisecond, wantMax: 5 * time.Second},
+		{name: "range with spaces", raw: "  1s - 2s ", wantMin: time.Second, wantMax: 2 * time.Second},
+		{name: "equal range", raw: "3s-3s", wantMin: 3 * time.Second, wantMax: 3 * time.Second},
+		{name: "max below min", raw: "5s-500ms", wantErr: true},
+		{name: "unparseable", raw: "soon", wantErr: true},
+		{name: "unparseable max", raw: "1s-later", wantErr: true},
+		{name: "negative", raw: "-1s", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseSendSpacing(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseSendSpacing(%q) = %+v, want error", tc.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseSendSpacing(%q) unexpected error: %v", tc.raw, err)
+			}
+			if got.min != tc.wantMin || got.max != tc.wantMax {
+				t.Fatalf("parseSendSpacing(%q) = {min:%s max:%s}, want {min:%s max:%s}", tc.raw, got.min, got.max, tc.wantMin, tc.wantMax)
+			}
+			if got.enabled() != (tc.wantMax > 0) {
+				t.Fatalf("enabled() = %v, want %v", got.enabled(), tc.wantMax > 0)
+			}
+		})
+	}
+}
+
+// fakePacer builds a pacer with a controllable clock: sleeping advances the
+// clock, so successive paces observe elapsed time deterministically.
+func fakePacer(spacing sendSpacing, rng func(int64) int64) (*sendPacer, *[]time.Duration) {
+	clock := time.Unix(1000, 0)
+	slept := []time.Duration{}
+	p := &sendPacer{
+		spacing: spacing,
+		now:     func() time.Time { return clock },
+		sleep: func(_ context.Context, d time.Duration) {
+			slept = append(slept, d)
+			clock = clock.Add(d)
+		},
+		rng: rng,
+	}
+	return p, &slept
+}
+
+func TestSendPacerDisabledNeverSleeps(t *testing.T) {
+	p, slept := fakePacer(sendSpacing{}, func(int64) int64 { return 0 })
+	for i := 0; i < 3; i++ {
+		p.pace(context.Background())
+	}
+	if len(*slept) != 0 {
+		t.Fatalf("disabled pacer slept: %v", *slept)
+	}
+}
+
+func TestSendPacerSpacesConsecutiveSends(t *testing.T) {
+	// Fixed 1s gap; no wall time elapses between paces (sends are instantaneous
+	// in the fake), so every send after the first waits the full gap.
+	p, slept := fakePacer(sendSpacing{min: time.Second, max: time.Second}, func(int64) int64 { return 0 })
+	for i := 0; i < 3; i++ {
+		p.pace(context.Background())
+	}
+	want := []time.Duration{time.Second, time.Second}
+	if len(*slept) != len(want) || (*slept)[0] != want[0] || (*slept)[1] != want[1] {
+		t.Fatalf("slept = %v, want %v (no wait on first send, then the gap)", *slept, want)
+	}
+}
+
+func TestSendPacerRandomGapWithinBounds(t *testing.T) {
+	spacing := sendSpacing{min: 500 * time.Millisecond, max: 5 * time.Second}
+	// rng returns 0 -> min; returns span -> max. Alternate to exercise both ends.
+	span := int64(spacing.max - spacing.min)
+	seq := []int64{0, span}
+	i := 0
+	p, slept := fakePacer(spacing, func(n int64) int64 {
+		v := seq[i%len(seq)]
+		i++
+		if v >= n { // rng contract is [0,n); clamp for the max case
+			v = n - 1
+		}
+		return v
+	})
+	for k := 0; k < 3; k++ {
+		p.pace(context.Background())
+	}
+	if len(*slept) != 2 {
+		t.Fatalf("expected 2 waits, got %v", *slept)
+	}
+	for _, d := range *slept {
+		if d < spacing.min || d > spacing.max {
+			t.Fatalf("gap %s out of bounds [%s,%s]", d, spacing.min, spacing.max)
+		}
+	}
+	// First waited gap should be the minimum (rng=0).
+	if (*slept)[0] != spacing.min {
+		t.Fatalf("first gap = %s, want min %s", (*slept)[0], spacing.min)
+	}
+}
+
+func TestSendPacerSkipsWaitWhenElapsedExceedsGap(t *testing.T) {
+	// A slow send: advance the clock past the gap before the next pace, so no
+	// additional wait is needed.
+	clock := time.Unix(1000, 0)
+	slept := []time.Duration{}
+	p := &sendPacer{
+		spacing: sendSpacing{min: time.Second, max: time.Second},
+		now:     func() time.Time { return clock },
+		sleep: func(_ context.Context, d time.Duration) {
+			slept = append(slept, d)
+			clock = clock.Add(d)
+		},
+		rng: func(int64) int64 { return 0 },
+	}
+	p.pace(context.Background()) // first: records start, no wait
+	clock = clock.Add(3 * time.Second)
+	p.pace(context.Background()) // elapsed 3s > 1s gap: no wait
+	if len(slept) != 0 {
+		t.Fatalf("expected no wait when elapsed exceeds gap, slept %v", slept)
+	}
+}

--- a/cmd/wacli/send_spacing_test.go
+++ b/cmd/wacli/send_spacing_test.go
@@ -10,6 +10,16 @@ import (
 	"time"
 )
 
+type deadlineRecordingConn struct {
+	net.Conn
+	deadlines []time.Time
+}
+
+func (c *deadlineRecordingConn) SetDeadline(deadline time.Time) error {
+	c.deadlines = append(c.deadlines, deadline)
+	return c.Conn.SetDeadline(deadline)
+}
+
 func TestParseSendSpacing(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -276,4 +286,44 @@ func TestSendPacingTimeoutCancelsQueueWait(t *testing.T) {
 		t.Fatalf("response = %+v, want pre-dispatch spacing timeout", resp)
 	}
 	<-done
+}
+
+func TestSendPacingExtendsIPCDeadlineThroughResponse(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	trackedServerConn := &deadlineRecordingConn{Conn: serverConn}
+	defer clientConn.Close()
+
+	var sendMu sync.Mutex
+	pacedSendSlot := make(chan struct{}, 1)
+	pacedSendSlot <- struct{}{}
+	pacer := newSendPacer(sendSpacing{min: time.Second, max: time.Second})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleSendDelegateConn(context.Background(), trackedServerConn, nil, &sendMu, pacedSendSlot, pacer)
+	}()
+
+	const requestTimeout = 10 * time.Minute
+	started := time.Now()
+	req := sendDelegateRequest{
+		Version:   sendDelegateVersion + 1,
+		Kind:      "text",
+		TimeoutMS: durationMillis(requestTimeout),
+	}
+	if err := json.NewEncoder(clientConn).Encode(req); err != nil {
+		t.Fatalf("encode request: %v", err)
+	}
+	var resp sendDelegateResponse
+	if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	<-done
+
+	if len(trackedServerConn.deadlines) != 2 {
+		t.Fatalf("deadlines = %v, want initial decode and paced request deadlines", trackedServerConn.deadlines)
+	}
+	wantAtLeast := started.Add(requestTimeout)
+	if got := trackedServerConn.deadlines[1]; got.Before(wantAtLeast) {
+		t.Fatalf("paced connection deadline = %s, want at least %s", got, wantAtLeast)
+	}
 }

--- a/cmd/wacli/sync.go
+++ b/cmd/wacli/sync.go
@@ -26,6 +26,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var webhookSecret string
 	var webhookAllowPrivate bool
 	var webhookEventsFlag string
+	var sendSpacingFlag string
 	var storage syncStorageLimitFlags
 
 	cmd := &cobra.Command{
@@ -52,6 +53,10 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 			}
 			if staleThreshold != 0 && staleThreshold < time.Second {
 				return fmt.Errorf("--stale-threshold must be at least 1s, got %s", staleThreshold)
+			}
+			sendSpacing, err := parseSendSpacing(sendSpacingFlag)
+			if err != nil {
+				return err
 			}
 			if maxStaleThreshold := appPkg.MaxStaleThreshold(); staleThreshold >= maxStaleThreshold {
 				return fmt.Errorf("--stale-threshold must be less than %s because whatsmeow auto-reconnects after that much keepalive failure, got %s", maxStaleThreshold, staleThreshold)
@@ -91,7 +96,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 			var afterConnect func(context.Context) error
 			if mode == appPkg.SyncModeFollow {
 				afterConnect = func(ctx context.Context) error {
-					stop, err := startSendDelegateServer(ctx, a)
+					stop, err := startSendDelegateServer(ctx, a, sendSpacing)
 					if err != nil {
 						return err
 					}
@@ -141,6 +146,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().DurationVar(&maxReconnect, "max-reconnect", 5*time.Minute, "give up reconnecting after this duration (0 = unlimited)")
 	cmd.Flags().DurationVar(&staleThreshold, "stale-threshold", 0, "force reconnect when keepalive failures last this long in follow mode (1s-<2m20s, 0 = disabled)")
 	cmd.Flags().StringVar(&presenceModeFlag, "presence-mode", string(appPkg.SyncPresenceModeNormal), "global sync presence behavior: normal or quiet")
+	cmd.Flags().StringVar(&sendSpacingFlag, "send-spacing", "", "space delegated sends by a min gap or random min-max range (e.g. 2s or 500ms-5s); avoids WhatsApp rate limits on automated bursts (default: none)")
 	cmd.Flags().BoolVar(&downloadMedia, "download-media", false, "download media in the background during sync")
 	cmd.Flags().BoolVar(&refreshContacts, "refresh-contacts", false, "refresh contacts from session store into local DB")
 	cmd.Flags().BoolVar(&refreshGroups, "refresh-groups", false, "refresh joined groups (live) into local DB")

--- a/cmd/wacli/sync.go
+++ b/cmd/wacli/sync.go
@@ -146,7 +146,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().DurationVar(&maxReconnect, "max-reconnect", 5*time.Minute, "give up reconnecting after this duration (0 = unlimited)")
 	cmd.Flags().DurationVar(&staleThreshold, "stale-threshold", 0, "force reconnect when keepalive failures last this long in follow mode (1s-<2m20s, 0 = disabled)")
 	cmd.Flags().StringVar(&presenceModeFlag, "presence-mode", string(appPkg.SyncPresenceModeNormal), "global sync presence behavior: normal or quiet")
-	cmd.Flags().StringVar(&sendSpacingFlag, "send-spacing", "", "space delegated sends by a min gap or random min-max range (e.g. 2s or 500ms-5s); avoids WhatsApp rate limits on automated bursts (default: none)")
+	cmd.Flags().StringVar(&sendSpacingFlag, "send-spacing", "", "pace delegated sends in follow mode by a fixed duration or random min-max range (e.g. 2s or 500ms-5s; default: disabled)")
 	cmd.Flags().BoolVar(&downloadMedia, "download-media", false, "download media in the background during sync")
 	cmd.Flags().BoolVar(&refreshContacts, "refresh-contacts", false, "refresh contacts from session store into local DB")
 	cmd.Flags().BoolVar(&refreshGroups, "refresh-groups", false, "refresh joined groups (live) into local DB")

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -7,7 +7,7 @@ Read when: running continuous capture, one-shot sync, contact/group refresh, or 
 ## Command
 
 ```bash
-wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-threshold DURATION] [--presence-mode normal|quiet] [--max-messages N] [--max-db-size SIZE] [--download-media] [--refresh-contacts] [--refresh-groups] [--refresh-channels] [--events] [--webhook URL] [--webhook-secret SECRET] [--webhook-events LIST]
+wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-threshold DURATION] [--presence-mode normal|quiet] [--send-spacing DURATION|MIN-MAX] [--max-messages N] [--max-db-size SIZE] [--download-media] [--refresh-contacts] [--refresh-groups] [--refresh-channels] [--events] [--webhook URL] [--webhook-secret SECRET] [--webhook-events LIST]
 ```
 
 ## Modes
@@ -19,6 +19,7 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-t
 - `--max-messages N` stops before storing more than `N` total messages locally.
 - `--max-db-size SIZE` stops when `wacli.db` plus SQLite sidecars reaches `SIZE` (`500MB`, `2GB`, etc.).
 - `--download-media` runs a bounded media downloader for sync events. Clean one-shot and bootstrap runs finish queued downloads before exiting; cancellation, errors, and storage-limit exits stop immediately.
+- `--send-spacing DURATION|MIN-MAX` paces serialized sends delegated to a running follow process. A single duration such as `2s` sets a fixed minimum gap; a range such as `500ms-5s` chooses a fresh random gap for each send. It is disabled by default, so unset behavior remains unchanged. The caller's command timeout includes time queued behind earlier sends, pacing, and the send itself; a request that runs out of time is not dispatched.
 - `--refresh-contacts` imports contacts from the session store.
 - `--refresh-groups` fetches joined groups live and updates the local DB.
 - `--refresh-channels` fetches subscribed WhatsApp Channels live and updates local chat rows.
@@ -82,6 +83,7 @@ wacli sync --once
 wacli sync --follow --max-reconnect 10m
 wacli sync --follow --stale-threshold 2m
 wacli sync --follow --presence-mode quiet
+wacli sync --follow --send-spacing 500ms-5s
 wacli sync --follow --max-messages 250000 --max-db-size 2GB
 wacli sync --once --refresh-contacts --refresh-groups --refresh-channels
 wacli sync --follow --download-media


### PR DESCRIPTION
## What

Adds an opt-in `sync --follow --send-spacing <min>[-<max>]` flag that spaces the daemon's serialized delegated sends.

- `--send-spacing 2s` — fixed 2s minimum gap between sends.
- `--send-spacing 500ms-5s` — a fresh random gap per send drawn from the range (jitter).
- Unset (default) — behavior is unchanged (the existing warn-only rapid-send guardrail; no delay).

## Why

When an automation fires several `wacli send` processes at a running `sync --follow` daemon, the daemon already serializes them under `sendMu` in `handleSendDelegateConn` — but with **zero gap**, so the burst still leaves the wire back-to-back. WhatsApp punishes bursts from one account with rate-limiting, decrypt-retry storms, and account restrictions. The current guardrail (`warnRapidSendIfNeeded`) only prints a warning; nothing actually paces the sends.

This adds pacing at the one place every delegated send funnels through, so it covers all delegated send kinds (text, file, voice, sticker, react, poll, select) without touching each command.

## How it works

- `send_spacing.go`
  - `sendSpacing` + `parseSendSpacing` — parses `""` (disabled), a single duration (fixed gap), or a `min-max` range (validated: non-negative, `min <= max`).
  - `sendPacer` — `wait(ctx)` blocks out the remaining gap since the previous send start and reports whether the caller may proceed; `record()` advances the baseline only once a send is actually dispatched. Clock, sleeper, and RNG are injectable for tests; `sleepWithContext` returns early on ctx cancellation.
- `send_ipc.go` — one shared `sendPacer` per delegate server. Inside the existing `sendMu` critical section, pacing runs under a context **bounded by the caller's `req.TimeoutMS`**, and pacing + send share that one deadline. If the wait can't complete within the budget, the send is **aborted before dispatch** (returns a timeout error) so a long spacing interval can never deliver after the caller has already timed out. Disabled spacing leaves the path byte-for-byte unchanged.
- `sync.go` — the `--send-spacing` flag, parsed early in `RunE` so a bad value fails fast.

Scope note: this covers the **daemon/delegated** path (where automated fan-out funnels and the burst problem actually shows up). The direct path — multiple standalone `wacli send` processes with no daemon running — is already serialized by the store LOCK; a symmetric `--send-spacing` on the `send` subcommands (using the existing `.last-send-at` marker) would be a natural, small follow-up if wanted.

## New flags / env

- `sync --follow --send-spacing <min>[-<max>]` (e.g. `2s`, `500ms-5s`). No new env vars, no new dependencies.

## Testing

- `send_spacing_test.go`: table-driven `parseSendSpacing` cases (fixed, range, spaces, equal bounds, `max<min`, unparseable, negative) and `sendPacer` behavior (disabled no-op, first-send no wait, fixed and random gaps within bounds, elapsed-exceeds-gap skip, timeout-aborts-before-dispatch, already-expired-context blocks first send).
- Full gate green: `gofmt -l` clean, `go vet ./...`, `go build -tags sqlite_fts5` (CGO), `go test ./...` and `go test -tags sqlite_fts5 ./...`, windows-lock cross-compile, and the `cgo-required` guard — all pass; `git diff --check` clean.

## Live behavior proof

Ran against a **real linked WhatsApp account** on a clean VM (arm64, glibc 2.43) with a Go 1.26.5 CGO build of this branch. Daemon: `wacli sync --follow --send-spacing 2s-5s`. Every send targets the linked account's own "message yourself" chat — no third party. Numbers, JIDs, and names are redacted.

### 1. Spacing — five delegated sends fired in parallel

All five `wacli send` processes launched at the same instant; each fails the store lock and delegates to the running daemon. Client-side completion order/timing:

```
send #1 completed at +0.00s (first)
send #4 completed at +2.26s total, +2.26s after previous
send #2 completed at +5.00s total, +2.73s after previous
send #3 completed at +7.80s total, +2.81s after previous
send #5 completed at +10.50s total, +2.69s after previous
```

Consecutive gaps **2.26 / 2.73 / 2.81 / 2.69s** — every one inside the configured `[2s, 5s]`, with visible jitter. Without pacing all five complete within ~1s. A delegated result (redacted): `{"success":true,"data":{"id":"3EB0…","sent":true,"to":"<redacted>@lid"}}`.

### 2. Timeout safety (the P1 fix) — no dispatch after the caller's timeout

- **A** — normal send → `sent:true`; freshens the daemon's last-send time.
- **B** — `--timeout 300ms` → the remaining spacing gap (≥ ~1s) can't be met within 300ms. B fails client-side at **0.31s**: `read unix …/.send.sock: i/o timeout`.
- **9 seconds later** (well past the 5s max gap), a full-text message search for the demo texts returns **only A**:

```
timeout-demo-A-normal        (FromMe, sent)
timeout-demo-B-shorttimeout  — ABSENT (never dispatched)
```

B was never put on the wire. Under the pre-fix code the pacer waited under the daemon's own long-lived context and would have dispatched B ~2–5s after the caller already reported failure; the fix bounds pacing by the request deadline and skips dispatch when the budget is exhausted.

_(Session logged out / device unlinked and the VM store wiped after capture.)_
