### PR TITLE
fix(send): extend store-warning contract to all remaining send surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Send: surface local history failures after a delivered file, voice, or status send as a `store_warning` (stderr warning plus JSON field) instead of silently diverging local history, while keeping the delivered message id so scripts do not retry an already-sent message. (#328 - thanks @SebTardif)
+- Send: extend the `store_warning` partial-success contract to every remaining send surface — text, sticker, reactions, polls, poll votes, button/list selections, and message forwarding — including sends delegated to a running `sync --follow` process.
 
 ## 0.15.1 - 2026-08-01
 

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -845,8 +846,11 @@ func newMessagesForwardCmd(flags *rootFlags) *cobra.Command {
 
 			now := time.Now().UTC()
 			chatName := a.WA().ResolveChatName(ctx, toJID, "")
-			_ = a.DB().UpsertChat(toJID.String(), chatKindFromJID(toJID), chatName, now)
-			_ = a.DB().UpsertMessage(store.UpsertMessageParams{
+			var storeErr error
+			if err := a.DB().UpsertChat(toJID.String(), chatKindFromJID(toJID), chatName, now); err != nil {
+				storeErr = fmt.Errorf("chat update: %w", err)
+			}
+			if err := a.DB().UpsertMessage(store.UpsertMessageParams{
 				ChatJID:         toJID.String(),
 				ChatName:        chatName,
 				MsgID:           string(sentID),
@@ -866,17 +870,20 @@ func newMessagesForwardCmd(flags *rootFlags) *cobra.Command {
 				FileLength:      payload.FileLength,
 				IsForwarded:     true,
 				ForwardingScore: payload.ForwardingScore,
-			})
+			}); err != nil {
+				storeErr = errors.Join(storeErr, fmt.Errorf("message update: %w", err))
+			}
+			warnSendStoreFailure(os.Stderr, string(sentID), storeErr)
 
 			waitForPostSendRetryReceipts(ctx, postSendWait)
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{
+				return out.WriteJSON(os.Stdout, addStoreWarning(map[string]any{
 					"forwarded": true,
 					"to":        toJID.String(),
 					"id":        sentID,
 					"source":    source.MsgID,
-				})
+				}, storeErr))
 			}
 			fmt.Fprintf(os.Stdout, "Forwarded message %s to %s (id %s)\n", source.MsgID, toJID.String(), sentID)
 			return nil

--- a/cmd/wacli/poll_cmd.go
+++ b/cmd/wacli/poll_cmd.go
@@ -126,17 +126,18 @@ func newPollVoteCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			now := time.Now().UTC()
-			persistOutboundVote(ctx, a, toJID, pollChatJID, msgID, string(sentID), cleaned, now)
+			storeErr := persistOutboundVote(ctx, a, toJID, pollChatJID, msgID, string(sentID), cleaned, now)
+			warnSendStoreFailure(os.Stderr, string(sentID), storeErr)
 			waitForPostSendRetryReceipts(ctx, postSendWait)
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{
+				return out.WriteJSON(os.Stdout, addStoreWarning(map[string]any{
 					"sent":     true,
 					"to":       toJID.String(),
 					"id":       string(sentID),
 					"target":   msgID,
 					"selected": cleaned,
-				})
+				}, storeErr))
 			}
 			fmt.Fprintf(os.Stdout, "Voted on %s in %s (id %s)\n", msgID, toJID.String(), sentID)
 			return nil
@@ -331,13 +332,16 @@ func pollChatJIDCandidates(ctx context.Context, a *app.App, jid types.JID) []str
 	return jidStrings(jids)
 }
 
-func persistOutboundVote(ctx context.Context, a *app.App, chat types.JID, chatJID, pollMsgID, voteMsgID string, options []string, now time.Time) {
+func persistOutboundVote(ctx context.Context, a *app.App, chat types.JID, chatJID, pollMsgID, voteMsgID string, options []string, now time.Time) error {
 	if strings.TrimSpace(chatJID) == "" {
 		chatJID = primaryPollChatJID(ctx, a, chat)
 	}
 	chatName := a.WA().ResolveChatName(ctx, chat, "")
-	_ = a.DB().UpsertChat(chatJID, chatKindFromJID(chat), chatName, now)
-	_ = a.DB().UpsertMessage(store.UpsertMessageParams{
+	var storeErr error
+	if err := a.DB().UpsertChat(chatJID, chatKindFromJID(chat), chatName, now); err != nil {
+		storeErr = fmt.Errorf("chat update: %w", err)
+	}
+	if err := a.DB().UpsertMessage(store.UpsertMessageParams{
 		ChatJID:    chatJID,
 		ChatName:   chatName,
 		MsgID:      voteMsgID,
@@ -345,19 +349,24 @@ func persistOutboundVote(ctx context.Context, a *app.App, chat types.JID, chatJI
 		Timestamp:  now,
 		FromMe:     true,
 		Text:       "Voted: " + strings.Join(options, ", "),
-	})
+	}); err != nil {
+		storeErr = errors.Join(storeErr, fmt.Errorf("message update: %w", err))
+	}
 	voter := a.WA().LinkedJID()
 	if voter == "" {
-		return
+		return storeErr
 	}
-	_ = a.DB().UpsertPollVote(store.PollVote{
+	if err := a.DB().UpsertPollVote(store.PollVote{
 		ChatJID:   chatJID,
 		PollMsgID: pollMsgID,
 		VoterJID:  voter,
 		VoteMsgID: voteMsgID,
 		Selected:  options,
 		VotedAt:   now,
-	})
+	}); err != nil {
+		storeErr = errors.Join(storeErr, fmt.Errorf("poll vote update: %w", err))
+	}
+	return storeErr
 }
 
 func executeDelegatedPollVote(ctx context.Context, a *app.App, req sendDelegateRequest) (sendDelegateResponse, error) {
@@ -395,16 +404,20 @@ func executeDelegatedPollVote(ctx context.Context, a *app.App, req sendDelegateR
 		return sendDelegateResponse{}, err
 	}
 	now := time.Now().UTC()
-	persistOutboundVote(ctx, a, toJID, pollChatJID, req.ID, string(sentID), cleaned, now)
+	storeErr := persistOutboundVote(ctx, a, toJID, pollChatJID, req.ID, string(sentID), cleaned, now)
 	waitForPostSendRetryReceipts(ctx, millisDuration(req.PostSendWaitMS, 0))
-	return sendDelegateResponse{
+	resp := sendDelegateResponse{
 		OK:       true,
 		Sent:     true,
 		To:       toJID.String(),
 		ID:       string(sentID),
 		Target:   req.ID,
 		Selected: cleaned,
-	}, nil
+	}
+	if storeErr != nil {
+		resp.StoreWarning = storeErr.Error()
+	}
+	return resp, nil
 }
 
 // ---- show -----------------------------------------------------------------

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -138,16 +138,17 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 
 			now := time.Now().UTC()
 			chat := toJID
-			persistOutboundText(ctx, a, chat, string(msgID), message, now)
+			storeErr := persistOutboundText(ctx, a, chat, string(msgID), message, now)
+			warnSendStoreFailure(os.Stderr, string(msgID), storeErr)
 
 			waitForPostSendRetryReceipts(ctx, postSendWait)
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{
+				return out.WriteJSON(os.Stdout, addStoreWarning(map[string]any{
 					"sent": true,
 					"to":   chat.String(),
 					"id":   msgID,
-				})
+				}, storeErr))
 			}
 			fmt.Fprintf(os.Stdout, "Sent to %s (id %s)\n", chat.String(), msgID)
 			return nil
@@ -168,8 +169,8 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 	return cmd
 }
 
-func persistOutboundText(ctx context.Context, a *app.App, chat types.JID, msgID, text string, now time.Time) {
-	persistOutboundTextWith(ctx, a.DB(), a.WA(), chat, msgID, text, now)
+func persistOutboundText(ctx context.Context, a *app.App, chat types.JID, msgID, text string, now time.Time) error {
+	return persistOutboundTextWith(ctx, a.DB(), a.WA(), chat, msgID, text, now)
 }
 
 type outboundTextResolver interface {
@@ -177,15 +178,15 @@ type outboundTextResolver interface {
 	ResolveLIDToPN(ctx context.Context, jid types.JID) types.JID
 }
 
-func persistOutboundTextWith(ctx context.Context, db *store.DB, resolver outboundTextResolver, chat types.JID, msgID, text string, now time.Time) {
+func persistOutboundTextWith(ctx context.Context, db *store.DB, resolver outboundTextResolver, chat types.JID, msgID, text string, now time.Time) error {
 	chat = resolver.ResolveLIDToPN(ctx, chat)
 	if chat.Server == types.DefaultUserServer {
 		chat = chat.ToNonAD()
 	}
 	chatName := resolver.ResolveChatName(ctx, chat, "")
+	var storeErr error
 	if err := db.UpsertChat(chat.String(), chatKindFromJID(chat), chatName, now); err != nil {
-		warnOutboundPersist("chat", msgID, err)
-		return
+		storeErr = fmt.Errorf("chat update: %w", err)
 	}
 	if err := db.UpsertMessage(store.UpsertMessageParams{
 		ChatJID:    chat.String(),
@@ -197,15 +198,9 @@ func persistOutboundTextWith(ctx context.Context, db *store.DB, resolver outboun
 		FromMe:     true,
 		Text:       text,
 	}); err != nil {
-		warnOutboundPersist("message", msgID, err)
+		storeErr = errors.Join(storeErr, fmt.Errorf("message update: %w", err))
 	}
-}
-
-func warnOutboundPersist(kind, msgID string, err error) {
-	if err == nil {
-		return
-	}
-	fmt.Fprintf(os.Stderr, "warning: sent message %s was accepted by WhatsApp, but local outbound %s persistence failed: %v\n", msgID, kind, err)
+	return storeErr
 }
 
 type sendTextApp interface {

--- a/cmd/wacli/send_file.go
+++ b/cmd/wacli/send_file.go
@@ -241,7 +241,16 @@ func warnSendStoreFailure(w io.Writer, id string, storeWarning error) {
 	if storeWarning == nil {
 		return
 	}
-	fmt.Fprintf(w, "warning: message delivered (id %s) but local history update failed: %v\n", id, storeWarning)
+	warnSendStoreFailureMsg(w, id, storeWarning.Error())
+}
+
+// warnSendStoreFailureMsg is the string form for callers that receive the
+// warning across the IPC boundary.
+func warnSendStoreFailureMsg(w io.Writer, id, msg string) {
+	if msg == "" {
+		return
+	}
+	fmt.Fprintf(w, "warning: message delivered (id %s) but local history update failed: %s\n", id, msg)
 }
 
 // addStoreWarning annotates a JSON success payload with the partial-success

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -370,9 +370,13 @@ func executeDelegatedText(ctx context.Context, a *app.App, req sendDelegateReque
 		return sendDelegateResponse{}, err
 	}
 	now := time.Now().UTC()
-	persistOutboundText(ctx, a, toJID, string(msgID), req.Message, now)
+	storeErr := persistOutboundText(ctx, a, toJID, string(msgID), req.Message, now)
 	waitForPostSendRetryReceipts(ctx, millisDuration(req.PostSendWaitMS, 0))
-	return sendDelegateResponse{OK: true, Sent: true, To: toJID.String(), ID: string(msgID)}, nil
+	resp := sendDelegateResponse{OK: true, Sent: true, To: toJID.String(), ID: string(msgID)}
+	if storeErr != nil {
+		resp.StoreWarning = storeErr.Error()
+	}
+	return resp, nil
 }
 
 func executeDelegatedFile(ctx context.Context, a *app.App, req sendDelegateRequest) (sendDelegateResponse, error) {
@@ -424,14 +428,18 @@ func executeDelegatedSticker(ctx context.Context, a *app.App, req sendDelegateRe
 		return sendDelegateResponse{}, err
 	}
 	res, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (sendDelegateResponse, error) {
-		msgID, meta, err := sendSticker(ctx, a, toJID, req.File, sendStickerOptions{
+		outcome, err := sendSticker(ctx, a, toJID, req.File, sendStickerOptions{
 			replyTo:       req.ReplyTo,
 			replyToSender: req.ReplyToSender,
 		})
 		if err != nil {
 			return sendDelegateResponse{}, err
 		}
-		return sendDelegateResponse{OK: true, Sent: true, To: toJID.String(), ID: msgID, File: meta}, nil
+		resp := sendDelegateResponse{OK: true, Sent: true, To: toJID.String(), ID: outcome.id, File: outcome.meta}
+		if outcome.storeWarning != nil {
+			resp.StoreWarning = outcome.storeWarning.Error()
+		}
+		return resp, nil
 	})
 	if err != nil {
 		return sendDelegateResponse{}, err
@@ -457,15 +465,17 @@ func executeDelegatedReact(ctx context.Context, a *app.App, req sendDelegateRequ
 	}
 	now := time.Now().UTC()
 	chatName := a.WA().ResolveChatName(ctx, chat, "")
-	upsertSentReaction(a.DB(), chat, chatName, sentID, req.ID, req.Reaction, now)
+	storeErr := upsertSentReaction(a.DB(), chat, chatName, sentID, req.ID, req.Reaction, now)
 	waitForPostSendRetryReceipts(ctx, millisDuration(req.PostSendWaitMS, 0))
-	return sendDelegateResponse{OK: true, Sent: true, To: chat.String(), ID: string(sentID), Target: req.ID, Reaction: req.Reaction}, nil
+	resp := sendDelegateResponse{OK: true, Sent: true, To: chat.String(), ID: string(sentID), Target: req.ID, Reaction: req.Reaction}
+	if storeErr != nil {
+		resp.StoreWarning = storeErr.Error()
+	}
+	return resp, nil
 }
 
 func writeDelegatedSendOutput(flags *rootFlags, kind string, resp sendDelegateResponse) error {
-	if resp.StoreWarning != "" {
-		fmt.Fprintf(os.Stderr, "warning: message delivered (id %s) but local history update failed: %s\n", resp.ID, resp.StoreWarning)
-	}
+	warnSendStoreFailureMsg(os.Stderr, resp.ID, resp.StoreWarning)
 	if flags.asJSON {
 		body := map[string]any{"sent": resp.Sent, "to": resp.To, "id": resp.ID}
 		if resp.File != nil {

--- a/cmd/wacli/send_poll_cmd.go
+++ b/cmd/wacli/send_poll_cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -100,17 +101,18 @@ func newSendPollCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			persistOutboundPoll(ctx, a, toJID, string(msgID), question, cleaned, uint32(multi), time.Now().UTC())
+			storeErr := persistOutboundPoll(ctx, a, toJID, string(msgID), question, cleaned, uint32(multi), time.Now().UTC())
+			warnSendStoreFailure(os.Stderr, string(msgID), storeErr)
 			waitForPostSendRetryReceipts(ctx, postSendWait)
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{
+				return out.WriteJSON(os.Stdout, addStoreWarning(map[string]any{
 					"sent":     true,
 					"to":       toJID.String(),
 					"id":       msgID,
 					"question": question,
 					"options":  cleaned,
-				})
+				}, storeErr))
 			}
 			fmt.Fprintf(os.Stdout, "Sent poll to %s (id %s)\n", toJID.String(), msgID)
 			return nil
@@ -166,11 +168,14 @@ func sendPollMessage(ctx context.Context, sender pollSender, to types.JID, quest
 	return sender.SendPoll(ctx, to, question, options, multi, ephemeral)
 }
 
-func persistOutboundPoll(ctx context.Context, a *app.App, chat types.JID, msgID, question string, options []string, selectable uint32, now time.Time) {
+func persistOutboundPoll(ctx context.Context, a *app.App, chat types.JID, msgID, question string, options []string, selectable uint32, now time.Time) error {
 	chatJID := primaryPollChatJID(ctx, a, chat)
 	chatName := a.WA().ResolveChatName(ctx, chat, "")
-	_ = a.DB().UpsertChat(chatJID, chatKindFromJID(chat), chatName, now)
-	_ = a.DB().UpsertMessage(store.UpsertMessageParams{
+	var storeErr error
+	if err := a.DB().UpsertChat(chatJID, chatKindFromJID(chat), chatName, now); err != nil {
+		storeErr = fmt.Errorf("chat update: %w", err)
+	}
+	if err := a.DB().UpsertMessage(store.UpsertMessageParams{
 		ChatJID:    chatJID,
 		ChatName:   chatName,
 		MsgID:      msgID,
@@ -178,8 +183,10 @@ func persistOutboundPoll(ctx context.Context, a *app.App, chat types.JID, msgID,
 		Timestamp:  now,
 		FromMe:     true,
 		Text:       "Poll: " + question,
-	})
-	_ = a.DB().UpsertPoll(store.Poll{
+	}); err != nil {
+		storeErr = errors.Join(storeErr, fmt.Errorf("message update: %w", err))
+	}
+	if err := a.DB().UpsertPoll(store.Poll{
 		ChatJID:         chatJID,
 		MsgID:           msgID,
 		SenderJID:       outboundPollSenderJID(ctx, a.WA(), chat),
@@ -187,7 +194,10 @@ func persistOutboundPoll(ctx context.Context, a *app.App, chat types.JID, msgID,
 		Options:         options,
 		SelectableCount: selectable,
 		CreatedAt:       now,
-	})
+	}); err != nil {
+		storeErr = errors.Join(storeErr, fmt.Errorf("poll update: %w", err))
+	}
+	return storeErr
 }
 
 func outboundPollSenderJID(ctx context.Context, wa outboundPollIdentityResolver, chat types.JID) string {
@@ -232,14 +242,18 @@ func executeDelegatedPoll(ctx context.Context, a *app.App, req sendDelegateReque
 	if err != nil {
 		return sendDelegateResponse{}, err
 	}
-	persistOutboundPoll(ctx, a, toJID, string(msgID), req.Question, cleaned, uint32(req.Selectable), time.Now().UTC())
+	storeErr := persistOutboundPoll(ctx, a, toJID, string(msgID), req.Question, cleaned, uint32(req.Selectable), time.Now().UTC())
 	waitForPostSendRetryReceipts(ctx, millisDuration(req.PostSendWaitMS, 0))
-	return sendDelegateResponse{
+	resp := sendDelegateResponse{
 		OK:       true,
 		Sent:     true,
 		To:       toJID.String(),
 		ID:       string(msgID),
 		Question: req.Question,
 		Options:  cleaned,
-	}, nil
+	}
+	if storeErr != nil {
+		resp.StoreWarning = storeErr.Error()
+	}
+	return resp, nil
 }

--- a/cmd/wacli/send_react_cmd.go
+++ b/cmd/wacli/send_react_cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -79,18 +80,19 @@ func newSendReactCmd(flags *rootFlags) *cobra.Command {
 
 			now := time.Now().UTC()
 			chatName := a.WA().ResolveChatName(ctx, chat, "")
-			upsertSentReaction(a.DB(), chat, chatName, sentID, msgID, emoji, now)
+			storeErr := upsertSentReaction(a.DB(), chat, chatName, sentID, msgID, emoji, now)
+			warnSendStoreFailure(os.Stderr, string(sentID), storeErr)
 
 			waitForPostSendRetryReceipts(ctx, postSendWait)
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{
+				return out.WriteJSON(os.Stdout, addStoreWarning(map[string]any{
 					"sent":     true,
 					"to":       chat.String(),
 					"id":       sentID,
 					"target":   msgID,
 					"reaction": emoji,
-				})
+				}, storeErr))
 			}
 			if emoji == "" {
 				fmt.Fprintf(os.Stdout, "Removed reaction from %s (id %s)\n", msgID, sentID)
@@ -127,12 +129,15 @@ func reactionTarget(to, sender string) (types.JID, types.JID, error) {
 	return chat, senderJID, nil
 }
 
-func upsertSentReaction(db *store.DB, chat types.JID, chatName string, sentID types.MessageID, targetID, emoji string, now time.Time) {
+func upsertSentReaction(db *store.DB, chat types.JID, chatName string, sentID types.MessageID, targetID, emoji string, now time.Time) error {
 	if db == nil || chat.IsEmpty() || sentID == "" {
-		return
+		return nil
 	}
-	_ = db.UpsertChat(chat.String(), chatKindFromJID(chat), chatName, now)
-	_ = db.UpsertMessage(store.UpsertMessageParams{
+	var storeErr error
+	if err := db.UpsertChat(chat.String(), chatKindFromJID(chat), chatName, now); err != nil {
+		storeErr = fmt.Errorf("chat update: %w", err)
+	}
+	if err := db.UpsertMessage(store.UpsertMessageParams{
 		ChatJID:       chat.String(),
 		ChatName:      chatName,
 		MsgID:         string(sentID),
@@ -142,7 +147,10 @@ func upsertSentReaction(db *store.DB, chat types.JID, chatName string, sentID ty
 		DisplayText:   sentReactionDisplayText(db, chat.String(), targetID, emoji),
 		ReactionToID:  targetID,
 		ReactionEmoji: emoji,
-	})
+	}); err != nil {
+		storeErr = errors.Join(storeErr, fmt.Errorf("message update: %w", err))
+	}
+	return storeErr
 }
 
 func sentReactionDisplayText(db *store.DB, chatJID, targetID, emoji string) string {

--- a/cmd/wacli/send_select_cmd.go
+++ b/cmd/wacli/send_select_cmd.go
@@ -51,11 +51,12 @@ type selectOption struct {
 }
 
 type selectResult struct {
-	Sent     bool         `json:"sent"`
-	To       string       `json:"to"`
-	ID       string       `json:"id"`
-	Target   string       `json:"target"`
-	Selected selectOption `json:"selected"`
+	Sent         bool         `json:"sent"`
+	To           string       `json:"to"`
+	ID           string       `json:"id"`
+	Target       string       `json:"target"`
+	Selected     selectOption `json:"selected"`
+	StoreWarning string       `json:"store_warning,omitempty"`
 }
 
 func newSendSelectCmd(flags *rootFlags) *cobra.Command {
@@ -135,6 +136,7 @@ func newSendSelectCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			warnSendStoreFailureMsg(os.Stderr, res.ID, res.StoreWarning)
 			if flags.asJSON {
 				return out.WriteJSON(os.Stdout, res)
 			}
@@ -203,15 +205,19 @@ func sendButtonListSelection(ctx context.Context, a *app.App, chat types.JID, ta
 		return selectResult{}, err
 	}
 	now := time.Now().UTC()
-	persistOutboundSelection(ctx, a, chat, chatJID, string(sentID), selected, now)
+	storeErr := persistOutboundSelection(ctx, a, chat, chatJID, string(sentID), selected, now)
 	waitForPostSendRetryReceipts(ctx, req.PostSendWait)
-	return selectResult{
+	res := selectResult{
 		Sent:     true,
 		To:       chat.String(),
 		ID:       string(sentID),
 		Target:   targetID,
 		Selected: selected,
-	}, nil
+	}
+	if storeErr != nil {
+		res.StoreWarning = storeErr.Error()
+	}
+	return res, nil
 }
 
 func sendSelectProto(ctx context.Context, sender selectSender, to types.JID, msg *waProto.Message) (types.MessageID, error) {
@@ -446,14 +452,14 @@ func resolveSelectSender(chat types.JID, target store.Message, override string) 
 	return types.JID{}, nil
 }
 
-func persistOutboundSelection(ctx context.Context, a *app.App, chat types.JID, chatJID, msgID string, selected selectOption, now time.Time) {
+func persistOutboundSelection(ctx context.Context, a *app.App, chat types.JID, chatJID, msgID string, selected selectOption, now time.Time) error {
 	if strings.TrimSpace(chatJID) == "" {
 		chatJID = primaryPollChatJID(ctx, a, chat)
 	}
 	chatName := a.WA().ResolveChatName(ctx, chat, "")
+	var storeErr error
 	if err := a.DB().UpsertChat(chatJID, chatKindFromJID(chat), chatName, now); err != nil {
-		warnOutboundPersist("chat", msgID, err)
-		return
+		storeErr = fmt.Errorf("chat update: %w", err)
 	}
 	if err := a.DB().UpsertMessage(store.UpsertMessageParams{
 		ChatJID:    chatJID,
@@ -464,8 +470,9 @@ func persistOutboundSelection(ctx context.Context, a *app.App, chat types.JID, c
 		FromMe:     true,
 		Text:       "Selected: " + selected.DisplayText,
 	}); err != nil {
-		warnOutboundPersist("message", msgID, err)
+		storeErr = errors.Join(storeErr, fmt.Errorf("message update: %w", err))
 	}
+	return storeErr
 }
 
 func executeDelegatedButtonListSelect(ctx context.Context, a *app.App, req sendDelegateRequest) (sendDelegateResponse, error) {
@@ -500,5 +507,6 @@ func executeDelegatedButtonListSelect(ctx context.Context, a *app.App, req sendD
 		ID:             res.ID,
 		Target:         res.Target,
 		SelectedOption: &res.Selected,
+		StoreWarning:   res.StoreWarning,
 	}, nil
 }

--- a/cmd/wacli/send_sticker.go
+++ b/cmd/wacli/send_sticker.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -39,41 +40,44 @@ type webPStickerMetadata struct {
 func sendSticker(ctx context.Context, a interface {
 	WA() app.WAClient
 	DB() *store.DB
-}, to types.JID, filePath string, opts sendStickerOptions) (string, map[string]string, error) {
+}, to types.JID, filePath string, opts sendStickerOptions) (sendFileOutcome, error) {
 	data, err := readSendFileData(filePath)
 	if err != nil {
-		return "", nil, err
+		return sendFileOutcome{}, err
 	}
 	meta, err := validateWebPSticker(data)
 	if err != nil {
-		return "", nil, err
+		return sendFileOutcome{}, err
 	}
 
 	uploadType, err := wa.MediaTypeFromString("sticker")
 	if err != nil {
-		return "", nil, err
+		return sendFileOutcome{}, err
 	}
 	up, err := a.WA().Upload(ctx, data, uploadType)
 	if err != nil {
-		return "", nil, err
+		return sendFileOutcome{}, err
 	}
 
 	replyContext, err := buildReplyContextInfo(a.DB(), to, opts.replyTo, opts.replyToSender)
 	if err != nil {
-		return "", nil, err
+		return sendFileOutcome{}, err
 	}
 	msg := newStickerMessage(up, replyContext, meta)
 
 	id, err := a.WA().SendProtoMessage(ctx, to, msg)
 	if err != nil {
-		return "", nil, err
+		return sendFileOutcome{}, err
 	}
 
 	now := time.Now().UTC()
 	name := filepath.Base(filePath)
 	chatName := a.WA().ResolveChatName(ctx, to, "")
-	_ = a.DB().UpsertChat(to.String(), chatKindFromJID(to), chatName, now)
-	_ = a.DB().UpsertMessage(store.UpsertMessageParams{
+	var storeErr error
+	if err := a.DB().UpsertChat(to.String(), chatKindFromJID(to), chatName, now); err != nil {
+		storeErr = fmt.Errorf("chat update: %w", err)
+	}
+	if err := a.DB().UpsertMessage(store.UpsertMessageParams{
 		ChatJID:       to.String(),
 		ChatName:      chatName,
 		MsgID:         id,
@@ -89,12 +93,18 @@ func sendSticker(ctx context.Context, a interface {
 		FileSHA256:    up.FileSHA256,
 		FileEncSHA256: up.FileEncSHA256,
 		FileLength:    up.FileLength,
-	})
+	}); err != nil {
+		storeErr = errors.Join(storeErr, fmt.Errorf("message update: %w", err))
+	}
 
-	return id, map[string]string{
-		"name":      name,
-		"mime_type": sendStickerMIME,
-		"media":     "sticker",
+	return sendFileOutcome{
+		id: id,
+		meta: map[string]string{
+			"name":      name,
+			"mime_type": sendStickerMIME,
+			"media":     "sticker",
+		},
+		storeWarning: storeErr,
 	}, nil
 }
 

--- a/cmd/wacli/send_sticker_cmd.go
+++ b/cmd/wacli/send_sticker_cmd.go
@@ -74,33 +74,26 @@ func newSendStickerCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			type sendStickerResult struct {
-				id   string
-				meta map[string]string
-			}
-			res, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (sendStickerResult, error) {
-				msgID, meta, err := sendSticker(ctx, a, toJID, filePath, sendStickerOptions{
+			res, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (sendFileOutcome, error) {
+				return sendSticker(ctx, a, toJID, filePath, sendStickerOptions{
 					replyTo:       replyTo,
 					replyToSender: replyToSender,
 				})
-				if err != nil {
-					return sendStickerResult{}, err
-				}
-				return sendStickerResult{id: msgID, meta: meta}, nil
 			})
 			if err != nil {
 				return err
 			}
+			warnSendStoreFailure(os.Stderr, res.id, res.storeWarning)
 
 			waitForPostSendRetryReceipts(ctx, postSendWait)
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]any{
+				return out.WriteJSON(os.Stdout, addStoreWarning(map[string]any{
 					"sent": true,
 					"to":   toJID.String(),
 					"id":   res.id,
 					"file": res.meta,
-				})
+				}, res.storeWarning))
 			}
 			fmt.Fprintf(os.Stdout, "Sent sticker to %s (id %s)\n", toJID.String(), res.id)
 			return nil

--- a/cmd/wacli/send_sticker_test.go
+++ b/cmd/wacli/send_sticker_test.go
@@ -88,7 +88,7 @@ func TestSendStickerRejectsNonWebPBeforeUpload(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	_, _, err := sendSticker(context.Background(), nil, types.JID{}, path, sendStickerOptions{})
+	_, err := sendSticker(context.Background(), nil, types.JID{}, path, sendStickerOptions{})
 	if err == nil || !strings.Contains(err.Error(), "stickers must be valid WebP") {
 		t.Fatalf("expected WebP validation error, got %v", err)
 	}

--- a/cmd/wacli/send_store_warning_test.go
+++ b/cmd/wacli/send_store_warning_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+// minimalStickerWebP builds the smallest VP8L container that passes
+// validateWebPSticker: a 512x512 static lossless header with no pixel data.
+func minimalStickerWebP(t *testing.T) string {
+	t.Helper()
+	chunk := []byte{0x2f, 0, 0, 0, 0}
+	// 14-bit width-1 and height-1 packed little-endian: 511 | 511<<14.
+	binary.LittleEndian.PutUint32(chunk[1:5], 511|511<<14)
+	payload := append([]byte("WEBPVP8L"), 5, 0, 0, 0)
+	payload = append(payload, chunk...)
+	payload = append(payload, 0) // odd chunk size padding
+	data := append([]byte("RIFF"), 0, 0, 0, 0)
+	binary.LittleEndian.PutUint32(data[4:8], uint32(len(payload)))
+	data = append(data, payload...)
+
+	path := filepath.Join(t.TempDir(), "sticker.webp")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write sticker: %v", err)
+	}
+	return path
+}
+
+func TestSendStickerPersistsHistory(t *testing.T) {
+	a, db, _ := newSendFileFixture(t)
+	to := types.NewJID("15550000001", types.DefaultUserServer)
+
+	res, err := sendSticker(context.Background(), a, to, minimalStickerWebP(t), sendStickerOptions{})
+	if err != nil {
+		t.Fatalf("sendSticker: %v", err)
+	}
+	if res.id != "MSG1" || res.storeWarning != nil {
+		t.Fatalf("expected clean outcome, got %+v", res)
+	}
+	msg, err := db.GetMessage(to.String(), "MSG1")
+	if err != nil {
+		t.Fatalf("sent sticker not persisted: %v", err)
+	}
+	if msg.MediaType != "sticker" {
+		t.Fatalf("unexpected persisted message: %+v", msg)
+	}
+}
+
+func TestSendStickerStoreFailureKeepsDeliveredID(t *testing.T) {
+	a, db, _ := newSendFileFixture(t)
+	path := minimalStickerWebP(t)
+	if err := db.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	to := types.NewJID("15550000001", types.DefaultUserServer)
+
+	res, err := sendSticker(context.Background(), a, to, path, sendStickerOptions{})
+	if err != nil {
+		t.Fatalf("store failure must not fail the send, got %v", err)
+	}
+	if res.id != "MSG1" || res.storeWarning == nil {
+		t.Fatalf("expected delivered ID with store warning, got %+v", res)
+	}
+}
+
+func TestUpsertSentReactionSurfacesStoreFailure(t *testing.T) {
+	_, db, _ := newSendFileFixture(t)
+	chat := types.NewJID("15550000001", types.DefaultUserServer)
+	now := time.Now().UTC()
+
+	if err := upsertSentReaction(db, chat, "Chat", "R1", "T1", "👍", now); err != nil {
+		t.Fatalf("healthy store: %v", err)
+	}
+	if _, err := db.GetMessage(chat.String(), "R1"); err != nil {
+		t.Fatalf("sent reaction not persisted: %v", err)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	if err := upsertSentReaction(db, chat, "Chat", "R2", "T1", "👍", now); err == nil {
+		t.Fatal("expected store error after close")
+	}
+}
+
+type fakeTextResolver struct{}
+
+func (fakeTextResolver) ResolveChatName(context.Context, types.JID, string) string { return "Chat" }
+func (fakeTextResolver) ResolveLIDToPN(_ context.Context, jid types.JID) types.JID { return jid }
+
+func TestPersistOutboundTextSurfacesStoreFailure(t *testing.T) {
+	_, db, _ := newSendFileFixture(t)
+	chat := types.NewJID("15550000001", types.DefaultUserServer)
+	now := time.Now().UTC()
+
+	if err := persistOutboundTextWith(context.Background(), db, fakeTextResolver{}, chat, "TX1", "hello", now); err != nil {
+		t.Fatalf("healthy store: %v", err)
+	}
+	if _, err := db.GetMessage(chat.String(), "TX1"); err != nil {
+		t.Fatalf("sent text not persisted: %v", err)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	if err := persistOutboundTextWith(context.Background(), db, fakeTextResolver{}, chat, "TX2", "hello", now); err == nil {
+		t.Fatal("expected store error after close")
+	}
+}

--- a/docs/send.md
+++ b/docs/send.md
@@ -47,7 +47,7 @@ wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 - Sent reactions are stored locally immediately, including reaction target and display text.
 - For group reactions, pass `--sender` for the original message sender.
 - Use `--post-send-wait 0` to disable the retry-receipt grace window for latency-sensitive scripts.
-- If `send file`, `send voice`, or `send status` delivers a message but recording it in local history fails (disk full, locked store), the command still succeeds with the delivered id and prints a warning to stderr; JSON output carries the failure in `store_warning`. Do not retry such a send — the recipient already has the message.
+- If any send command (text, file, voice, sticker, status, react, poll, poll vote, select, or message forward) delivers a message but recording it in local history fails (disk full, locked store), the command still succeeds with the delivered id and prints a warning to stderr; JSON output carries the failure in `store_warning`, including for sends delegated to a running `sync --follow` process. Do not retry such a send — the recipient already has the message.
 
 ## Polls
 


### PR DESCRIPTION
## What

Completes the partial-success contract started in #333: every remaining send surface now surfaces post-delivery local-history failures instead of silently discarding them. Covered: `send text`, `send sticker`, `send react`, `send poll`, `poll vote`, `send select`, `messages forward` — each via CLI and, where applicable, the IPC path delegated to a running `sync --follow` process.

## Why

These paths discarded `UpsertChat` / `UpsertMessage` / `UpsertPoll` / `UpsertPollVote` errors with blank identifiers (text and select stderr-warned but exposed nothing in JSON). A disk-full or locked store left local history quietly diverged. Per the #333 design, a hard error would be worse — callers would drop the delivered ID and automation would retry an already-delivered message — so failures ride next to the delivered ID as warnings.

## Design

- Persist helpers (`persistOutboundText(With)`, `upsertSentReaction`, `persistOutboundPoll`, `persistOutboundVote`, `persistOutboundSelection`) return joined errors instead of swallowing them; `sendSticker` returns a `sendFileOutcome` like `sendFile`.
- Every boundary keeps exit code 0 + the delivered id, prints the shared stderr warning, and adds `store_warning` to JSON output; delegated sends carry it through `sendDelegateResponse.StoreWarning`, surfaced by the single client-side output funnel.
- The legacy `warnOutboundPersist` path is folded into the shared `warnSendStoreFailure(Msg)` helpers, so all send commands phrase partial success identically.
- Deliberately excluded: `internal/app` sync/bootstrap best-effort upserts and group-metadata cache refreshes — no delivered message is at stake there.

## Tests

Same reproduction style as #333 (real SQLite store closed mid-flight, stub client delivering):

- `TestSendStickerPersistsHistory` / `TestSendStickerStoreFailureKeepsDeliveredID` (end-to-end through `sendSticker`, using a minimal valid 512x512 VP8L WebP)
- `TestUpsertSentReactionSurfacesStoreFailure`, `TestPersistOutboundTextSurfacesStoreFailure` (healthy-store persistence proven via `GetMessage`, closed-store failure surfaced)

Full gate: `pnpm docs:site && pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`. Pre-land Codex autoreview clean ("patch is correct, 0.98").

After this, `grep '_ = .*Upsert' cmd/wacli` is clean of send-path sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
