### PR TITLE
fix(media): add 5m overall timeout on direct media HTTP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.15.3 - Unreleased
 
+### Fixed
+
+- Media: give direct downloads a 5-minute overall HTTP client timeout while keeping phase bounds (TLS/headers) for fast stall detection. Thanks @SebTardif.
+
 ## 0.15.2 - 2026-08-02
 
 ### Added

--- a/internal/wa/media.go
+++ b/internal/wa/media.go
@@ -27,10 +27,17 @@ var directMediaBaseURL = "https://mmg.whatsapp.net"
 
 var directMediaHTTPClient = newDirectMediaHTTPClient()
 
+// directMediaHTTPClientTimeout is a safety bound on the full request including body.
+// Phase timeouts on the transport still fail stalled handshakes/headers quickly;
+// this ceiling prevents a forever-slow body from hanging the process when the
+// caller context has no deadline.
+const directMediaHTTPClientTimeout = 5 * time.Minute
+
 func newDirectMediaHTTPClient() *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.ResponseHeaderTimeout = 10 * time.Second
 	return &http.Client{
+		Timeout:   directMediaHTTPClientTimeout,
 		Transport: transport,
 	}
 }

--- a/internal/wa/media_timeout_test.go
+++ b/internal/wa/media_timeout_test.go
@@ -16,10 +16,13 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
-func TestNewDirectMediaHTTPClientBoundsPhasesWithoutTotalBodyTimeout(t *testing.T) {
+func TestNewDirectMediaHTTPClientBoundsPhasesWithGenerousBodyTimeout(t *testing.T) {
 	client := newDirectMediaHTTPClient()
-	if client.Timeout != 0 {
-		t.Fatalf("direct media HTTP client timeout = %s, want zero to preserve caller/body budget", client.Timeout)
+	if client.Timeout != directMediaHTTPClientTimeout {
+		t.Fatalf("direct media HTTP client timeout = %s, want %s safety ceiling", client.Timeout, directMediaHTTPClientTimeout)
+	}
+	if client.Timeout < 2*time.Minute {
+		t.Fatalf("direct media HTTP client timeout = %s, want at least 2m so large media bodies can finish", client.Timeout)
 	}
 	transport, ok := client.Transport.(*http.Transport)
 	if !ok {
@@ -46,7 +49,7 @@ func TestNewDirectMediaHTTPClientBoundsPhasesWithoutTotalBodyTimeout(t *testing.
 	if transport.MaxIdleConns <= 0 {
 		t.Fatalf("max idle connections = %d, want positive limit", transport.MaxIdleConns)
 	}
-	t.Logf("direct media behavior: client.Timeout=%s, so valid response bodies keep the caller context budget", client.Timeout)
+	t.Logf("direct media behavior: client.Timeout=%s safety ceiling with phase bounds for headers/handshake", client.Timeout)
 	t.Logf("direct media behavior: default transport semantics preserved: ForceAttemptHTTP2=%t DialContextPresent=%t MaxIdleConnsPerHost=%d", transport.ForceAttemptHTTP2, transport.DialContext != nil, transport.MaxIdleConnsPerHost)
 	t.Logf("direct media behavior: phase bounds active: TLSHandshakeTimeout=%s ResponseHeaderTimeout=%s ExpectContinueTimeout=%s IdleConnTimeout=%s MaxIdleConns=%d", transport.TLSHandshakeTimeout, transport.ResponseHeaderTimeout, transport.ExpectContinueTimeout, transport.IdleConnTimeout, transport.MaxIdleConns)
 }


### PR DESCRIPTION
## What Problem This Solves

Direct media downloads use a dedicated HTTP client with phase timeouts (TLS/headers) but `Client.Timeout == 0`, so a server that sends headers then dribbles a body forever can hang the process when the caller context has no deadline.

## Evidence

- #271 intentionally avoided a tight body timeout so large media can finish; this keeps that spirit with a **5 minute** overall ceiling (`directMediaHTTPClientTimeout`).
- Phase bounds unchanged: `ResponseHeaderTimeout` still fails pre-header stalls fast.
- Callers with a deadline on `context` still cancel early; the client Timeout is a safety ceiling.

## Real behavior proof

**Environment:** Go 1.26.5, macOS arm64; branch `fix/media-client-overall-timeout` @ dee1ef6

**Setup:** none (module cache warm)

**Command:**
```bash
# GREEN (with fix)
go test ./internal/wa/ -count=1 -run 'TestNewDirectMediaHTTPClientBoundsPhases|TestDownloadDirect' -v

# RED (Timeout line removed from newDirectMediaHTTPClient)
go test ./internal/wa/ -count=1 -run 'TestNewDirectMediaHTTPClientBoundsPhases' -v
```

**Output:**
```
# GREEN
=== RUN   TestNewDirectMediaHTTPClientBoundsPhasesWithGenerousBodyTimeout
    media_timeout_test.go:52: direct media behavior: client.Timeout=5m0s safety ceiling with phase bounds for headers/handshake
    media_timeout_test.go:54: direct media behavior: phase bounds active: TLSHandshakeTimeout=10s ResponseHeaderTimeout=10s ...
--- PASS: TestNewDirectMediaHTTPClientBoundsPhasesWithGenerousBodyTimeout (0.00s)
=== RUN   TestDownloadDirectBytesFailsFastWhenServerStallsBeforeHeaders
    media_timeout_test.go:121: pre-header stall failed in 51.793333ms with error "net/http: timeout awaiting response headers"
--- PASS: TestDownloadDirectBytesFailsFastWhenServerStallsBeforeHeaders (0.05s)
=== RUN   TestDownloadDirectBytesAllowsSlowBodyAfterHeaders
    media_timeout_test.go:155: ... slow body completed in 151.3925ms and returned 9 bytes
--- PASS: TestDownloadDirectBytesAllowsSlowBodyAfterHeaders (0.15s)
PASS
ok  github.com/openclaw/wacli/internal/wa  0.588s

# RED
=== RUN   TestNewDirectMediaHTTPClientBoundsPhasesWithGenerousBodyTimeout
    media_timeout_test.go:22: direct media HTTP client timeout = 0s, want 5m0s safety ceiling
--- FAIL: TestNewDirectMediaHTTPClientBoundsPhasesWithGenerousBodyTimeout (0.00s)
FAIL
```

**Why this proves it:** RED fails when `Timeout` is omitted (0s). GREEN asserts 5m ceiling, keeps phase stall fail-fast (~52ms), and still allows slow bodies after headers (150ms body under 5m ceiling).

**Limits:** Does not hit live mmg.whatsapp.net; uses unit tests + httptest for phase/body behavior.

## Test plan

- [x] Red/green on overall Timeout assertion
- [x] Existing stall + slow-body media tests pass under the new ceiling
