### PR TITLE
feat(sync): stop `sync --follow` on logout instead of reconnecting forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Sync: stop promptly when WhatsApp revokes the linked session, including while a reconnect is already in progress, and print the re-authentication steps. (#325 - thanks @cohnen)
 - Send: keep self-chat storage under the canonical phone-number chat and reject text sends to the linked account itself instead of reporting an acknowledgement that may never reach Message Yourself. (#319 - thanks @Lucas-Kim-J)
 
 ### Chore

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -16,6 +16,7 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-t
 - `--once` exits after sync becomes idle.
 - `--idle-exit` controls idle exit timing in once mode.
 - `--max-reconnect 0` keeps reconnecting indefinitely.
+- If WhatsApp revokes the linked session, sync emits a terminal `logged_out` event, cancels any reconnect already in progress, and exits cleanly. Re-pair with `wacli auth logout` followed by `wacli auth --phone`.
 - `--max-messages N` stops before storing more than `N` total messages locally.
 - `--max-db-size SIZE` stops when `wacli.db` plus SQLite sidecars reaches `SIZE` (`500MB`, `2GB`, etc.).
 - `--download-media` runs a bounded media downloader for sync events. Clean one-shot and bootstrap runs finish queued downloads before exiting; cancellation, errors, and storage-limit exits stop immediately.

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -34,12 +34,13 @@ type fakeWA struct {
 	nextHandlerID uint32
 	handlers      map[uint32]func(interface{})
 
-	connectEvents []interface{}
-	connectErrs   []error
-	connectCalls  int
-	connectDelay  time.Duration
-	downloadDelay time.Duration
-	downloadErr   error
+	connectEvents  []interface{}
+	connectErrs    []error
+	connectCalls   int
+	connectDelay   time.Duration
+	connectStarted chan struct{}
+	downloadDelay  time.Duration
+	downloadErr    error
 
 	onMediaRetry       func(info *types.MessageInfo, mediaKey []byte) interface{}
 	mediaRetryReceipts []string
@@ -178,6 +179,12 @@ func (f *fakeWA) Connect(ctx context.Context, opts wa.ConnectOptions) error {
 		return nil
 	}
 	f.connectCalls++
+	if f.connectStarted != nil {
+		select {
+		case f.connectStarted <- struct{}{}:
+		default:
+		}
+	}
 	authed := f.authed
 	var connectErr error
 	if len(f.connectErrs) > 0 {

--- a/internal/app/heartbeat_test.go
+++ b/internal/app/heartbeat_test.go
@@ -28,6 +28,7 @@ func TestSyncWritesHeartbeatFileOnActivity(t *testing.T) {
 		&messagesStored,
 		&lastEvent,
 		make(chan struct{}, 1),
+		make(chan struct{}, 1),
 		make(chan staleReconnectRequest, 1),
 		func(string, string) {},
 		nil,
@@ -66,6 +67,7 @@ func TestSyncOnceDoesNotWriteHeartbeatFile(t *testing.T) {
 		&messagesStored,
 		&lastEvent,
 		make(chan struct{}, 1),
+		make(chan struct{}, 1),
 		make(chan staleReconnectRequest, 1),
 		func(string, string) {},
 		nil,
@@ -95,6 +97,7 @@ func TestSyncFollowDoesNotWriteHeartbeatOnKeepAliveTimeout(t *testing.T) {
 		SyncOptions{Mode: SyncModeFollow},
 		&messagesStored,
 		&lastEvent,
+		make(chan struct{}, 1),
 		make(chan struct{}, 1),
 		make(chan staleReconnectRequest, 1),
 		func(string, string) {},
@@ -191,6 +194,7 @@ func TestSyncFollowDoesNotReconnectOnFreshKeepAliveTimeout(t *testing.T) {
 	var messagesStored atomic.Int64
 	var lastEvent atomic.Int64
 	disconnected := make(chan struct{}, 1)
+	loggedOut := make(chan struct{}, 1)
 	staleReconnect := make(chan staleReconnectRequest, 1)
 	handlerID := a.addSyncEventHandler(
 		context.Background(),
@@ -198,6 +202,7 @@ func TestSyncFollowDoesNotReconnectOnFreshKeepAliveTimeout(t *testing.T) {
 		&messagesStored,
 		&lastEvent,
 		disconnected,
+		loggedOut,
 		staleReconnect,
 		func(string, string) {},
 		nil,
@@ -243,6 +248,7 @@ func TestSyncFollowEmitsStaleEvent(t *testing.T) {
 	var lastEvent atomic.Int64
 	var connectionEpoch atomic.Int64
 	disconnected := make(chan struct{}, 1)
+	loggedOut := make(chan struct{}, 1)
 	staleReconnect := make(chan staleReconnectRequest, 1)
 	handlerID := a.addSyncEventHandler(
 		context.Background(),
@@ -250,6 +256,7 @@ func TestSyncFollowEmitsStaleEvent(t *testing.T) {
 		&messagesStored,
 		&lastEvent,
 		disconnected,
+		loggedOut,
 		staleReconnect,
 		func(string, string) {},
 		nil,
@@ -263,7 +270,7 @@ func TestSyncFollowEmitsStaleEvent(t *testing.T) {
 	defer cancel()
 	done := make(chan error, 1)
 	go func() {
-		_, err := a.runSyncFollow(ctx, time.Second, SyncPresenceModeNormal, &messagesStored, &connectionEpoch, disconnected, staleReconnect)
+		_, err := a.runSyncFollow(ctx, time.Second, SyncPresenceModeNormal, &messagesStored, &connectionEpoch, disconnected, loggedOut, staleReconnect)
 		done <- err
 	}()
 

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -140,6 +140,7 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 	lastEvent.Store(now)
 
 	disconnected := make(chan struct{}, 1)
+	loggedOut := make(chan struct{}, 1)
 	staleReconnect := make(chan staleReconnectRequest, 1)
 
 	var waitMedia func(context.Context) bool
@@ -173,7 +174,7 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 	}
 
 	ps := &syncPresence{}
-	handlerID := a.addSyncEventHandler(syncCtx, opts, &messagesStored, &lastEvent, disconnected, staleReconnect, enqueueMedia, enqueueWebhook, limits, ps, mediaQ)
+	handlerID := a.addSyncEventHandler(syncCtx, opts, &messagesStored, &lastEvent, disconnected, loggedOut, staleReconnect, enqueueMedia, enqueueWebhook, limits, ps, mediaQ)
 	defer a.wa.RemoveEventHandler(handlerID)
 
 	connectionEpoch.Store(nowUTC().UnixNano())
@@ -234,9 +235,9 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 
 	var err error
 	if opts.Mode == SyncModeFollow {
-		_, err = a.runSyncFollow(syncCtx, opts.MaxReconnect, opts.PresenceMode, &messagesStored, &connectionEpoch, disconnected, staleReconnect)
+		_, err = a.runSyncFollow(syncCtx, opts.MaxReconnect, opts.PresenceMode, &messagesStored, &connectionEpoch, disconnected, loggedOut, staleReconnect)
 	} else {
-		_, err = a.runSyncUntilIdle(syncCtx, opts.IdleExit, opts.MaxReconnect, opts.PresenceMode, &messagesStored, &lastEvent, disconnected)
+		_, err = a.runSyncUntilIdle(syncCtx, opts.IdleExit, opts.MaxReconnect, opts.PresenceMode, &messagesStored, &lastEvent, disconnected, loggedOut)
 	}
 	limitErr := limits.Err()
 	// Successful one-shot modes must finish queued downloads before cleanup

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -46,7 +46,7 @@ type syncPresence struct {
 	cleanupStarted bool
 }
 
-func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, messagesStored, lastEvent *atomic.Int64, disconnected chan<- struct{}, staleReconnect chan<- staleReconnectRequest, enqueueMedia func(string, string), enqueueWebhook func(syncWebhookEvent), limits *syncStorageLimits, ps *syncPresence, mediaQ *mediaQueue) uint32 {
+func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, messagesStored, lastEvent *atomic.Int64, disconnected chan<- struct{}, loggedOut chan<- struct{}, staleReconnect chan<- staleReconnectRequest, enqueueMedia func(string, string), enqueueWebhook func(syncWebhookEvent), limits *syncStorageLimits, ps *syncPresence, mediaQ *mediaQueue) uint32 {
 	var panicCount atomic.Int64
 	var appStateRecoveries sync.Map
 	if enqueueWebhook == nil {
@@ -155,6 +155,20 @@ func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, message
 			}
 		case *events.AppStateSyncError:
 			a.handleAppStateSyncError(ctx, v, &appStateRecoveries)
+		case *events.LoggedOut:
+			// WhatsApp revoked this session (linked device removed on the phone,
+			// or a logout/ban). whatsmeow reconnects on Disconnected, so without
+			// this the follow loop spins forever against a dead session. Surface
+			// the logout and signal the loop to stop instead of reconnecting.
+			a.emitOrPrint("logged_out", map[string]any{
+				"reason":      v.Reason.String(),
+				"reason_code": int(v.Reason),
+				"on_connect":  v.OnConnect,
+			}, "\nLogged out of WhatsApp (%s). Stopping sync.\n", v.Reason.String())
+			select {
+			case loggedOut <- struct{}{}:
+			default:
+			}
 		}
 	})
 }

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -21,6 +21,12 @@ import (
 	"go.mau.fi/whatsmeow/types/events"
 )
 
+// loggedOutRecoveryHint is the operator-facing recovery sequence for a revoked
+// session. sync deliberately keeps the local device record (see the LoggedOut
+// case), and `auth --phone` short-circuits while that record exists — so
+// re-pairing needs the explicit local logout first.
+const loggedOutRecoveryHint = "To re-authenticate, run `wacli auth logout` to clear the local session, then `wacli auth --phone` to pair again."
+
 func newMediaEnqueuer(ctx context.Context, queue *mediaQueue) func(chatJID, msgID string) {
 	return func(chatJID, msgID string) {
 		if strings.TrimSpace(chatJID) == "" || strings.TrimSpace(msgID) == "" {
@@ -164,7 +170,8 @@ func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, message
 				"reason":      v.Reason.String(),
 				"reason_code": int(v.Reason),
 				"on_connect":  v.OnConnect,
-			}, "\nLogged out of WhatsApp (%s). Stopping sync.\n", v.Reason.String())
+				"recovery":    loggedOutRecoveryHint,
+			}, "\nLogged out of WhatsApp (%s). Stopping sync.\n%s\n", v.Reason.String(), loggedOutRecoveryHint)
 			select {
 			case loggedOut <- struct{}{}:
 			default:

--- a/internal/app/sync_idle.go
+++ b/internal/app/sync_idle.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openclaw/wacli/internal/wa"
 )
 
-func (a *App) runSyncFollow(ctx context.Context, maxReconnect time.Duration, presenceMode SyncPresenceMode, messagesStored, connectionEpoch *atomic.Int64, disconnected <-chan struct{}, staleReconnect <-chan staleReconnectRequest) (SyncResult, error) {
+func (a *App) runSyncFollow(ctx context.Context, maxReconnect time.Duration, presenceMode SyncPresenceMode, messagesStored, connectionEpoch *atomic.Int64, disconnected <-chan struct{}, loggedOut <-chan struct{}, staleReconnect <-chan staleReconnectRequest) (SyncResult, error) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -38,11 +38,19 @@ func (a *App) runSyncFollow(ctx context.Context, maxReconnect time.Duration, pre
 			if err := a.reconnect(ctx, maxReconnect, presenceMode); err != nil {
 				return SyncResult{MessagesStored: messagesStored.Load()}, err
 			}
+		case <-loggedOut:
+			// Session revoked (see the LoggedOut handler). Stop cleanly instead
+			// of reconnecting forever against a dead session.
+			a.emitOrPrint("stopping", map[string]any{
+				"messages_synced": messagesStored.Load(),
+				"reason":          "logged_out",
+			}, "\nStopping sync (logged out).\n")
+			return SyncResult{MessagesStored: messagesStored.Load()}, nil
 		}
 	}
 }
 
-func (a *App) runSyncUntilIdle(ctx context.Context, idleExit, maxReconnect time.Duration, presenceMode SyncPresenceMode, messagesStored, lastEvent *atomic.Int64, disconnected <-chan struct{}) (SyncResult, error) {
+func (a *App) runSyncUntilIdle(ctx context.Context, idleExit, maxReconnect time.Duration, presenceMode SyncPresenceMode, messagesStored, lastEvent *atomic.Int64, disconnected <-chan struct{}, loggedOut <-chan struct{}) (SyncResult, error) {
 	poll := 250 * time.Millisecond
 	if idleExit >= 2*time.Second {
 		poll = 1 * time.Second
@@ -59,6 +67,14 @@ func (a *App) runSyncUntilIdle(ctx context.Context, idleExit, maxReconnect time.
 			if err := a.reconnect(ctx, maxReconnect, presenceMode); err != nil {
 				return SyncResult{MessagesStored: messagesStored.Load()}, err
 			}
+		case <-loggedOut:
+			// Session revoked (see the LoggedOut handler). Stop cleanly instead
+			// of reconnecting forever against a dead session.
+			a.emitOrPrint("stopping", map[string]any{
+				"messages_synced": messagesStored.Load(),
+				"reason":          "logged_out",
+			}, "\nStopping sync (logged out).\n")
+			return SyncResult{MessagesStored: messagesStored.Load()}, nil
 		case <-ticker.C:
 			last := time.Unix(0, lastEvent.Load())
 			if time.Since(last) >= idleExit {

--- a/internal/app/sync_idle.go
+++ b/internal/app/sync_idle.go
@@ -56,7 +56,11 @@ func (a *App) runSyncFollow(ctx context.Context, maxReconnect time.Duration, pre
 			// Client.Connect can see the existing socket as still live and return nil.
 			a.wa.Close()
 			connectionEpoch.Store(nowUTC().UnixNano())
-			if err := a.reconnect(ctx, maxReconnect, presenceMode); err != nil {
+			loggedOutDuringReconnect, err := a.reconnectWhileWatchingLogout(ctx, maxReconnect, presenceMode, loggedOut)
+			if loggedOutDuringReconnect {
+				return a.stopLoggedOut(messagesStored)
+			}
+			if err != nil {
 				return SyncResult{MessagesStored: messagesStored.Load()}, err
 			}
 		case <-disconnected:
@@ -65,7 +69,11 @@ func (a *App) runSyncFollow(ctx context.Context, maxReconnect time.Duration, pre
 			}
 			a.emitOrPrint("reconnecting", nil, "Reconnecting...\n")
 			connectionEpoch.Store(nowUTC().UnixNano())
-			if err := a.reconnect(ctx, maxReconnect, presenceMode); err != nil {
+			loggedOutDuringReconnect, err := a.reconnectWhileWatchingLogout(ctx, maxReconnect, presenceMode, loggedOut)
+			if loggedOutDuringReconnect {
+				return a.stopLoggedOut(messagesStored)
+			}
+			if err != nil {
 				return SyncResult{MessagesStored: messagesStored.Load()}, err
 			}
 		case <-loggedOut:
@@ -93,7 +101,11 @@ func (a *App) runSyncUntilIdle(ctx context.Context, idleExit, maxReconnect time.
 				return a.stopLoggedOut(messagesStored)
 			}
 			a.emitOrPrint("reconnecting", nil, "Reconnecting...\n")
-			if err := a.reconnect(ctx, maxReconnect, presenceMode); err != nil {
+			loggedOutDuringReconnect, err := a.reconnectWhileWatchingLogout(ctx, maxReconnect, presenceMode, loggedOut)
+			if loggedOutDuringReconnect {
+				return a.stopLoggedOut(messagesStored)
+			}
+			if err != nil {
 				return SyncResult{MessagesStored: messagesStored.Load()}, err
 			}
 		case <-loggedOut:
@@ -130,4 +142,31 @@ func (a *App) reconnect(ctx context.Context, maxDuration time.Duration, presence
 		return fmt.Errorf("could not reconnect after %s: %w", maxDuration, err)
 	}
 	return err
+}
+
+// reconnectWhileWatchingLogout lets the terminal logout signal interrupt an
+// active reconnect. Checking the channel only before reconnecting is not enough:
+// LoggedOut may arrive while ReconnectWithBackoff is sleeping or dialing.
+func (a *App) reconnectWhileWatchingLogout(ctx context.Context, maxDuration time.Duration, presenceMode SyncPresenceMode, loggedOut <-chan struct{}) (bool, error) {
+	reconnectCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- a.reconnect(reconnectCtx, maxDuration, presenceMode)
+	}()
+
+	select {
+	case <-loggedOut:
+		cancel()
+		<-done
+		return true, nil
+	case err := <-done:
+		// If reconnect and logout complete together, the terminal signal still
+		// wins. Otherwise it remains queued for the loop's next select.
+		if loggedOutPending(loggedOut) {
+			return true, nil
+		}
+		return false, err
+	}
 }

--- a/internal/app/sync_idle.go
+++ b/internal/app/sync_idle.go
@@ -9,6 +9,30 @@ import (
 	"github.com/openclaw/wacli/internal/wa"
 )
 
+// loggedOutPending does a non-blocking receive on the terminal logout signal.
+// A revocation delivers Disconnected and LoggedOut back to back, and with both
+// buffered channels ready select picks a branch at random — so every reconnect
+// path must check this first. The terminal signal wins; never dial a dead
+// session.
+func loggedOutPending(loggedOut <-chan struct{}) bool {
+	select {
+	case <-loggedOut:
+		return true
+	default:
+		return false
+	}
+}
+
+// stopLoggedOut emits the terminal stop for a revoked session and returns the
+// final result.
+func (a *App) stopLoggedOut(messagesStored *atomic.Int64) (SyncResult, error) {
+	a.emitOrPrint("stopping", map[string]any{
+		"messages_synced": messagesStored.Load(),
+		"reason":          "logged_out",
+	}, "\nStopping sync (logged out).\n")
+	return SyncResult{MessagesStored: messagesStored.Load()}, nil
+}
+
 func (a *App) runSyncFollow(ctx context.Context, maxReconnect time.Duration, presenceMode SyncPresenceMode, messagesStored, connectionEpoch *atomic.Int64, disconnected <-chan struct{}, loggedOut <-chan struct{}, staleReconnect <-chan staleReconnectRequest) (SyncResult, error) {
 	for {
 		select {
@@ -16,6 +40,9 @@ func (a *App) runSyncFollow(ctx context.Context, maxReconnect time.Duration, pre
 			a.emitOrPrint("stopping", map[string]any{"messages_synced": messagesStored.Load()}, "\nStopping sync.\n")
 			return SyncResult{MessagesStored: messagesStored.Load()}, nil
 		case req := <-staleReconnect:
+			if loggedOutPending(loggedOut) {
+				return a.stopLoggedOut(messagesStored)
+			}
 			if epoch := connectionEpoch.Load(); epoch > 0 && req.lastSuccess.Before(time.Unix(0, epoch)) {
 				continue
 			}
@@ -33,6 +60,9 @@ func (a *App) runSyncFollow(ctx context.Context, maxReconnect time.Duration, pre
 				return SyncResult{MessagesStored: messagesStored.Load()}, err
 			}
 		case <-disconnected:
+			if loggedOutPending(loggedOut) {
+				return a.stopLoggedOut(messagesStored)
+			}
 			a.emitOrPrint("reconnecting", nil, "Reconnecting...\n")
 			connectionEpoch.Store(nowUTC().UnixNano())
 			if err := a.reconnect(ctx, maxReconnect, presenceMode); err != nil {
@@ -41,11 +71,7 @@ func (a *App) runSyncFollow(ctx context.Context, maxReconnect time.Duration, pre
 		case <-loggedOut:
 			// Session revoked (see the LoggedOut handler). Stop cleanly instead
 			// of reconnecting forever against a dead session.
-			a.emitOrPrint("stopping", map[string]any{
-				"messages_synced": messagesStored.Load(),
-				"reason":          "logged_out",
-			}, "\nStopping sync (logged out).\n")
-			return SyncResult{MessagesStored: messagesStored.Load()}, nil
+			return a.stopLoggedOut(messagesStored)
 		}
 	}
 }
@@ -63,6 +89,9 @@ func (a *App) runSyncUntilIdle(ctx context.Context, idleExit, maxReconnect time.
 			a.emitOrPrint("stopping", map[string]any{"messages_synced": messagesStored.Load()}, "\nStopping sync.\n")
 			return SyncResult{MessagesStored: messagesStored.Load()}, nil
 		case <-disconnected:
+			if loggedOutPending(loggedOut) {
+				return a.stopLoggedOut(messagesStored)
+			}
 			a.emitOrPrint("reconnecting", nil, "Reconnecting...\n")
 			if err := a.reconnect(ctx, maxReconnect, presenceMode); err != nil {
 				return SyncResult{MessagesStored: messagesStored.Load()}, err
@@ -70,11 +99,7 @@ func (a *App) runSyncUntilIdle(ctx context.Context, idleExit, maxReconnect time.
 		case <-loggedOut:
 			// Session revoked (see the LoggedOut handler). Stop cleanly instead
 			// of reconnecting forever against a dead session.
-			a.emitOrPrint("stopping", map[string]any{
-				"messages_synced": messagesStored.Load(),
-				"reason":          "logged_out",
-			}, "\nStopping sync (logged out).\n")
-			return SyncResult{MessagesStored: messagesStored.Load()}, nil
+			return a.stopLoggedOut(messagesStored)
 		case <-ticker.C:
 			last := time.Unix(0, lastEvent.Load())
 			if time.Since(last) >= idleExit {

--- a/internal/app/sync_logout_test.go
+++ b/internal/app/sync_logout_test.go
@@ -240,6 +240,47 @@ func TestRunSyncFollowLoggedOutWinsOverPendingReconnect(t *testing.T) {
 	}
 }
 
+// A logout can arrive after the loop has already entered ReconnectWithBackoff.
+// The terminal signal must cancel that active reconnect instead of waiting for
+// the reconnect deadline before the loop gets another chance to select it.
+func TestRunSyncFollowStopsWhenLoggedOutDuringReconnect(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	f.connectDelay = time.Hour
+	f.connectStarted = make(chan struct{}, 1)
+	a.wa = f
+
+	var messagesStored, connectionEpoch atomic.Int64
+	disconnected := make(chan struct{}, 1)
+	loggedOut := make(chan struct{}, 1)
+	staleReconnect := make(chan staleReconnectRequest, 1)
+	disconnected <- struct{}{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := a.runSyncFollow(ctx, time.Hour, SyncPresenceModeNormal, &messagesStored, &connectionEpoch, disconnected, loggedOut, staleReconnect)
+		done <- err
+	}()
+
+	select {
+	case <-f.connectStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("follow loop did not enter reconnect")
+	}
+	loggedOut <- struct{}{}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runSyncFollow returned error on logout during reconnect: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runSyncFollow did not cancel reconnect after logged_out signal")
+	}
+}
+
 // The bootstrap/once idle loop must also stop on logout rather than reconnect.
 func TestRunSyncUntilIdleStopsOnLoggedOut(t *testing.T) {
 	a := newTestApp(t)
@@ -313,6 +354,44 @@ func TestRunSyncUntilIdleLoggedOutWinsOverDisconnected(t *testing.T) {
 		if calls != 0 {
 			t.Fatalf("run %d: idle loop reconnected before consuming logout (connectCalls=%d), want 0", i, calls)
 		}
+	}
+}
+
+func TestRunSyncUntilIdleStopsWhenLoggedOutDuringReconnect(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	f.connectDelay = time.Hour
+	f.connectStarted = make(chan struct{}, 1)
+	a.wa = f
+
+	var messagesStored, lastEvent atomic.Int64
+	lastEvent.Store(nowUTC().UnixNano())
+	disconnected := make(chan struct{}, 1)
+	loggedOut := make(chan struct{}, 1)
+	disconnected <- struct{}{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := a.runSyncUntilIdle(ctx, time.Hour, time.Hour, SyncPresenceModeNormal, &messagesStored, &lastEvent, disconnected, loggedOut)
+		done <- err
+	}()
+
+	select {
+	case <-f.connectStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("idle loop did not enter reconnect")
+	}
+	loggedOut <- struct{}{}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runSyncUntilIdle returned error on logout during reconnect: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runSyncUntilIdle did not cancel reconnect after logged_out signal")
 	}
 }
 

--- a/internal/app/sync_logout_test.go
+++ b/internal/app/sync_logout_test.go
@@ -1,0 +1,208 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openclaw/wacli/internal/out"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+// findLoggedOutEvent parses NDJSON --events output and returns the first event
+// with the given name, failing the test if none is present.
+func findEventByName(t *testing.T, raw, name string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(raw), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var evt map[string]any
+		if err := json.Unmarshal([]byte(line), &evt); err != nil {
+			t.Fatalf("event line is not valid JSON %q: %v\nfull output:\n%s", line, err, raw)
+		}
+		if evt["event"] == name {
+			return evt
+		}
+	}
+	t.Fatalf("no %q event in:\n%s", name, raw)
+	return nil
+}
+
+// A forced logout (device removed on the phone, or a ban) must be surfaced as a
+// structured `logged_out` event and must signal the loggedOut channel so the
+// follow loop can stop instead of reconnecting forever.
+func TestSyncEventHandlerEmitsLoggedOutAndSignals(t *testing.T) {
+	cases := []struct {
+		name           string
+		event          *events.LoggedOut
+		wantOnConnect  bool
+		wantReasonCode float64
+	}{
+		{"forced_logout", &events.LoggedOut{OnConnect: true, Reason: events.ConnectFailureLoggedOut}, true, 401},
+		{"stream_error", &events.LoggedOut{OnConnect: false}, false, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := newTestApp(t)
+			f := newFakeWA()
+			a.wa = f
+			var eventsOut bytes.Buffer
+			a.opts.Events = out.NewEventWriter(&eventsOut, true)
+
+			var messagesStored, lastEvent atomic.Int64
+			loggedOut := make(chan struct{}, 1)
+			handlerID := a.addSyncEventHandler(
+				context.Background(),
+				SyncOptions{Mode: SyncModeFollow},
+				&messagesStored,
+				&lastEvent,
+				make(chan struct{}, 1),
+				loggedOut,
+				make(chan staleReconnectRequest, 1),
+				func(string, string) {},
+				nil,
+				nil,
+				&syncPresence{},
+				nil,
+			)
+			defer f.RemoveEventHandler(handlerID)
+
+			f.emit(tc.event)
+
+			select {
+			case <-loggedOut:
+			default:
+				t.Fatal("LoggedOut event did not signal the loggedOut channel")
+			}
+
+			evt := findEventByName(t, eventsOut.String(), "logged_out")
+			data, ok := evt["data"].(map[string]any)
+			if !ok {
+				t.Fatalf("logged_out event has no data object: %#v", evt)
+			}
+			if data["on_connect"] != tc.wantOnConnect {
+				t.Fatalf("logged_out on_connect = %v, want %v", data["on_connect"], tc.wantOnConnect)
+			}
+			if code, _ := data["reason_code"].(float64); code != tc.wantReasonCode {
+				t.Fatalf("logged_out reason_code = %v, want %v", data["reason_code"], tc.wantReasonCode)
+			}
+			if s, _ := data["reason"].(string); s == "" {
+				t.Fatal("logged_out reason string is empty")
+			}
+		})
+	}
+}
+
+// The follow loop must stop (return nil) on a logout signal without attempting a
+// reconnect. Uses a background context so the ONLY way to return is the logout
+// signal — proving it, not context cancellation, ends the loop.
+func TestRunSyncFollowStopsOnLoggedOut(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	var messagesStored, connectionEpoch atomic.Int64
+	disconnected := make(chan struct{}, 1)
+	loggedOut := make(chan struct{}, 1)
+	staleReconnect := make(chan staleReconnectRequest, 1)
+	loggedOut <- struct{}{}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := a.runSyncFollow(context.Background(), time.Second, SyncPresenceModeNormal, &messagesStored, &connectionEpoch, disconnected, loggedOut, staleReconnect)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runSyncFollow returned error on logout: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runSyncFollow did not stop after logged_out signal")
+	}
+
+	f.mu.Lock()
+	calls := f.connectCalls
+	f.mu.Unlock()
+	if calls != 0 {
+		t.Fatalf("logged-out follow loop reconnected (connectCalls=%d), want 0", calls)
+	}
+}
+
+// The bootstrap/once idle loop must also stop on logout rather than reconnect.
+func TestRunSyncUntilIdleStopsOnLoggedOut(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	var messagesStored, lastEvent atomic.Int64
+	lastEvent.Store(nowUTC().UnixNano())
+	disconnected := make(chan struct{}, 1)
+	loggedOut := make(chan struct{}, 1)
+	loggedOut <- struct{}{}
+
+	done := make(chan error, 1)
+	go func() {
+		// Large idleExit so the idle ticker never fires before the logout signal.
+		_, err := a.runSyncUntilIdle(context.Background(), time.Hour, time.Second, SyncPresenceModeNormal, &messagesStored, &lastEvent, disconnected, loggedOut)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runSyncUntilIdle returned error on logout: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runSyncUntilIdle did not stop after logged_out signal")
+	}
+
+	f.mu.Lock()
+	calls := f.connectCalls
+	f.mu.Unlock()
+	if calls != 0 {
+		t.Fatalf("logged-out idle loop reconnected (connectCalls=%d), want 0", calls)
+	}
+}
+
+// End-to-end: a LoggedOut delivered while `sync --follow` is running stops the
+// daemon cleanly (Sync returns nil) and never reconnects.
+func TestSyncFollowStopsWhenLoggedOut(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := a.Sync(context.Background(), SyncOptions{
+			Mode: SyncModeFollow,
+			AfterConnect: func(context.Context) error {
+				f.emit(&events.LoggedOut{OnConnect: true, Reason: events.ConnectFailureLoggedOut})
+				return nil
+			},
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Sync --follow returned error on logout: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Sync --follow did not stop after logout")
+	}
+
+	f.mu.Lock()
+	calls := f.connectCalls
+	f.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("connectCalls = %d after logout, want 1 (initial connect, no reconnect)", calls)
+	}
+}

--- a/internal/app/sync_logout_test.go
+++ b/internal/app/sync_logout_test.go
@@ -135,6 +135,63 @@ func TestRunSyncFollowStopsOnLoggedOut(t *testing.T) {
 	}
 }
 
+// A revocation delivers Disconnected and LoggedOut back to back, so both
+// buffered signals can be ready when the follow loop selects. The terminal
+// logout signal must win even when select picks the disconnect (or stale)
+// branch first: the loop must stop without a single reconnect attempt.
+// Repeated runs cover Go's random choice between the ready channels.
+func TestRunSyncFollowLoggedOutWinsOverPendingReconnect(t *testing.T) {
+	cases := []struct {
+		name  string
+		queue func(disconnected chan struct{}, staleReconnect chan staleReconnectRequest)
+	}{
+		{"paired_with_disconnected", func(disconnected chan struct{}, _ chan staleReconnectRequest) {
+			disconnected <- struct{}{}
+		}},
+		{"paired_with_stale_reconnect", func(_ chan struct{}, staleReconnect chan staleReconnectRequest) {
+			staleReconnect <- staleReconnectRequest{lastSuccess: nowUTC(), threshold: time.Minute, idle: time.Minute, source: "test"}
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i := 0; i < 50; i++ {
+				a := newTestApp(t)
+				f := newFakeWA()
+				a.wa = f
+
+				var messagesStored, connectionEpoch atomic.Int64
+				disconnected := make(chan struct{}, 1)
+				loggedOut := make(chan struct{}, 1)
+				staleReconnect := make(chan staleReconnectRequest, 1)
+				tc.queue(disconnected, staleReconnect)
+				loggedOut <- struct{}{}
+
+				done := make(chan error, 1)
+				go func() {
+					_, err := a.runSyncFollow(context.Background(), time.Second, SyncPresenceModeNormal, &messagesStored, &connectionEpoch, disconnected, loggedOut, staleReconnect)
+					done <- err
+				}()
+
+				select {
+				case err := <-done:
+					if err != nil {
+						t.Fatalf("run %d: runSyncFollow returned error: %v", i, err)
+					}
+				case <-time.After(2 * time.Second):
+					t.Fatalf("run %d: runSyncFollow did not stop with paired signals queued", i)
+				}
+
+				f.mu.Lock()
+				calls := f.connectCalls
+				f.mu.Unlock()
+				if calls != 0 {
+					t.Fatalf("run %d: follow loop reconnected before consuming logout (connectCalls=%d), want 0", i, calls)
+				}
+			}
+		})
+	}
+}
+
 // The bootstrap/once idle loop must also stop on logout rather than reconnect.
 func TestRunSyncUntilIdleStopsOnLoggedOut(t *testing.T) {
 	a := newTestApp(t)
@@ -168,6 +225,46 @@ func TestRunSyncUntilIdleStopsOnLoggedOut(t *testing.T) {
 	f.mu.Unlock()
 	if calls != 0 {
 		t.Fatalf("logged-out idle loop reconnected (connectCalls=%d), want 0", calls)
+	}
+}
+
+// Same pairing race in the idle loop: with disconnected and loggedOut both
+// queued, the loop must stop without reconnecting.
+func TestRunSyncUntilIdleLoggedOutWinsOverDisconnected(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		a := newTestApp(t)
+		f := newFakeWA()
+		a.wa = f
+
+		var messagesStored, lastEvent atomic.Int64
+		lastEvent.Store(nowUTC().UnixNano())
+		disconnected := make(chan struct{}, 1)
+		loggedOut := make(chan struct{}, 1)
+		disconnected <- struct{}{}
+		loggedOut <- struct{}{}
+
+		done := make(chan error, 1)
+		go func() {
+			// Large idleExit so the idle ticker never fires before the logout signal.
+			_, err := a.runSyncUntilIdle(context.Background(), time.Hour, time.Second, SyncPresenceModeNormal, &messagesStored, &lastEvent, disconnected, loggedOut)
+			done <- err
+		}()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("run %d: runSyncUntilIdle returned error: %v", i, err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("run %d: runSyncUntilIdle did not stop with paired signals queued", i)
+		}
+
+		f.mu.Lock()
+		calls := f.connectCalls
+		f.mu.Unlock()
+		if calls != 0 {
+			t.Fatalf("run %d: idle loop reconnected before consuming logout (connectCalls=%d), want 0", i, calls)
+		}
 	}
 }
 

--- a/internal/app/sync_logout_test.go
+++ b/internal/app/sync_logout_test.go
@@ -94,7 +94,55 @@ func TestSyncEventHandlerEmitsLoggedOutAndSignals(t *testing.T) {
 			if s, _ := data["reason"].(string); s == "" {
 				t.Fatal("logged_out reason string is empty")
 			}
+			recovery, _ := data["recovery"].(string)
+			if !strings.Contains(recovery, "wacli auth logout") || !strings.Contains(recovery, "wacli auth --phone") {
+				t.Fatalf("logged_out recovery hint must name the `wacli auth logout` + `wacli auth --phone` sequence, got %q", recovery)
+			}
 		})
+	}
+}
+
+// The human (non --events) output must tell the operator how to recover:
+// sync keeps the local device record on a forced logout, so a bare
+// `auth --phone` short-circuits — the printed hint must name the
+// `wacli auth logout` → `wacli auth --phone` sequence.
+func TestSyncLoggedOutHumanOutputIncludesRecoveryHint(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	var human bytes.Buffer
+	st := newSyncStatus(&human)
+	a.statusMu.Lock()
+	a.status = st
+	a.statusMu.Unlock()
+
+	var messagesStored, lastEvent atomic.Int64
+	loggedOut := make(chan struct{}, 1)
+	handlerID := a.addSyncEventHandler(
+		context.Background(),
+		SyncOptions{Mode: SyncModeFollow},
+		&messagesStored,
+		&lastEvent,
+		make(chan struct{}, 1),
+		loggedOut,
+		make(chan staleReconnectRequest, 1),
+		func(string, string) {},
+		nil,
+		nil,
+		&syncPresence{},
+		nil,
+	)
+	defer f.RemoveEventHandler(handlerID)
+
+	f.emit(&events.LoggedOut{OnConnect: true, Reason: events.ConnectFailureLoggedOut})
+
+	got := human.String()
+	if !strings.Contains(got, "Logged out of WhatsApp") {
+		t.Fatalf("human output missing logout notice:\n%s", got)
+	}
+	if !strings.Contains(got, "wacli auth logout") || !strings.Contains(got, "wacli auth --phone") {
+		t.Fatalf("human output must name the `wacli auth logout` + `wacli auth --phone` recovery sequence:\n%s", got)
 	}
 }
 

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -132,6 +132,7 @@ func TestSyncEventHandlerClearsUnreadCountOnReadSelfReceipt(t *testing.T) {
 		&messagesStored,
 		&lastEvent,
 		make(chan struct{}, 1),
+		make(chan struct{}, 1),
 		make(chan staleReconnectRequest, 1),
 		func(string, string) {},
 		nil,
@@ -174,6 +175,7 @@ func TestSyncEventHandlerIgnoresRegularReadReceiptsForUnreadCount(t *testing.T) 
 		SyncOptions{},
 		&messagesStored,
 		&lastEvent,
+		make(chan struct{}, 1),
 		make(chan struct{}, 1),
 		make(chan staleReconnectRequest, 1),
 		func(string, string) {},
@@ -3590,6 +3592,7 @@ func TestSyncFollowIgnoresKeepAliveTimeoutFromPreviousConnection(t *testing.T) {
 	var connectionEpoch atomic.Int64
 	connectionEpoch.Store(nowUTC().UnixNano())
 	disconnected := make(chan struct{}, 1)
+	loggedOut := make(chan struct{}, 1)
 	staleReconnect := make(chan staleReconnectRequest, 1)
 	staleReconnect <- staleReconnectRequest{
 		threshold:   200 * time.Millisecond,
@@ -3601,7 +3604,7 @@ func TestSyncFollowIgnoresKeepAliveTimeoutFromPreviousConnection(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
-	_, err := a.runSyncFollow(ctx, time.Second, SyncPresenceModeNormal, &messagesStored, &connectionEpoch, disconnected, staleReconnect)
+	_, err := a.runSyncFollow(ctx, time.Second, SyncPresenceModeNormal, &messagesStored, &connectionEpoch, disconnected, loggedOut, staleReconnect)
 	if err != nil {
 		t.Fatalf("runSyncFollow: %v", err)
 	}

--- a/internal/app/webhook_events_test.go
+++ b/internal/app/webhook_events_test.go
@@ -355,6 +355,7 @@ func emitWebhookEvents(t *testing.T, webhookEvents string, emit func(f *fakeWA))
 		&messagesStored,
 		&lastEvent,
 		make(chan struct{}, 1),
+		make(chan struct{}, 1),
 		make(chan staleReconnectRequest, 1),
 		func(string, string) {},
 		a.newSyncWebhookEnqueuer(ctx, jobs),


### PR DESCRIPTION
## What
`sync --follow` now handles `*events.LoggedOut`: it emits a structured `logged_out` event and stops the loop cleanly, instead of reconnecting forever against a revoked session.

## Why
When WhatsApp revokes the session — the linked device is removed from the phone, or a logout/ban — whatsmeow emits `*events.LoggedOut`. wacli had no case for it, and whatsmeow keeps issuing `Disconnected` around the logout, so the follow loop's `<-disconnected → reconnect` path spun forever against a dead session. Nothing surfaced the logout and the daemon never stopped.

## What changed
- `internal/app/sync_events.go`: add `case *events.LoggedOut` → `emitOrPrint("logged_out", {reason, reason_code, on_connect}, …)` and signal a new buffered `loggedOut` channel (mirrors the existing `disconnected` plumbing).
- `internal/app/sync_idle.go`: both `runSyncFollow` and `runSyncUntilIdle` gain a `case <-loggedOut` that emits a terminal `stopping` line (`reason: logged_out`) and returns `nil` — clean stop, no reconnect.
- `internal/app/sync.go`: create the `loggedOut` channel and thread it through.
- **Review follow-up (`f322470`):** a revocation delivers `Disconnected` and `LoggedOut` back to back, and with both buffered channels ready `select` picks at random — so the loop could start one reconnect against the dead session before consuming the terminal signal. Every reconnect path (`disconnected` + `staleReconnect` in follow mode, `disconnected` in idle mode) now drains `loggedOut` non-blockingly first, so the terminal logout signal always wins.
- **Review follow-up (`333b27c`):** the `logged_out` output now names the recovery sequence in both modes — a `recovery` field on the NDJSON event and a printed hint on the human path: run `wacli auth logout` to clear the local session, then `wacli auth --phone` to pair again. Regression tests assert the wording in both the `--events` data and the human status-line output.

**Scope note:** this reports and stops only — it deliberately does **not** delete the local session store; that stays `auth logout`'s job. One consequence worth flagging: after a forced logout the `whatsmeow_device` row lingers, so a bare `auth --phone` re-pair short-circuits (it only pairs when `Store.ID == nil`) — which is why the emitted output now spells out the `auth logout` → `auth --phone` recovery sequence. If you'd prefer `sync` to also clear the session on logout (which would make `auth status` report not-authenticated and let re-pair start fresh), I'm happy to add it here or as a follow-up — I kept it out to keep this change non-destructive.

## New event
```json
{"event":"logged_out","data":{"reason":"401: logged out from another device","reason_code":401,"on_connect":true,"recovery":"To re-authenticate, run `wacli auth logout` to clear the local session, then `wacli auth --phone` to pair again."},"ts":…}
```

## Tested
Deterministic fake-client unit tests (no live account), in `internal/app/sync_logout_test.go`:
- the handler emits `logged_out` and signals the channel — both the forced-logout (`OnConnect=true`, reason 401) and stream-error (`OnConnect=false`, reason 0) paths;
- `runSyncFollow` and `runSyncUntilIdle` each stop on the logout signal with **no reconnect** (`connectCalls == 0`), under a background context so only the logout — not ctx cancellation — ends the loop;
- **paired-signal races:** `loggedOut` queued together with `disconnected` (and, in follow mode, with a `staleReconnect` request) still stops with `connectCalls == 0` — 50 iterations per case to cover `select`'s random choice between ready channels. These fail on the pre-fix head `d7be620` within a few runs;
- end-to-end `sync --follow` stops (`Sync` returns nil, `connectCalls == 1`) when a `LoggedOut` is delivered after connect;
- **recovery-hint wording:** the `logged_out` NDJSON `recovery` field and the human status-line output must both name `wacli auth logout` and `wacli auth --phone`.

`make check` is green locally on go1.26.5: gofmt, `go vet`, `go test ./...` plain + `-tags sqlite_fts5`, windows-lock cross-compile, cgo-required guard, docs tests, build, GoReleaser config checks, and `git diff --check`.

## Real behavior proof (live linked account)

Binary built from this PR's head (`f322470`, `CGO_ENABLED=1 -tags sqlite_fts5`, linux/arm64), paired to a real WhatsApp account via `auth --phone` (pair code) in a throwaway store; bootstrap synced ~3.9k messages. Then `sync --follow --events` ran while the linked device was removed from the phone (**Settings → Linked devices → Log out**). Phone numbers/JIDs never appear in the NDJSON; local IPs/ports redacted below.

```console
$ wacli --store /tmp/proof-store --events sync --follow
{"event":"connected","ts":1785339889247}

# ~35 min of normal operation. Several transient network drops during the run
# each took the normal path — disconnected → reconnecting → connected — e.g.:
16:19:12.623 [Client/Socket ERROR] Error reading from websocket: failed to get reader: failed to read frame header: read tcp REDACTED->REDACTED:443: read: connection reset by peer
{"event":"disconnected","ts":1785341952623}
{"event":"reconnecting","ts":1785341952623}
{"event":"connected","ts":1785341953614}

# 16:35 UTC: linked device removed from the phone →
{"event":"logged_out","data":{"on_connect":false,"reason":"401: logged out from another device","reason_code":401},"ts":1785342925277}
{"event":"stopping","data":{"messages_synced":1,"reason":"logged_out"},"ts":1785342925277}
Messages stored: 1
$ # process exited 0 — no reconnecting/connected events after logged_out
```

The contrast is the point: ordinary disconnects still reconnect (the pre-existing path, exercised repeatedly in the same run), while the real revocation emitted `logged_out`, stopped follow mode, and made no further reconnect attempt.

