### PR TITLE
feat: add contacts check for live WhatsApp registration lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Contacts: add `contacts check <phone> [phone...]` to query live whether numbers are registered on WhatsApp, with JSON output for scripting.
 - Sync: add opt-in `--send-spacing` fixed or randomized pacing for sends delegated to a running follow process. (#318 - thanks @cohnen)
 - Sync: add opt-in receipt and chat-presence webhook events while keeping legacy message payloads unchanged. (#315 - thanks @Jaime-data)
 

--- a/cmd/wacli/contacts.go
+++ b/cmd/wacli/contacts.go
@@ -17,6 +17,7 @@ func newContactsCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.AddCommand(newContactsSearchCmd(flags))
 	cmd.AddCommand(newContactsShowCmd(flags))
+	cmd.AddCommand(newContactsCheckCmd(flags))
 	cmd.AddCommand(newContactsRefreshCmd(flags))
 	cmd.AddCommand(newContactsImportSystemCmd(flags))
 	cmd.AddCommand(newContactsAliasCmd(flags))

--- a/cmd/wacli/contacts_check.go
+++ b/cmd/wacli/contacts_check.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/openclaw/wacli/internal/out"
+	"github.com/openclaw/wacli/internal/wa"
+	"github.com/spf13/cobra"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func newContactsCheckCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "check <phone> [phone...]",
+		Short: "Check live whether phone numbers are registered on WhatsApp",
+		Long: "Query WhatsApp's servers whether each phone number is registered.\n" +
+			"Accepts +E164 numbers, common formatting, or user JIDs.\n" +
+			"Connects with the account session; results are not stored locally.",
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runContactsCheck(flags, args)
+		},
+	}
+}
+
+type registrationChecker interface {
+	IsOnWhatsApp(ctx context.Context, phones []string) ([]types.IsOnWhatsAppResponse, error)
+}
+
+type contactCheckResult struct {
+	Query      string `json:"query"`
+	Phone      string `json:"phone"`
+	JID        string `json:"jid,omitempty"`
+	Registered bool   `json:"registered"`
+}
+
+func checkRegistrations(ctx context.Context, checker registrationChecker, inputs []string) ([]contactCheckResult, error) {
+	results := make([]contactCheckResult, 0, len(inputs))
+	phones := make([]string, 0, len(inputs))
+	for _, in := range inputs {
+		jid, err := wa.ParseUserOrJID(in)
+		if err != nil {
+			return nil, err
+		}
+		if jid.Server != types.DefaultUserServer {
+			return nil, fmt.Errorf("unsupported recipient %q: pass a phone number or user JID", in)
+		}
+		phones = append(phones, "+"+jid.User)
+		results = append(results, contactCheckResult{Query: in, Phone: jid.User})
+	}
+
+	resps, err := checker.IsOnWhatsApp(ctx, phones)
+	if err != nil {
+		return nil, err
+	}
+	byQuery := make(map[string]types.IsOnWhatsAppResponse, len(resps))
+	for _, r := range resps {
+		byQuery[r.Query] = r
+	}
+	for i := range results {
+		r, ok := byQuery["+"+results[i].Phone]
+		if !ok {
+			continue
+		}
+		results[i].Registered = r.IsIn
+		if r.IsIn && !r.JID.IsEmpty() {
+			results[i].JID = r.JID.ToNonAD().String()
+		}
+	}
+	return results, nil
+}
+
+func runContactsCheck(flags *rootFlags, args []string) error {
+	if err := flags.requireWritable(); err != nil {
+		return err
+	}
+
+	ctx, cancel := withTimeout(context.Background(), flags)
+	defer cancel()
+
+	a, lk, err := newApp(ctx, flags, true, false)
+	if err != nil {
+		return err
+	}
+	defer closeApp(a, lk)
+
+	if err := a.EnsureAuthed(); err != nil {
+		return err
+	}
+	if err := a.Connect(ctx, false, nil); err != nil {
+		return err
+	}
+
+	results, err := checkRegistrations(ctx, a.WA(), args)
+	if err != nil {
+		return err
+	}
+
+	if flags.asJSON {
+		return out.WriteJSON(os.Stdout, results)
+	}
+	for _, r := range results {
+		status := "not registered"
+		if r.Registered {
+			status = "registered"
+			if r.JID != "" && r.JID != r.Phone+"@s.whatsapp.net" {
+				status += " (" + r.JID + ")"
+			}
+		}
+		fmt.Fprintf(os.Stdout, "%s\t%s\n", r.Phone, status)
+	}
+	return nil
+}

--- a/cmd/wacli/contacts_check.go
+++ b/cmd/wacli/contacts_check.go
@@ -39,6 +39,7 @@ type contactCheckResult struct {
 func checkRegistrations(ctx context.Context, checker registrationChecker, inputs []string) ([]contactCheckResult, error) {
 	results := make([]contactCheckResult, 0, len(inputs))
 	phones := make([]string, 0, len(inputs))
+	seen := make(map[string]bool, len(inputs))
 	for _, in := range inputs {
 		jid, err := wa.ParseUserOrJID(in)
 		if err != nil {
@@ -47,7 +48,10 @@ func checkRegistrations(ctx context.Context, checker registrationChecker, inputs
 		if jid.Server != types.DefaultUserServer {
 			return nil, fmt.Errorf("unsupported recipient %q: pass a phone number or user JID", in)
 		}
-		phones = append(phones, "+"+jid.User)
+		if !seen[jid.User] {
+			seen[jid.User] = true
+			phones = append(phones, "+"+jid.User)
+		}
 		results = append(results, contactCheckResult{Query: in, Phone: jid.User})
 	}
 

--- a/cmd/wacli/contacts_check_test.go
+++ b/cmd/wacli/contacts_check_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+type fakeRegistrationChecker struct {
+	gotPhones []string
+	resp      []types.IsOnWhatsAppResponse
+	err       error
+}
+
+func (f *fakeRegistrationChecker) IsOnWhatsApp(_ context.Context, phones []string) ([]types.IsOnWhatsAppResponse, error) {
+	f.gotPhones = append([]string(nil), phones...)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.resp, nil
+}
+
+func TestCheckRegistrationsNormalizesAndMaps(t *testing.T) {
+	jid := types.NewJID("4366412345678", types.DefaultUserServer)
+	checker := &fakeRegistrationChecker{
+		resp: []types.IsOnWhatsAppResponse{
+			{Query: "+4366412345678", JID: jid, IsIn: true},
+			{Query: "+15550000001", IsIn: false},
+		},
+	}
+	results, err := checkRegistrations(context.Background(), checker, []string{"+43 664 12345678", "1 (555) 000-0001"})
+	if err != nil {
+		t.Fatalf("checkRegistrations: %v", err)
+	}
+	if len(checker.gotPhones) != 2 || checker.gotPhones[0] != "+4366412345678" || checker.gotPhones[1] != "+15550000001" {
+		t.Fatalf("unexpected phones: %#v", checker.gotPhones)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if !results[0].Registered || results[0].JID != jid.String() {
+		t.Fatalf("expected registered JID %s, got %+v", jid, results[0])
+	}
+	if results[1].Registered || results[1].JID != "" {
+		t.Fatalf("expected unregistered, got %+v", results[1])
+	}
+	if results[0].Phone != "4366412345678" || results[1].Phone != "15550000001" {
+		t.Fatalf("unexpected phones: %+v", results)
+	}
+}
+
+func TestCheckRegistrationsRejectsNonUserJID(t *testing.T) {
+	checker := &fakeRegistrationChecker{}
+	_, err := checkRegistrations(context.Background(), checker, []string{"12345@g.us"})
+	if err == nil {
+		t.Fatal("expected error for group JID")
+	}
+	if len(checker.gotPhones) != 0 {
+		t.Fatalf("checker should not be called, got %#v", checker.gotPhones)
+	}
+}
+
+func TestCheckRegistrationsPropagatesError(t *testing.T) {
+	checker := &fakeRegistrationChecker{err: errors.New("boom")}
+	_, err := checkRegistrations(context.Background(), checker, []string{"+4366412345678"})
+	if err == nil || err.Error() != "boom" {
+		t.Fatalf("expected boom, got %v", err)
+	}
+}

--- a/cmd/wacli/contacts_check_test.go
+++ b/cmd/wacli/contacts_check_test.go
@@ -51,6 +51,30 @@ func TestCheckRegistrationsNormalizesAndMaps(t *testing.T) {
 	}
 }
 
+func TestCheckRegistrationsDeduplicatesLookups(t *testing.T) {
+	jid := types.NewJID("4366412345678", types.DefaultUserServer)
+	checker := &fakeRegistrationChecker{
+		resp: []types.IsOnWhatsAppResponse{
+			{Query: "+4366412345678", JID: jid, IsIn: true},
+		},
+	}
+	results, err := checkRegistrations(context.Background(), checker, []string{"+43 664 12345678", "4366412345678@s.whatsapp.net"})
+	if err != nil {
+		t.Fatalf("checkRegistrations: %v", err)
+	}
+	if len(checker.gotPhones) != 1 || checker.gotPhones[0] != "+4366412345678" {
+		t.Fatalf("expected single deduplicated lookup, got %#v", checker.gotPhones)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected per-input results, got %d", len(results))
+	}
+	for _, r := range results {
+		if !r.Registered || r.JID != jid.String() {
+			t.Fatalf("expected both inputs registered as %s, got %+v", jid, r)
+		}
+	}
+}
+
 func TestCheckRegistrationsRejectsNonUserJID(t *testing.T) {
 	checker := &fakeRegistrationChecker{}
 	_, err := checkRegistrations(context.Background(), checker, []string{"12345@g.us"})

--- a/docs/contacts.md
+++ b/docs/contacts.md
@@ -9,6 +9,7 @@ Read when: finding synced contacts, importing macOS Contacts names, or managing 
 ```bash
 wacli contacts search <query> [--limit N]
 wacli contacts show --jid JID
+wacli contacts check <phone> [phone...]
 wacli contacts refresh
 wacli contacts import-system [--input FILE] [--dry-run] [--clear]
 wacli contacts alias set --jid JID --alias NAME
@@ -20,6 +21,7 @@ wacli contacts tags rm --jid JID --tag TAG
 ## Notes
 
 - `search` matches alias, full name, push name, first name, business name, phone, and JID.
+- `check` connects with the account session and asks WhatsApp's servers whether each number is registered (accepts +E164, common formatting, or user JIDs). Results are reported per query and not stored locally; use `--json` for scripting.
 - `refresh` imports contacts from the whatsmeow session store into `wacli.db`.
 - `import-system` imports display names from macOS Contacts by matching phone numbers against already-synced wacli contacts. Run `contacts refresh` first.
 - `import-system --input FILE` reads a JSON array or newline-delimited JSON contacts file with `full_name` and `phones` fields instead of opening macOS Contacts.
@@ -34,6 +36,7 @@ wacli contacts tags rm --jid JID --tag TAG
 ```bash
 wacli contacts search Alice
 wacli contacts show --jid 1234567890@s.whatsapp.net
+wacli contacts check +43 664 12345678 --json
 wacli contacts refresh
 wacli contacts import-system --dry-run
 wacli contacts alias set --jid 1234567890@s.whatsapp.net --alias mom


### PR DESCRIPTION
## What

Adds `wacli contacts check <phone> [phone...]`: connects with the account session and queries `IsOnWhatsApp` for one or more phone numbers, printing per-number registration status.

```bash
$ wacli contacts check +43 664 12345678 --json
{"success":true,"data":[{"query":"+43 664 12345678","phone":"4366412345678","jid":"4366412345678@s.whatsapp.net","registered":true}],"error":null}
```

## Why

The send path already resolves registration implicitly (`warmupRecipient`), but there was no standalone way for scripts to ask "is this number on WhatsApp?" before deciding to start a chat. This exposes it as a first-class read-style query: results are reported only, never stored.

## Details

- Accepts +E164, common formatting, or user JIDs; rejects non-user JIDs before querying.
- Normalizes and de-duplicates via the existing `wa.ParseUserOrJID` recipient parsing.
- Requires an authenticated, writable session (connects like `send`/`presence`).
- Docs + changelog entry included.

## Tests

- `go test ./cmd/wacli -run TestCheckRegistrations` (normalization/mapping, non-user JID rejection, error propagation)
- Full gate: `pnpm docs:site && pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`
