### PR TITLE
chore: open 0.15.3 unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.15.3 - Unreleased
+
 ## 0.15.2 - 2026-08-02
 
 ### Added


### PR DESCRIPTION
## Summary

- Open the 0.15.3 Unreleased section after the verified 0.15.2 publication.

## Verification

- Autoreview clean.
- Homebrew install, version, architecture, signature, and notarization proof complete.
