### PR TITLE
fix(send): surface local store failures after successful file send

### DIFF
--- a/cmd/wacli/send_file.go
+++ b/cmd/wacli/send_file.go
@@ -159,8 +159,10 @@ func sendFile(ctx context.Context, a interface {
 		return "", nil, err
 	}
 
+	// Network send already succeeded. Local store failures must still surface so
+	// history does not silently diverge (disk full, locked DB, corruption).
 	if to == types.StatusBroadcastJID {
-		_ = a.DB().UpsertStatusMessage(store.UpsertStatusMessageParams{
+		if err := a.DB().UpsertStatusMessage(store.UpsertStatusMessageParams{
 			MsgID:         id,
 			Timestamp:     now,
 			FromMe:        true,
@@ -175,12 +177,16 @@ func sendFile(ctx context.Context, a interface {
 			FileSHA256:    up.FileSHA256,
 			FileEncSHA256: up.FileEncSHA256,
 			FileLength:    up.FileLength,
-		})
+		}); err != nil {
+			return id, nil, fmt.Errorf("message sent but local store update failed: %w", err)
+		}
 	} else {
 		chatName := a.WA().ResolveChatName(ctx, to, "")
 		kind := chatKindFromJID(to)
-		_ = a.DB().UpsertChat(to.String(), kind, chatName, now)
-		_ = a.DB().UpsertMessage(store.UpsertMessageParams{
+		if err := a.DB().UpsertChat(to.String(), kind, chatName, now); err != nil {
+			return id, nil, fmt.Errorf("message sent but local chat store update failed: %w", err)
+		}
+		if err := a.DB().UpsertMessage(store.UpsertMessageParams{
 			ChatJID:       to.String(),
 			ChatName:      chatName,
 			MsgID:         id,
@@ -198,7 +204,9 @@ func sendFile(ctx context.Context, a interface {
 			FileSHA256:    up.FileSHA256,
 			FileEncSHA256: up.FileEncSHA256,
 			FileLength:    up.FileLength,
-		})
+		}); err != nil {
+			return id, nil, fmt.Errorf("message sent but local message store update failed: %w", err)
+		}
 	}
 
 	return id, map[string]string{


### PR DESCRIPTION
## What Problem This Solves

After a successful WhatsApp file send, `send_file` discarded `UpsertChat` / `UpsertMessage` / `UpsertStatusMessage` errors (`_ = ...`). Disk full, locked DB, or corruption left local history silently wrong while the network send succeeded.

## Evidence

### After

```go
if err := a.DB().UpsertMessage(...); err != nil {
  return id, nil, fmt.Errorf("message sent but local message store update failed: %w", err)
}
```

```console
$ go test ./cmd/wacli/ -count=1
ok  github.com/openclaw/wacli/cmd/wacli
$ go build ./...
```

## Real behavior proof

- **Behavior or issue addressed:** Surface local SQLite persist failures after a successful media send instead of swallowing them.
- **Real environment tested:** macOS arm64, Go, `/tmp/oc-batch-20260802/wacli`.
- **Exact steps or command run after this patch:** `go test ./cmd/wacli/ -count=1` and `go build ./...`.
- **Evidence after fix:** Package tests pass; build clean.
- **Observed result after fix:** Store errors return with message id still available when send completed.
- **What was not tested:** Live WhatsApp send against a forced SQLite failure (would need a broken DB path in integration).

## Summary

Check Upsert* errors after SendProtoMessage; wrap with clear "sent but store failed" errors.
