### PR TITLE
fix(send): resolve quoted messages under the chat's PN/LID alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 
 ### Fixed
 
-- Send: resolve quoted direct messages across phone-number and LID chat aliases so replies can find migrated history. (#326 - thanks @0xlucuma)
 - Send: keep self-chat storage under the canonical phone-number chat and reject text sends to the linked account itself instead of reporting an acknowledgement that may never reach Message Yourself. (#319 - thanks @Lucas-Kim-J)
+- Send: resolve quoted direct messages across phone-number and LID chat aliases so replies can find migrated history. (#326 - thanks @0xlucuma)
 
 ### Chore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Send: resolve quoted direct messages across phone-number and LID chat aliases so replies can find migrated history. (#326 - thanks @0xlucuma)
 - Send: keep self-chat storage under the canonical phone-number chat and reject text sends to the linked account itself instead of reporting an acknowledgement that may never reach Message Yourself. (#319 - thanks @Lucas-Kim-J)
 
 ### Chore

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -218,6 +218,7 @@ type textMessageSender interface {
 	SendProtoMessage(ctx context.Context, to types.JID, msg *waProto.Message) (types.MessageID, error)
 	GetGroupInfo(ctx context.Context, jid types.JID) (*types.GroupInfo, error)
 	ResolvePNToLID(ctx context.Context, jid types.JID) types.JID
+	ResolveLIDToPN(ctx context.Context, jid types.JID) types.JID
 	LinkedJID() string
 	LinkedLID() string
 }
@@ -250,7 +251,11 @@ func sendTextMessageWithSender(ctx context.Context, sender textMessageSender, db
 	if err != nil {
 		return "", err
 	}
-	msg, plainText, err := buildTextMessageWithSelf(db, to, text, replyTo, replyToSender, selfJID, preview, mentionedJIDs)
+	var aliasTo types.JID
+	if strings.TrimSpace(replyTo) != "" {
+		aliasTo = replyLookupAlias(ctx, sender, to)
+	}
+	msg, plainText, err := buildTextMessageWithSelf(db, to, aliasTo, text, replyTo, replyToSender, selfJID, preview, mentionedJIDs)
 	if err != nil {
 		return "", err
 	}
@@ -466,11 +471,11 @@ func decodeMessageEscapes(s string) (string, error) {
 }
 
 func buildTextMessage(db *store.DB, to types.JID, text, replyTo, replyToSender string, preview *linkpreview.Preview, mentionedJIDs []string) (*waProto.Message, bool, error) {
-	return buildTextMessageWithSelf(db, to, text, replyTo, replyToSender, "", preview, mentionedJIDs)
+	return buildTextMessageWithSelf(db, to, types.EmptyJID, text, replyTo, replyToSender, "", preview, mentionedJIDs)
 }
 
-func buildTextMessageWithSelf(db *store.DB, to types.JID, text, replyTo, replyToSender, selfJID string, preview *linkpreview.Preview, mentionedJIDs []string) (*waProto.Message, bool, error) {
-	info, err := buildTextContextInfo(db, to, replyTo, replyToSender, selfJID, mentionedJIDs)
+func buildTextMessageWithSelf(db *store.DB, to, aliasTo types.JID, text, replyTo, replyToSender, selfJID string, preview *linkpreview.Preview, mentionedJIDs []string) (*waProto.Message, bool, error) {
+	info, err := buildTextContextInfo(db, to, aliasTo, replyTo, replyToSender, selfJID, mentionedJIDs)
 	if err != nil {
 		return nil, false, err
 	}
@@ -507,8 +512,27 @@ func attachLinkPreview(msg *waProto.ExtendedTextMessage, preview *linkpreview.Pr
 	msg.PreviewType = waProto.ExtendedTextMessage_NONE.Enum()
 }
 
-func buildTextContextInfo(db *store.DB, chat types.JID, replyTo, replyToSender, selfJID string, mentionedJIDs []string) (*waProto.ContextInfo, error) {
-	info, err := buildTextReplyContextInfo(db, chat, replyTo, replyToSender, selfJID)
+func getQuotedMessage(db *store.DB, chat, aliasChat types.JID, replyTo string) (store.Message, error) {
+	quoted, err := db.GetMessage(chat.String(), replyTo)
+	if !errors.Is(err, sql.ErrNoRows) || aliasChat.IsEmpty() || aliasChat.String() == chat.String() {
+		return quoted, err
+	}
+	return db.GetMessage(aliasChat.String(), replyTo)
+}
+
+func replyLookupAlias(ctx context.Context, sender textMessageSender, to types.JID) types.JID {
+	switch to.Server {
+	case types.DefaultUserServer:
+		return sender.ResolvePNToLID(ctx, to).ToNonAD()
+	case types.HiddenUserServer:
+		return sender.ResolveLIDToPN(ctx, to).ToNonAD()
+	default:
+		return types.EmptyJID
+	}
+}
+
+func buildTextContextInfo(db *store.DB, chat, aliasChat types.JID, replyTo, replyToSender, selfJID string, mentionedJIDs []string) (*waProto.ContextInfo, error) {
+	info, err := buildTextReplyContextInfo(db, chat, aliasChat, replyTo, replyToSender, selfJID)
 	if err != nil {
 		return nil, err
 	}
@@ -522,13 +546,13 @@ func buildTextContextInfo(db *store.DB, chat types.JID, replyTo, replyToSender, 
 	return info, nil
 }
 
-func buildTextReplyContextInfo(db *store.DB, chat types.JID, replyTo, replyToSender, selfJID string) (*waProto.ContextInfo, error) {
+func buildTextReplyContextInfo(db *store.DB, chat, aliasChat types.JID, replyTo, replyToSender, selfJID string) (*waProto.ContextInfo, error) {
 	replyTo = strings.TrimSpace(replyTo)
 	if replyTo == "" {
 		return nil, nil
 	}
 
-	quoted, err := db.GetMessage(chat.String(), replyTo)
+	quoted, err := getQuotedMessage(db, chat, aliasChat, replyTo)
 	if errors.Is(err, sql.ErrNoRows) {
 		if chat.Server == types.GroupServer && strings.TrimSpace(replyToSender) != "" {
 			participant, participantErr := resolveTextReplyParticipant(chat, store.Message{}, replyToSender, selfJID)

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -247,13 +247,13 @@ func sendTextMessageWithSender(ctx context.Context, sender textMessageSender, db
 	if err := validateTextRecipient(sender, to); err != nil {
 		return "", err
 	}
-	selfJID, err := textReplySelfJID(ctx, sender, db, to, replyTo, replyToSender)
-	if err != nil {
-		return "", err
-	}
 	var aliasTo types.JID
 	if strings.TrimSpace(replyTo) != "" {
 		aliasTo = replyLookupAlias(ctx, sender, to)
+	}
+	selfJID, err := textReplySelfJID(ctx, sender, db, to, aliasTo, replyTo, replyToSender)
+	if err != nil {
+		return "", err
 	}
 	msg, plainText, err := buildTextMessageWithSelf(db, to, aliasTo, text, replyTo, replyToSender, selfJID, preview, mentionedJIDs)
 	if err != nil {
@@ -303,13 +303,13 @@ func isSelfTextRecipient(sender textMessageSender, to types.JID) bool {
 	return err == nil && !linkedLID.IsEmpty() && linkedLID.ToNonAD() == to
 }
 
-func textReplySelfJID(ctx context.Context, sender textMessageSender, db *store.DB, chat types.JID, replyTo, replyToSender string) (string, error) {
+func textReplySelfJID(ctx context.Context, sender textMessageSender, db *store.DB, chat, aliasChat types.JID, replyTo, replyToSender string) (string, error) {
 	linked := strings.TrimSpace(sender.LinkedJID())
 	replyTo = strings.TrimSpace(replyTo)
 	if replyTo == "" || strings.TrimSpace(replyToSender) != "" {
 		return linked, nil
 	}
-	quoted, err := db.GetMessage(chat.String(), replyTo)
+	quoted, err := getQuotedMessage(db, chat, aliasChat, replyTo)
 	if err != nil || !quoted.FromMe {
 		return linked, nil
 	}

--- a/cmd/wacli/send_test.go
+++ b/cmd/wacli/send_test.go
@@ -45,6 +45,7 @@ type recordingTextSender struct {
 	linkedJID       string
 	linkedLID       types.JID
 	resolveLIDCalls int
+	lidToPN         types.JID
 }
 
 func (s *recordingTextSender) SendText(_ context.Context, to types.JID, text string) (types.MessageID, error) {
@@ -86,6 +87,9 @@ func (s *recordingTextSender) ResolvePNToLID(_ context.Context, _ types.JID) typ
 }
 
 func (s *recordingTextSender) ResolveLIDToPN(_ context.Context, jid types.JID) types.JID {
+	if !s.lidToPN.IsEmpty() {
+		return s.lidToPN
+	}
 	return jid
 }
 
@@ -1175,5 +1179,50 @@ func TestBuildTextReplyContextInfoFindsQuoteUnderChatAlias(t *testing.T) {
 				t.Fatalf("participant = %q, want %q", got.GetParticipant(), tc.storedIn.String())
 			}
 		})
+	}
+}
+
+func TestSendTextReplyToOwnMessageUnderChatAliasUsesLIDParticipant(t *testing.T) {
+	db := openSendTestDB(t)
+	pn := types.NewJID("51918505715", types.DefaultUserServer)
+	lid := types.NewJID("46922702278894", types.HiddenUserServer)
+	linkedPN := types.NewJID("15550000000", types.DefaultUserServer)
+	linkedLID := types.NewJID("99887766554433", types.HiddenUserServer)
+
+	if err := db.UpsertChat(pn.String(), "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := db.UpsertMessage(store.UpsertMessageParams{
+		ChatJID:   pn.String(),
+		MsgID:     "quoted",
+		Timestamp: time.Now(),
+		FromMe:    true,
+		Text:      "my earlier message",
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	sender := &recordingTextSender{
+		linkedJID: linkedPN.String(),
+		linkedLID: linkedLID,
+		lidToPN:   pn,
+	}
+
+	if _, err := sendTextMessageWithSender(context.Background(), sender, db, lid, "reply", "quoted", "", nil, nil, textEphemeralOptions{}); err != nil {
+		t.Fatalf("sendTextMessageWithSender: %v", err)
+	}
+
+	if sender.protoMsg == nil {
+		t.Fatal("no proto message sent")
+	}
+	ctxInfo := sender.protoMsg.GetExtendedTextMessage().GetContextInfo()
+	if ctxInfo == nil {
+		t.Fatal("no context info on the sent message")
+	}
+	if ctxInfo.GetStanzaID() != "quoted" {
+		t.Fatalf("stanza ID = %q, want quoted", ctxInfo.GetStanzaID())
+	}
+	if ctxInfo.GetParticipant() != linkedLID.String() {
+		t.Fatalf("participant = %q, want the linked LID %q", ctxInfo.GetParticipant(), linkedLID.String())
 	}
 }

--- a/cmd/wacli/send_test.go
+++ b/cmd/wacli/send_test.go
@@ -85,6 +85,10 @@ func (s *recordingTextSender) ResolvePNToLID(_ context.Context, _ types.JID) typ
 	return s.linkedLID
 }
 
+func (s *recordingTextSender) ResolveLIDToPN(_ context.Context, jid types.JID) types.JID {
+	return jid
+}
+
 type outboundTextResolverStub struct {
 	lid types.JID
 	pn  types.JID
@@ -465,7 +469,7 @@ func TestBuildTextReplyContextInfo(t *testing.T) {
 				t.Fatalf("UpsertMessage: %v", err)
 			}
 
-			got, err := buildTextReplyContextInfo(db, tc.chat, "quoted", "", self)
+			got, err := buildTextReplyContextInfo(db, tc.chat, types.EmptyJID, "quoted", "", self)
 			if err != nil {
 				t.Fatalf("buildTextReplyContextInfo: %v", err)
 			}
@@ -1124,5 +1128,52 @@ func TestBuildTextMessageAttachesLinkPreview(t *testing.T) {
 	}
 	if string(ext.GetJPEGThumbnail()) != "jpeg" {
 		t.Fatalf("thumbnail = %q", string(ext.GetJPEGThumbnail()))
+	}
+}
+
+func TestBuildTextReplyContextInfoFindsQuoteUnderChatAlias(t *testing.T) {
+	pn := types.NewJID("51918505715", types.DefaultUserServer)
+	lid := types.NewJID("46922702278894", types.HiddenUserServer)
+
+	tests := []struct {
+		name      string
+		storedIn  types.JID
+		addressed types.JID
+	}{
+		{name: "history under phone JID, addressed by LID", storedIn: pn, addressed: lid},
+		{name: "history under LID, addressed by phone JID", storedIn: lid, addressed: pn},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openSendTestDB(t)
+			if err := db.UpsertChat(tc.storedIn.String(), "chat", "alias chat", time.Now()); err != nil {
+				t.Fatalf("UpsertChat: %v", err)
+			}
+			if err := db.UpsertMessage(store.UpsertMessageParams{
+				ChatJID:   tc.storedIn.String(),
+				MsgID:     "quoted",
+				SenderJID: tc.storedIn.String(),
+				Timestamp: time.Now(),
+				Text:      "original",
+			}); err != nil {
+				t.Fatalf("UpsertMessage: %v", err)
+			}
+
+			if _, err := buildTextReplyContextInfo(db, tc.addressed, types.EmptyJID, "quoted", "", ""); err == nil {
+				t.Fatal("expected the un-aliased lookup to fail")
+			}
+
+			got, err := buildTextReplyContextInfo(db, tc.addressed, tc.storedIn, "quoted", "", "")
+			if err != nil {
+				t.Fatalf("alias lookup should resolve the quote: %v", err)
+			}
+			if got == nil || got.GetStanzaID() != "quoted" {
+				t.Fatalf("context info = %+v, want StanzaID=quoted", got)
+			}
+			if got.GetParticipant() != tc.storedIn.String() {
+				t.Fatalf("participant = %q, want %q", got.GetParticipant(), tc.storedIn.String())
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- fall back to the chat's PN/LID counterpart when looking up a quoted message
- resolve the counterpart only when a reply is requested, so plain sends are unchanged
- normalize the resolved JID with `ToNonAD()`, matching `canonicalMessageFilterJID`

## Why

`send text --reply-to` fails in one-to-one chats with `quoted message <id> not found in local store for chat <lid>; run `wacli sync` first`, and syncing never helps.

Sends resolve the recipient to whichever addressing mode WhatsApp reports, so a LID-addressed contact becomes `<lid>@lid`, and `buildTextReplyContextInfo` does a single exact-match `GetMessage` against it. The store canonicalizes the other way, because the LID migration on authenticated startup re-homes `@lid` rows to the phone-number JID. The lookup therefore searches the LID chat while the history sits under the PN chat. On a live store that was 181 messages under `<pn>` against 1 under `<lid>`. Reads already compensate through `mappedChatJIDs`, but the send path does not. Groups escape it through the `ErrNoRows` plus `--reply-to-sender` fallback, so only DMs are affected.

## Validation

Full repository gate green. New table-driven regression test `TestBuildTextReplyContextInfoFindsQuoteUnderChatAlias` covers both directions and asserts the un-aliased lookup still fails, so it cannot pass vacuously. Verified against a live account, where a reply that previously failed was delivered and quoted correctly.

## Redacted live behaviour proof

`textReplySelfJID` ran its own unaliased lookup before the alias existed, so an
own quoted message under the counterpart JID produced the linked phone JID as
`ContextInfo.Participant` instead of the linked LID. Addressed in the second
commit by resolving the alias first and passing it into that lookup, plus a
send-path regression that goes through `sendTextMessageWithSender` with a
`FromMe` quote.

Proof below uses a temporary diagnostic build with stderr-only tracing that
stops before the wire send. The tracing is not part of the PR diff. It runs
against a scratch copy of an authenticated store, put into the split state the
bug requires: 188 messages under the phone JID, 1 under the LID, both chats
present. Numbers redacted.

```text
### main
$ WACLI_PROOF=1 wacli-proof-stock --store REDACTED --json send text \
    --to <redacted>@s.whatsapp.net --reply-to 3EB0B3DD... --message proof
{"success":false,"data":null,"error":"quoted message 3EB0B3DD... not found in
 local store for chat <redacted>@lid; run `wacli sync` first"}

### first commit only (quote lookup aliased, participant lookup not)
proof: chat=<redacted>@lid alias=<redacted>@s.whatsapp.net
       selfJID=<redacted>@s.whatsapp.net stanza=3EB0B3DD...
       participant=<redacted>@s.whatsapp.net      <-- linked PN, the reported bug

### this PR head
proof: chat=<redacted>@lid alias=<redacted>@s.whatsapp.net
       selfJID=<redacted>@lid stanza=3EB0B3DD...
       participant=<redacted>@lid                 <-- linked LID, matches main's
                                                      LID-addressed branch
```

Reverting only the ordering change makes the new regression fail with
`participant = "<linked pn>", want the linked LID`, so it cannot pass
vacuously.

End to end on a real linked account, before the second commit existed, a reply
that had failed with the `not found in local store` error above was delivered
and quoted correctly once the first commit was in place.

## Reproducing

The failure needs the split state, which is why it can look unreproducible: the
LID migration on authenticated startup merges the LID chat into the phone-JID
chat, and after that the lookup hits the right rows and stock succeeds. The bug
appears in the window between an `@lid`-addressed message creating a LID chat
and the next authenticated startup.

## Scope

Left out to keep this reviewable, happy to follow up:

- the same single-JID lookup exists at other by-id call sites and would fail the same way: `send react` (`send_react_cmd.go:151`), `send select` (`send_select_cmd.go:224`), `media download` (`media.go:255`), `messages purge` (`messages_purge.go:46`), `messages_helpers.go:145`, and `poll vote/show` (`poll_cmd.go:258`, in a file that already resolves aliases for list filters)
- a shared helper in `internal/wa` would cover all of them, since it already owns `ResolvePNToLID` and `ResolveLIDToPN`, if you want one and can say where it should live
- wacli does not persist reply context for messages it sends, so an outbound reply is stored locally without its quote even though the quote goes out on the wire
