### PR TITLE
fix(send): file outbound self-chat messages under the canonical phone-number JID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Sync: add opt-in receipt and chat-presence webhook events while keeping legacy message payloads unchanged. (#315 - thanks @Jaime-data)
 
+### Fixed
+
+- Send: file immediately persisted outbound text messages under the canonical phone-number chat instead of a separate LID chat.
+
 ### Chore
 
 - Dependencies: update `whatsmeow`, terminal support, GraphQL parsing, and supporting Go modules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Send: file immediately persisted outbound text messages under the canonical phone-number chat instead of a separate LID chat.
+- Send: file immediately persisted outbound text messages under the canonical phone-number chat instead of a separate LID chat. (#319 - thanks @Lucas-Kim-J)
 
 ### Chore
 

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -166,12 +166,25 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 }
 
 func persistOutboundText(ctx context.Context, a *app.App, chat types.JID, msgID, text string, now time.Time) {
-	chatName := a.WA().ResolveChatName(ctx, chat, "")
-	if err := a.DB().UpsertChat(chat.String(), chatKindFromJID(chat), chatName, now); err != nil {
+	persistOutboundTextWith(ctx, a.DB(), a.WA(), chat, msgID, text, now)
+}
+
+type outboundTextResolver interface {
+	ResolveChatName(ctx context.Context, chat types.JID, pushName string) string
+	ResolveLIDToPN(ctx context.Context, jid types.JID) types.JID
+}
+
+func persistOutboundTextWith(ctx context.Context, db *store.DB, resolver outboundTextResolver, chat types.JID, msgID, text string, now time.Time) {
+	chat = resolver.ResolveLIDToPN(ctx, chat)
+	if chat.Server == types.DefaultUserServer {
+		chat = chat.ToNonAD()
+	}
+	chatName := resolver.ResolveChatName(ctx, chat, "")
+	if err := db.UpsertChat(chat.String(), chatKindFromJID(chat), chatName, now); err != nil {
 		warnOutboundPersist("chat", msgID, err)
 		return
 	}
-	if err := a.DB().UpsertMessage(store.UpsertMessageParams{
+	if err := db.UpsertMessage(store.UpsertMessageParams{
 		ChatJID:    chat.String(),
 		ChatName:   chatName,
 		MsgID:      msgID,

--- a/cmd/wacli/send_test.go
+++ b/cmd/wacli/send_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"testing"
@@ -80,6 +81,22 @@ func (s *recordingTextSender) ResolvePNToLID(_ context.Context, _ types.JID) typ
 	return s.linkedLID
 }
 
+type outboundTextResolverStub struct {
+	lid types.JID
+	pn  types.JID
+}
+
+func (r outboundTextResolverStub) ResolveChatName(_ context.Context, chat types.JID, _ string) string {
+	return chat.String()
+}
+
+func (r outboundTextResolverStub) ResolveLIDToPN(_ context.Context, jid types.JID) types.JID {
+	if jid.ToNonAD() == r.lid {
+		return r.pn
+	}
+	return jid
+}
+
 func requireExtendedText(t *testing.T, msg *waProto.Message) *waProto.ExtendedTextMessage {
 	t.Helper()
 	if msg.GetEphemeralMessage() != nil {
@@ -101,6 +118,71 @@ func TestResolveRecipientFallsBackToFormattedPhone(t *testing.T) {
 	}
 	if got.String() != "15551234567@s.whatsapp.net" {
 		t.Fatalf("recipient = %q", got.String())
+	}
+}
+
+func TestSendTextToOwnPNTargetsRegisteredLID(t *testing.T) {
+	pn := types.NewJID("15551234567", types.DefaultUserServer)
+	lid := types.NewJID("999123456789", types.HiddenUserServer)
+	warmup := &mockUserInfoClient{
+		isOnWhatsApp: func(_ context.Context, phones []string) ([]types.IsOnWhatsAppResponse, error) {
+			if len(phones) != 1 || phones[0] != "+15551234567" {
+				t.Fatalf("registration lookup = %v", phones)
+			}
+			return []types.IsOnWhatsAppResponse{{JID: lid, PhoneNumber: pn, IsIn: true}}, nil
+		},
+		getUserInfo: func(_ context.Context, jids []types.JID) (map[types.JID]types.UserInfo, error) {
+			if len(jids) != 1 || jids[0] != lid {
+				t.Fatalf("user info target = %v, want %s", jids, lid)
+			}
+			return nil, nil
+		},
+	}
+
+	var stderr bytes.Buffer
+	target := warmupRecipient(context.Background(), warmup, pn, &stderr)
+	sender := &recordingTextSender{}
+	if _, err := sendTextMessageWithSender(context.Background(), sender, openSendTestDB(t), target, "self-test", "", "", nil, nil, textEphemeralOptions{}); err != nil {
+		t.Fatalf("sendTextMessageWithSender: %v", err)
+	}
+	if sender.textRecipient != lid {
+		t.Fatalf("send target = %s, want registered LID %s", sender.textRecipient, lid)
+	}
+}
+
+func TestPersistOutboundTextCanonicalizesSelfLIDToPN(t *testing.T) {
+	db := openSendTestDB(t)
+	pn := types.NewJID("15551234567", types.DefaultUserServer)
+	lid := types.NewJID("999123456789", types.HiddenUserServer)
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+
+	if err := db.UpsertChat(pn.String(), "dm", "Message Yourself", now.Add(-time.Minute)); err != nil {
+		t.Fatalf("UpsertChat inbound: %v", err)
+	}
+	if err := db.UpsertMessage(store.UpsertMessageParams{
+		ChatJID:   pn.String(),
+		MsgID:     "inbound-id",
+		Timestamp: now.Add(-time.Minute),
+		Text:      "from phone",
+	}); err != nil {
+		t.Fatalf("UpsertMessage inbound: %v", err)
+	}
+
+	persistOutboundTextWith(context.Background(), db, outboundTextResolverStub{lid: lid, pn: pn}, lid, "outbound-id", "self-test", now)
+
+	stored, err := db.GetMessage(pn.String(), "outbound-id")
+	if err != nil {
+		t.Fatalf("GetMessage PN outbound: %v", err)
+	}
+	if stored.ChatJID != pn.String() || !stored.FromMe || stored.Text != "self-test" {
+		t.Fatalf("stored outbound = %+v", stored)
+	}
+	chats, err := db.ListChats("", 10)
+	if err != nil {
+		t.Fatalf("ListChats: %v", err)
+	}
+	if len(chats) != 1 || chats[0].JID != pn.String() {
+		t.Fatalf("chats = %+v, want only canonical PN %s", chats, pn)
 	}
 }
 


### PR DESCRIPTION
Fixes the archive half of #319.

## What was wrong

`warmupRecipient` replaces the supplied phone-number JID with the LID returned by `IsOnWhatsApp`, and outbound text was persisted under that LID. Incoming sync canonicalizes LID to PN before storage, so a self-chat ended up split across two rows: inbound from the phone under `<pn>@s.whatsapp.net`, outbound from wacli under `<lid>@lid` — exactly as @Lucas-Kim-J reported.

## What changed

Outbound persistence now resolves LID to PN before upserting the chat and message, matching what sync already does. The send target is unchanged.

## What this does NOT fix

The reported delivery symptom (nothing appears in Message Yourself) is a separate question and stays open:

- The "wacli substituted the LID, so it became a peer message" hypothesis is disproven. whatsmeow uses peer semantics only when `SendRequestExtra.Peer` is set, and it rewrites every PN direct message to LID itself, so preserving the PN would not change the wire target.
- `sent: true` reflects a server acknowledgement, not delivery to a recipient device — whatsmeow documents it that way. It is stronger than a socket write and weaker than delivery.

Establishing the delivery cause needs a live protocol reproduction, which was deliberately not attempted here.

## Proof

`make check` green (fmt, lint, dead-code, both test modes, build, release checks). New regression tests: `TestSendTextToOwnPNTargetsRegisteredLID`, `TestPersistOutboundTextCanonicalizesSelfLIDToPN`. Codex autoreview clean.
