### PR TITLE
build(deps): update pnpm to v11

### DIFF
--- a/.github/actions/setup-ci-env/action.yml
+++ b/.github/actions/setup-ci-env/action.yml
@@ -43,7 +43,7 @@ runs:
       shell: bash
       run: |
         corepack enable
-        corepack prepare pnpm@10.34.4 --activate
+        corepack prepare pnpm@11.18.0 --activate
         pnpm --version
 
     - name: Install apt packages

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   NODE_VERSION: "24"
-  PNPM_VERSION: "10.34.4"
+  PNPM_VERSION: "11.18.0"
 
 jobs:
   hydrate:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Chore
 
 - Dependencies: update `whatsmeow`, terminal support, GraphQL parsing, and supporting Go modules.
+- Tooling: update the pinned pnpm version from 10.34.4 to 11.18.0.
 - Build: migrate `sqlc` code generator to Go 1.24+ `go tool` directive and bump project toolchain requirement to Go 1.26.5. (#313 - thanks @thedavidweng)
 - Build: standardize the Makefile's build, check, snapshot, and verified local-release targets across the crawler repositories.
 - Release: publish v0.15.0 under a one-time clean-VM Gatekeeper waiver, with retroactive VM proof still required when hardware returns, and verify preserved drafts against their release commit's Go toolchain.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wacli",
   "private": true,
-  "packageManager": "pnpm@10.34.4",
+  "packageManager": "pnpm@11.18.0+sha512.33d83c77da82f49fba836925c6f1b841181ec3132b670639bd012f7075f5c7cf634c5f870147c19aae7478fac01df09d8892e880454896edd23ee9b33757563c",
   "scripts": {
     "wacli": "bash -lc 'pnpm -s build >/dev/null && exec ./dist/wacli \"$@\"' _",
     "build": "mkdir -p dist && CGO_ENABLED=1 CGO_CFLAGS=\"${CGO_CFLAGS:+$CGO_CFLAGS }-Wno-error=missing-braces\" go build -tags sqlite_fts5 -o dist/wacli ./cmd/wacli",


### PR DESCRIPTION
## Summary

- update the integrity-pinned package manager from pnpm 10.34.4 to stable pnpm 11.18.0
- record the tooling update in the unreleased changelog

## Freshness pass

`go list -m -u -json all` reported no available update for any direct, indirect, or tool module. The Go 1.26.5 toolchain and sqlc v1.31.1 tool dependency are already current in this repository. The project has no npm dependencies, so pnpm's lockfile remains unchanged.

Registry evidence: npm's `latest` tag points to pnpm 11.18.0; it requires Node >=22.13, and the proof host runs Node 24.18.0.

## Proof

- `pnpm install --frozen-lockfile` under pnpm 11.18.0
- `pnpm format:check`
- `pnpm lint`
- `pnpm test:go`
- `pnpm test:fts`
- `pnpm test:windows-lock`
- `pnpm test:cgo-required`
- `pnpm test:docs` (42/42)
- `pnpm build`
- `pnpm docs:site`
- `go tool github.com/sqlc-dev/sqlc/cmd/sqlc version` -> v1.31.1
- `git diff --check`
- live built binary: `./dist/wacli --version` -> `wacli 0.15.0`
- live built binary: read-only JSON doctor against a fresh store returned success with `authenticated:false`, `connected:false`, and exit 0
- Codex autoreview: clean, no accepted/actionable findings (overall correctness 0.99)
