### PR TITLE
chore: open 0.15.2 unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.15.2 - Unreleased
+
 ## 0.15.1 - 2026-08-01
 
 ### Added


### PR DESCRIPTION
Opens the next versioned Unreleased changelog section after the verified v0.15.1 release and recovered Homebrew handoff.

Proof: changelog/release contract tests pass; autoreview clean.
