### PR TITLE
fix(send): reject undeliverable self text sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Send: file immediately persisted outbound text messages under the canonical phone-number chat instead of a separate LID chat. (#319 - thanks @Lucas-Kim-J)
+- Send: keep self-chat storage under the canonical phone-number chat and reject text sends to the linked account itself instead of reporting an acknowledgement that may never reach Message Yourself. (#319 - thanks @Lucas-Kim-J)
 
 ### Chore
 

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -113,6 +113,9 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if err := validateTextRecipient(a.WA(), toJID); err != nil {
+				return err
+			}
 			mentionedJIDs, err := parseMentionedJIDs(mentions)
 			if err != nil {
 				return err
@@ -216,6 +219,7 @@ type textMessageSender interface {
 	GetGroupInfo(ctx context.Context, jid types.JID) (*types.GroupInfo, error)
 	ResolvePNToLID(ctx context.Context, jid types.JID) types.JID
 	LinkedJID() string
+	LinkedLID() string
 }
 
 type textEphemeralOptions struct {
@@ -232,11 +236,16 @@ type resolvedTextEphemeral struct {
 
 const defaultEphemeralExpiration uint32 = 7 * 24 * 60 * 60
 
+var errSelfTextRecipient = errors.New("send text to the linked account itself is not supported: WhatsApp can acknowledge self-messages without delivering them; use the official Message Yourself chat")
+
 func sendTextMessage(ctx context.Context, a sendTextApp, to types.JID, text, replyTo, replyToSender string, preview *linkpreview.Preview, mentionedJIDs []string, ephemeral textEphemeralOptions) (types.MessageID, error) {
 	return sendTextMessageWithSender(ctx, a.WA(), a.DB(), to, text, replyTo, replyToSender, preview, mentionedJIDs, ephemeral)
 }
 
 func sendTextMessageWithSender(ctx context.Context, sender textMessageSender, db *store.DB, to types.JID, text, replyTo, replyToSender string, preview *linkpreview.Preview, mentionedJIDs []string, ephemeral textEphemeralOptions) (types.MessageID, error) {
+	if err := validateTextRecipient(sender, to); err != nil {
+		return "", err
+	}
 	selfJID, err := textReplySelfJID(ctx, sender, db, to, replyTo, replyToSender)
 	if err != nil {
 		return "", err
@@ -263,6 +272,30 @@ func sendTextMessageWithSender(ctx context.Context, sender textMessageSender, db
 		applyEphemeralContext(msg, resolved.expiration)
 	}
 	return sender.SendProtoMessage(ctx, to, msg)
+}
+
+func validateTextRecipient(sender textMessageSender, to types.JID) error {
+	if isSelfTextRecipient(sender, to) {
+		return errSelfTextRecipient
+	}
+	return nil
+}
+
+func isSelfTextRecipient(sender textMessageSender, to types.JID) bool {
+	linked, err := types.ParseJID(strings.TrimSpace(sender.LinkedJID()))
+	if err != nil || linked.IsEmpty() {
+		return false
+	}
+	linked = linked.ToNonAD()
+	to = to.ToNonAD()
+	if to == linked {
+		return true
+	}
+	if to.Server != types.HiddenUserServer || linked.Server != types.DefaultUserServer {
+		return false
+	}
+	linkedLID, err := types.ParseJID(strings.TrimSpace(sender.LinkedLID()))
+	return err == nil && !linkedLID.IsEmpty() && linkedLID.ToNonAD() == to
 }
 
 func textReplySelfJID(ctx context.Context, sender textMessageSender, db *store.DB, chat types.JID, replyTo, replyToSender string) (string, error) {

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -350,6 +350,9 @@ func executeDelegatedText(ctx context.Context, a *app.App, req sendDelegateReque
 	if err != nil {
 		return sendDelegateResponse{}, err
 	}
+	if err := validateTextRecipient(a.WA(), toJID); err != nil {
+		return sendDelegateResponse{}, err
+	}
 	toJID = warmupDelegatedRecipient(ctx, a, toJID)
 	mentionedJIDs, err := parseMentionedJIDs(req.Mentions)
 	if err != nil {

--- a/cmd/wacli/send_test.go
+++ b/cmd/wacli/send_test.go
@@ -76,6 +76,10 @@ func (s *recordingTextSender) LinkedJID() string {
 	return s.linkedJID
 }
 
+func (s *recordingTextSender) LinkedLID() string {
+	return s.linkedLID.String()
+}
+
 func (s *recordingTextSender) ResolvePNToLID(_ context.Context, _ types.JID) types.JID {
 	s.resolveLIDCalls++
 	return s.linkedLID
@@ -121,7 +125,7 @@ func TestResolveRecipientFallsBackToFormattedPhone(t *testing.T) {
 	}
 }
 
-func TestSendTextToOwnPNTargetsRegisteredLID(t *testing.T) {
+func TestSendTextToOwnPNRejectsRegisteredLID(t *testing.T) {
 	pn := types.NewJID("15551234567", types.DefaultUserServer)
 	lid := types.NewJID("999123456789", types.HiddenUserServer)
 	warmup := &mockUserInfoClient{
@@ -141,12 +145,29 @@ func TestSendTextToOwnPNTargetsRegisteredLID(t *testing.T) {
 
 	var stderr bytes.Buffer
 	target := warmupRecipient(context.Background(), warmup, pn, &stderr)
-	sender := &recordingTextSender{}
-	if _, err := sendTextMessageWithSender(context.Background(), sender, openSendTestDB(t), target, "self-test", "", "", nil, nil, textEphemeralOptions{}); err != nil {
-		t.Fatalf("sendTextMessageWithSender: %v", err)
+	sender := &recordingTextSender{linkedJID: pn.String(), linkedLID: lid}
+	_, err := sendTextMessageWithSender(context.Background(), sender, openSendTestDB(t), target, "self-test", "", "", nil, nil, textEphemeralOptions{})
+	if err == nil || !strings.Contains(err.Error(), "linked account itself is not supported") {
+		t.Fatalf("sendTextMessageWithSender error = %v, want self-send rejection", err)
 	}
-	if sender.textRecipient != lid {
-		t.Fatalf("send target = %s, want registered LID %s", sender.textRecipient, lid)
+	if sender.textCalls != 0 || sender.protoCalls != 0 {
+		t.Fatalf("self-send reached protocol sender: text=%d proto=%d", sender.textCalls, sender.protoCalls)
+	}
+	if sender.resolveLIDCalls != 0 {
+		t.Fatalf("ResolvePNToLID calls = %d, want 0", sender.resolveLIDCalls)
+	}
+}
+
+func TestSendTextToOwnPNRejectsWithoutRegistrationCanonicalization(t *testing.T) {
+	pn := types.NewJID("15551234567", types.DefaultUserServer)
+	sender := &recordingTextSender{linkedJID: pn.String()}
+
+	_, err := sendTextMessageWithSender(context.Background(), sender, openSendTestDB(t), pn, "self-test", "", "", nil, nil, textEphemeralOptions{})
+	if err == nil || !strings.Contains(err.Error(), "linked account itself is not supported") {
+		t.Fatalf("sendTextMessageWithSender error = %v, want self-send rejection", err)
+	}
+	if sender.textCalls != 0 || sender.protoCalls != 0 || sender.resolveLIDCalls != 0 {
+		t.Fatalf("self-send reached protocol path: text=%d proto=%d resolve=%d", sender.textCalls, sender.protoCalls, sender.resolveLIDCalls)
 	}
 }
 

--- a/docs/send.md
+++ b/docs/send.md
@@ -29,6 +29,7 @@ wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 - If a name matches multiple recipients, interactive terminals prompt.
 - In scripts, use `--pick N` to choose a displayed match.
 - Phone numbers may use common formatting such as `+1 (234) 567-8900`.
+- `send text` rejects the linked account's own phone-number or LID target. WhatsApp may acknowledge these self-DMs without delivering them to Message Yourself, so wacli returns an explicit error instead of `sent: true`.
 
 ## Replies and reactions
 


### PR DESCRIPTION
Fixes #319.

## What changed

- Reject `send text` when the resolved recipient is the linked account's own phone-number JID or mapped LID.
- Apply the same preflight to direct sends and sends delegated to a running `sync --follow` process, before warmup or protocol dispatch.
- Document the limitation and keep the existing canonical-PN self-chat storage behavior.

## Why

`whatsmeow.SendMessage` waits for a server acknowledgement, not recipient-device delivery. It also normalizes phone-number direct messages to LIDs internally, so preserving the input PN would not change the wire target. The remaining self-device fanout behavior is not established well enough to invent a protocol workaround; an explicit error is safer than returning `sent: true` for a Message Yourself send that may never render.

## Proof

- `pnpm docs:site && pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`
- Focused regressions cover both the own-PN and post-warmup own-LID forms and verify that neither reaches the protocol sender.
- Codex autoreview: clean, no accepted/actionable findings.
- Source-blind behavior validation confirmed an unauthenticated store still reports its real auth failure without false success. Exact live self-delivery validation remained blocked because the authorized maintainer test store was no longer linked; no third-party account was contacted.
