### PR TITLE
fix(deps): update cel-go build dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/elliotchance/orderedmap/v3 v3.1.1 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/go-sql-driver/mysql v1.9.3 // indirect
-	github.com/google/cel-go v0.28.0 // indirect
+	github.com/google/cel-go v0.30.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -58,6 +58,7 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20260718201538-764159d718ef // indirect
 	golang.org/x/sync v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1
 github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/google/cel-go v0.28.0 h1:KjSWstCpz/MN5t4a8gnGJNIYUsJRpdi/r97xWDphIQc=
-github.com/google/cel-go v0.28.0/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
+github.com/google/cel-go v0.30.0 h1:ll54AkzKunWkBn9wSoiUXbFZXYZTkdJGNXTBXUoolGo=
+github.com/google/cel-go v0.30.0/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
## Summary

- update the transitive `github.com/google/cel-go` build-tool dependency from `v0.28.0` to `v0.30.0`
- record CEL-Go's required `go.yaml.in/yaml/v3` module
- keep the change limited to `go.mod` and `go.sum`

## Security context

Resolves Dependabot alert https://github.com/openclaw/wacli/security/dependabot/5 (`GHSA-gcjh-h69q-9w9g`).

The vulnerable CEL native-type adapter exposes fields tagged `json:"-"` to user expressions. The dependency reaches wacli through the pinned `github.com/sqlc-dev/sqlc/cmd/sqlc` build tool.

Although the advisory metadata names `v0.29.0` as patched, the upstream fix commit https://github.com/cel-expr/cel-go/commit/83eed56b0fe697952d3bbae964e5539c16cf3a09 landed on July 14, 2026, after the `v0.29.0`, `v0.29.1`, and `v0.29.2` tags. `v0.30.0` is the first stable release that actually contains the hidden-field fix.

## Validation

- `go mod why -m github.com/google/cel-go`
- `go list -m github.com/google/cel-go` (`v0.30.0`)
- `go tool github.com/sqlc-dev/sqlc/cmd/sqlc version` (`v1.31.1`)
- `pnpm generate:sqlc` (completed; unrelated existing generated-model drift excluded)
- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `git diff --check`
- autoreview clean
