### PR TITLE
fix(send): surface local store failures after delivered sends as warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Contacts: add `contacts check <phone> [phone...]` to query live whether numbers are registered on WhatsApp, with JSON output for scripting; per-number `responded` distinguishes a server non-answer from a confirmed "not registered". (#331)
 
+### Fixed
+
+- Send: surface local history failures after a delivered file, voice, or status send as a `store_warning` (stderr warning plus JSON field) instead of silently diverging local history, while keeping the delivered message id so scripts do not retry an already-sent message. (#328 - thanks @SebTardif)
+
 ## 0.15.1 - 2026-08-01
 
 ### Added

--- a/cmd/wacli/send_file.go
+++ b/cmd/wacli/send_file.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -11,6 +12,7 @@ import (
 	_ "image/gif"
 	"image/jpeg"
 	_ "image/png"
+	"io"
 	"math"
 	"mime"
 	"net/http"
@@ -52,19 +54,30 @@ type voiceNoteMetadata struct {
 	waveform []byte
 }
 
+// sendFileOutcome is the result of a completed file send. storeWarning is
+// non-nil when WhatsApp accepted the message but recording it in local
+// history failed; callers must surface the warning without discarding the
+// delivered ID, since reporting a hard error would invite automation to
+// retry an already-delivered message.
+type sendFileOutcome struct {
+	id           string
+	meta         map[string]string
+	storeWarning error
+}
+
 func sendFile(ctx context.Context, a interface {
 	WA() app.WAClient
 	DB() *store.DB
-}, to types.JID, filePath string, opts sendFileOptions) (string, map[string]string, error) {
+}, to types.JID, filePath string, opts sendFileOptions) (sendFileOutcome, error) {
 	mediaAs, err := validateSendFileMediaOptions(opts.mediaAs, opts.ptt)
 	if err != nil {
-		return "", nil, err
+		return sendFileOutcome{}, err
 	}
 	opts.mediaAs = mediaAs
 
 	data, err := readSendFileData(filePath)
 	if err != nil {
-		return "", nil, err
+		return sendFileOutcome{}, err
 	}
 
 	name := strings.TrimSpace(opts.filename)
@@ -73,20 +86,20 @@ func sendFile(ctx context.Context, a interface {
 	}
 	mimeType := detectSendFileMIME(filePath, opts.mimeOverride, data)
 	if opts.ptt && !isOggOpusMIME(mimeType) {
-		return "", nil, fmt.Errorf("voice notes require OGG Opus audio; got %s", mimeType)
+		return sendFileOutcome{}, fmt.Errorf("voice notes require OGG Opus audio; got %s", mimeType)
 	}
 
 	mediaType, uploadType, err := resolveSendMediaType(mimeType, opts.mediaAs)
 	if err != nil {
-		return "", nil, err
+		return sendFileOutcome{}, err
 	}
 
 	isNewsletter := to.Server == types.NewsletterServer
 	if isNewsletter && opts.ptt {
-		return "", nil, fmt.Errorf("voice-note mode is not supported for channels; omit --ptt to send audio")
+		return sendFileOutcome{}, fmt.Errorf("voice-note mode is not supported for channels; omit --ptt to send audio")
 	}
 	if isNewsletter && (strings.TrimSpace(opts.replyTo) != "" || strings.TrimSpace(opts.replyToSender) != "") {
-		return "", nil, fmt.Errorf("quoted file replies are not supported for channels")
+		return sendFileOutcome{}, fmt.Errorf("quoted file replies are not supported for channels")
 	}
 
 	var up whatsmeow.UploadResponse
@@ -96,7 +109,7 @@ func sendFile(ctx context.Context, a interface {
 		up, err = a.WA().Upload(ctx, data, uploadType)
 	}
 	if err != nil {
-		return "", nil, err
+		return sendFileOutcome{}, err
 	}
 
 	now := time.Now().UTC()
@@ -105,7 +118,7 @@ func sendFile(ctx context.Context, a interface {
 	if !isNewsletter {
 		replyContext, err = buildReplyContextInfo(a.DB(), to, opts.replyTo, opts.replyToSender)
 		if err != nil {
-			return "", nil, err
+			return sendFileOutcome{}, err
 		}
 	}
 	voiceMeta := voiceNoteMetadata{}
@@ -117,7 +130,7 @@ func sendFile(ctx context.Context, a interface {
 	case "image":
 		imageMsg, err := newImageMessage(up, mimeType, opts.caption, data)
 		if err != nil {
-			return "", nil, err
+			return sendFileOutcome{}, err
 		}
 		msg.ImageMessage = imageMsg
 	case "video":
@@ -156,11 +169,15 @@ func sendFile(ctx context.Context, a interface {
 		id, err = a.WA().SendProtoMessage(ctx, to, msg)
 	}
 	if err != nil {
-		return "", nil, err
+		return sendFileOutcome{}, err
 	}
 
+	// The send already succeeded; store failures below surface as a warning
+	// on the outcome instead of an error so history divergence is visible
+	// without turning a delivered message into a reported failure.
+	var storeErr error
 	if to == types.StatusBroadcastJID {
-		_ = a.DB().UpsertStatusMessage(store.UpsertStatusMessageParams{
+		storeErr = a.DB().UpsertStatusMessage(store.UpsertStatusMessageParams{
 			MsgID:         id,
 			Timestamp:     now,
 			FromMe:        true,
@@ -179,8 +196,10 @@ func sendFile(ctx context.Context, a interface {
 	} else {
 		chatName := a.WA().ResolveChatName(ctx, to, "")
 		kind := chatKindFromJID(to)
-		_ = a.DB().UpsertChat(to.String(), kind, chatName, now)
-		_ = a.DB().UpsertMessage(store.UpsertMessageParams{
+		if err := a.DB().UpsertChat(to.String(), kind, chatName, now); err != nil {
+			storeErr = fmt.Errorf("chat update: %w", err)
+		}
+		if err := a.DB().UpsertMessage(store.UpsertMessageParams{
 			ChatJID:       to.String(),
 			ChatName:      chatName,
 			MsgID:         id,
@@ -198,15 +217,40 @@ func sendFile(ctx context.Context, a interface {
 			FileSHA256:    up.FileSHA256,
 			FileEncSHA256: up.FileEncSHA256,
 			FileLength:    up.FileLength,
-		})
+		}); err != nil {
+			storeErr = errors.Join(storeErr, fmt.Errorf("message update: %w", err))
+		}
 	}
 
-	return id, map[string]string{
-		"name":      name,
-		"mime_type": mimeType,
-		"media":     mediaType,
-		"ptt":       strconv.FormatBool(opts.ptt),
+	return sendFileOutcome{
+		id: id,
+		meta: map[string]string{
+			"name":      name,
+			"mime_type": mimeType,
+			"media":     mediaType,
+			"ptt":       strconv.FormatBool(opts.ptt),
+		},
+		storeWarning: storeErr,
 	}, nil
+}
+
+// warnSendStoreFailure reports a post-delivery local-history failure on the
+// human channel. Kept alongside sendFileOutcome so every caller phrases the
+// partial success the same way.
+func warnSendStoreFailure(w io.Writer, id string, storeWarning error) {
+	if storeWarning == nil {
+		return
+	}
+	fmt.Fprintf(w, "warning: message delivered (id %s) but local history update failed: %v\n", id, storeWarning)
+}
+
+// addStoreWarning annotates a JSON success payload with the partial-success
+// marker; absent key means local history was written.
+func addStoreWarning(payload map[string]any, storeWarning error) map[string]any {
+	if storeWarning != nil {
+		payload["store_warning"] = storeWarning.Error()
+	}
+	return payload
 }
 
 // resolveSendMediaType decides the WhatsApp message type (and matching upload

--- a/cmd/wacli/send_file_cmd.go
+++ b/cmd/wacli/send_file_cmd.go
@@ -88,12 +88,8 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			type sendFileResult struct {
-				id   string
-				meta map[string]string
-			}
-			res, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (sendFileResult, error) {
-				msgID, meta, err := sendFile(ctx, a, toJID, filePath, sendFileOptions{
+			res, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (sendFileOutcome, error) {
+				return sendFile(ctx, a, toJID, filePath, sendFileOptions{
 					filename:      filename,
 					caption:       caption,
 					mimeOverride:  mimeOverride,
@@ -102,27 +98,23 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 					replyToSender: replyToSender,
 					ptt:           ptt,
 				})
-				if err != nil {
-					return sendFileResult{}, err
-				}
-				return sendFileResult{id: msgID, meta: meta}, nil
 			})
 			if err != nil {
 				return err
 			}
-			msgID, meta := res.id, res.meta
+			warnSendStoreFailure(os.Stderr, res.id, res.storeWarning)
 
 			waitForPostSendRetryReceipts(ctx, postSendWait)
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{
+				return out.WriteJSON(os.Stdout, addStoreWarning(map[string]any{
 					"sent": true,
 					"to":   toJID.String(),
-					"id":   msgID,
-					"file": meta,
-				})
+					"id":   res.id,
+					"file": res.meta,
+				}, res.storeWarning))
 			}
-			fmt.Fprintf(os.Stdout, "Sent %s to %s (id %s)\n", meta["name"], toJID.String(), msgID)
+			fmt.Fprintf(os.Stdout, "Sent %s to %s (id %s)\n", res.meta["name"], toJID.String(), res.id)
 			return nil
 		},
 	}

--- a/cmd/wacli/send_file_store_test.go
+++ b/cmd/wacli/send_file_store_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openclaw/wacli/internal/app"
+	"github.com/openclaw/wacli/internal/store"
+	"go.mau.fi/whatsmeow"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/types"
+)
+
+// fakeSendFileWA stubs only the methods sendFile touches; any other call
+// panics through the embedded nil interface, catching accidental coupling.
+type fakeSendFileWA struct {
+	app.WAClient
+	sentID types.MessageID
+}
+
+func (f *fakeSendFileWA) Upload(context.Context, []byte, whatsmeow.MediaType) (whatsmeow.UploadResponse, error) {
+	return whatsmeow.UploadResponse{}, nil
+}
+
+func (f *fakeSendFileWA) SendProtoMessage(context.Context, types.JID, *waProto.Message) (types.MessageID, error) {
+	return f.sentID, nil
+}
+
+func (f *fakeSendFileWA) ResolveChatName(context.Context, types.JID, string) string {
+	return "Test Chat"
+}
+
+type fakeSendFileApp struct {
+	wa app.WAClient
+	db *store.DB
+}
+
+func (f *fakeSendFileApp) WA() app.WAClient { return f.wa }
+func (f *fakeSendFileApp) DB() *store.DB    { return f.db }
+
+func newSendFileFixture(t *testing.T) (*fakeSendFileApp, *store.DB, string) {
+	t.Helper()
+	db, err := store.Open(filepath.Join(t.TempDir(), "wacli.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	filePath := filepath.Join(t.TempDir(), "note.txt")
+	if err := os.WriteFile(filePath, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	a := &fakeSendFileApp{wa: &fakeSendFileWA{sentID: "MSG1"}, db: db}
+	return a, db, filePath
+}
+
+func TestSendFilePersistsHistory(t *testing.T) {
+	a, db, filePath := newSendFileFixture(t)
+	to := types.NewJID("15550000001", types.DefaultUserServer)
+
+	res, err := sendFile(context.Background(), a, to, filePath, sendFileOptions{caption: "hi"})
+	if err != nil {
+		t.Fatalf("sendFile: %v", err)
+	}
+	if res.id != "MSG1" || res.storeWarning != nil {
+		t.Fatalf("expected clean outcome, got %+v", res)
+	}
+	msg, err := db.GetMessage(to.String(), "MSG1")
+	if err != nil {
+		t.Fatalf("sent message not persisted: %v", err)
+	}
+	if !msg.FromMe || msg.Text != "hi" {
+		t.Fatalf("unexpected persisted message: %+v", msg)
+	}
+}
+
+// Regression for the silently-swallowed store failures: a delivered message
+// whose local persistence fails must keep the ID and surface a warning, not
+// return a hard error that invites callers to retry an already-sent message.
+func TestSendFileStoreFailureKeepsDeliveredID(t *testing.T) {
+	a, db, filePath := newSendFileFixture(t)
+	if err := db.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	to := types.NewJID("15550000001", types.DefaultUserServer)
+
+	res, err := sendFile(context.Background(), a, to, filePath, sendFileOptions{})
+	if err != nil {
+		t.Fatalf("store failure must not fail the send, got %v", err)
+	}
+	if res.id != "MSG1" {
+		t.Fatalf("delivered ID lost, got %+v", res)
+	}
+	if res.storeWarning == nil {
+		t.Fatal("expected store warning for failed history update")
+	}
+}
+
+func TestSendFileStatusStoreFailureKeepsDeliveredID(t *testing.T) {
+	a, db, filePath := newSendFileFixture(t)
+	if err := db.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	res, err := sendFile(context.Background(), a, types.StatusBroadcastJID, filePath, sendFileOptions{})
+	if err != nil {
+		t.Fatalf("store failure must not fail the send, got %v", err)
+	}
+	if res.id != "MSG1" || res.storeWarning == nil {
+		t.Fatalf("expected delivered ID with store warning, got %+v", res)
+	}
+}
+
+func TestSendFileStatusPersistsHistory(t *testing.T) {
+	a, db, filePath := newSendFileFixture(t)
+
+	res, err := sendFile(context.Background(), a, types.StatusBroadcastJID, filePath, sendFileOptions{caption: "st"})
+	if err != nil {
+		t.Fatalf("sendFile: %v", err)
+	}
+	if res.storeWarning != nil {
+		t.Fatalf("unexpected store warning: %v", res.storeWarning)
+	}
+	if _, err := db.GetStatusMessage("MSG1"); err != nil {
+		t.Fatalf("status message not persisted: %v", err)
+	}
+}

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -75,6 +75,7 @@ type sendDelegateResponse struct {
 	Selected       []string          `json:"selected,omitempty"`
 	SelectedOption *selectOption     `json:"selected_option,omitempty"`
 	File           map[string]string `json:"file,omitempty"`
+	StoreWarning   string            `json:"store_warning,omitempty"`
 }
 
 func sendDelegateSocketPath(storeDir string) string {
@@ -388,7 +389,7 @@ func executeDelegatedFile(ctx context.Context, a *app.App, req sendDelegateReque
 		return sendDelegateResponse{}, err
 	}
 	res, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (sendDelegateResponse, error) {
-		msgID, meta, err := sendFile(ctx, a, toJID, req.File, sendFileOptions{
+		outcome, err := sendFile(ctx, a, toJID, req.File, sendFileOptions{
 			filename:      req.Filename,
 			caption:       req.Caption,
 			mimeOverride:  req.MIME,
@@ -400,7 +401,11 @@ func executeDelegatedFile(ctx context.Context, a *app.App, req sendDelegateReque
 		if err != nil {
 			return sendDelegateResponse{}, err
 		}
-		return sendDelegateResponse{OK: true, Sent: true, To: toJID.String(), ID: msgID, File: meta}, nil
+		resp := sendDelegateResponse{OK: true, Sent: true, To: toJID.String(), ID: outcome.id, File: outcome.meta}
+		if outcome.storeWarning != nil {
+			resp.StoreWarning = outcome.storeWarning.Error()
+		}
+		return resp, nil
 	})
 	if err != nil {
 		return sendDelegateResponse{}, err
@@ -458,10 +463,16 @@ func executeDelegatedReact(ctx context.Context, a *app.App, req sendDelegateRequ
 }
 
 func writeDelegatedSendOutput(flags *rootFlags, kind string, resp sendDelegateResponse) error {
+	if resp.StoreWarning != "" {
+		fmt.Fprintf(os.Stderr, "warning: message delivered (id %s) but local history update failed: %s\n", resp.ID, resp.StoreWarning)
+	}
 	if flags.asJSON {
 		body := map[string]any{"sent": resp.Sent, "to": resp.To, "id": resp.ID}
 		if resp.File != nil {
 			body["file"] = resp.File
+		}
+		if resp.StoreWarning != "" {
+			body["store_warning"] = resp.StoreWarning
 		}
 		if kind == "react" {
 			body["target"] = resp.Target

--- a/cmd/wacli/send_status_cmd.go
+++ b/cmd/wacli/send_status_cmd.go
@@ -80,24 +80,25 @@ func newSendStatusCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if filePath != "" {
-				msgID, meta, err := sendFile(ctx, a, types.StatusBroadcastJID, filePath, sendFileOptions{
+				res, err := sendFile(ctx, a, types.StatusBroadcastJID, filePath, sendFileOptions{
 					caption:      message,
 					mimeOverride: mimeOverride,
 				})
 				if err != nil {
 					return err
 				}
+				warnSendStoreFailure(os.Stderr, res.id, res.storeWarning)
 				waitForPostSendRetryReceipts(ctx, postSendWait)
 				if flags.asJSON {
-					return out.WriteJSON(os.Stdout, map[string]any{
+					return out.WriteJSON(os.Stdout, addStoreWarning(map[string]any{
 						"sent":      true,
 						"to":        types.StatusBroadcastJID.String(),
-						"id":        msgID,
-						"media":     meta["media"],
-						"mime_type": meta["mime_type"],
-					})
+						"id":        res.id,
+						"media":     res.meta["media"],
+						"mime_type": res.meta["mime_type"],
+					}, res.storeWarning))
 				}
-				fmt.Fprintf(os.Stdout, "Sent status (id %s)\n", msgID)
+				fmt.Fprintf(os.Stdout, "Sent status (id %s)\n", res.id)
 				return nil
 			}
 
@@ -114,7 +115,7 @@ func newSendStatusCmd(flags *rootFlags) *cobra.Command {
 			if fontPtr != nil {
 				storedFont = *fontPtr
 			}
-			_ = a.DB().UpsertStatusMessage(store.UpsertStatusMessageParams{
+			storeErr := a.DB().UpsertStatusMessage(store.UpsertStatusMessageParams{
 				MsgID:           string(msgID),
 				Timestamp:       now,
 				FromMe:          true,
@@ -122,15 +123,16 @@ func newSendStatusCmd(flags *rootFlags) *cobra.Command {
 				BackgroundColor: backgroundColor,
 				Font:            storedFont,
 			})
+			warnSendStoreFailure(os.Stderr, string(msgID), storeErr)
 
 			waitForPostSendRetryReceipts(ctx, postSendWait)
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{
+				return out.WriteJSON(os.Stdout, addStoreWarning(map[string]any{
 					"sent": true,
 					"to":   chat.String(),
 					"id":   msgID,
-				})
+				}, storeErr))
 			}
 			fmt.Fprintf(os.Stdout, "Sent status (id %s)\n", msgID)
 			return nil

--- a/cmd/wacli/send_voice_cmd.go
+++ b/cmd/wacli/send_voice_cmd.go
@@ -76,35 +76,28 @@ func newSendVoiceCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			type sendVoiceResult struct {
-				id   string
-				meta map[string]string
-			}
-			res, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (sendVoiceResult, error) {
-				msgID, meta, err := sendFile(ctx, a, toJID, filePath, sendFileOptions{
+			res, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (sendFileOutcome, error) {
+				return sendFile(ctx, a, toJID, filePath, sendFileOptions{
 					mimeOverride:  mimeOverride,
 					replyTo:       replyTo,
 					replyToSender: replyToSender,
 					ptt:           true,
 				})
-				if err != nil {
-					return sendVoiceResult{}, err
-				}
-				return sendVoiceResult{id: msgID, meta: meta}, nil
 			})
 			if err != nil {
 				return err
 			}
+			warnSendStoreFailure(os.Stderr, res.id, res.storeWarning)
 
 			waitForPostSendRetryReceipts(ctx, postSendWait)
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{
+				return out.WriteJSON(os.Stdout, addStoreWarning(map[string]any{
 					"sent": true,
 					"to":   toJID.String(),
 					"id":   res.id,
 					"file": res.meta,
-				})
+				}, res.storeWarning))
 			}
 			fmt.Fprintf(os.Stdout, "Sent voice note to %s (id %s)\n", toJID.String(), res.id)
 			return nil

--- a/docs/send.md
+++ b/docs/send.md
@@ -47,6 +47,7 @@ wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 - Sent reactions are stored locally immediately, including reaction target and display text.
 - For group reactions, pass `--sender` for the original message sender.
 - Use `--post-send-wait 0` to disable the retry-receipt grace window for latency-sensitive scripts.
+- If `send file`, `send voice`, or `send status` delivers a message but recording it in local history fails (disk full, locked store), the command still succeeds with the delivered id and prints a warning to stderr; JSON output carries the failure in `store_warning`. Do not retry such a send — the recipient already has the message.
 
 ## Polls
 


### PR DESCRIPTION
## What

Takeover of #328 (thanks @SebTardif for the report and initial patch). After WhatsApp accepts a file, voice, or status send, the local history upserts (`UpsertChat` / `UpsertMessage` / `UpsertStatusMessage`) were silently discarded — a disk-full or locked SQLite store left local history diverged with no signal.

## Why not just return the error (the #328 approach)

All four `sendFile` boundaries — `send file`, `send voice`, `send status`, and IPC-delegated sends — drop the returned message id when they see an error. Turning a post-delivery store failure into a hard error therefore reports a *delivered* message as a total failure, and retrying automation would double-send it (the `merge-risk: message-delivery` concern from review).

## Design

`sendFile` now returns a `sendFileOutcome`; a post-delivery persistence failure rides in `storeWarning` next to the delivered id instead of replacing it. Every boundary keeps exit code 0 and the id, prints a stderr warning (`warning: message delivered (id X) but local history update failed: ...`), and adds `store_warning` to JSON/IPC output. The text-status persist path gets the same treatment. Store failures never trigger the send-retry path since the operation returns success.

## Reproduction / Tests

Regression tests force the real failure: a genuine SQLite store is closed mid-flight while a stub client "delivers" the message —

- `TestSendFileStoreFailureKeepsDeliveredID` / `TestSendFileStatusStoreFailureKeepsDeliveredID`: err is nil, id preserved, warning present (on main these failures are invisible).
- `TestSendFilePersistsHistory` / `TestSendFileStatusPersistsHistory`: healthy store persists and stays warning-free.

Full gate: `pnpm docs:site && pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`. Pre-land Codex autoreview clean ("patch is correct, 0.99").

Follow-up (separate PR): the same swallowed-upsert pattern exists in sticker, reaction, poll, and text send paths.

Closes #328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
