### PR TITLE
fix(groups): preserve chat ordering on refresh

### DIFF
--- a/cmd/wacli/groups_refresh_list.go
+++ b/cmd/wacli/groups_refresh_list.go
@@ -46,7 +46,7 @@ func newGroupsRefreshCmd(flags *rootFlags) *cobra.Command {
 				}
 				joined[g.JID.String()] = true
 				_ = persistGroupInfo(a.DB(), g)
-				_ = a.DB().UpsertChat(g.JID.String(), "group", g.GroupName.Name, now)
+				_ = a.DB().UpsertChatMetadata(g.JID.String(), "group", g.GroupName.Name)
 			}
 			if err := a.DB().MarkGroupsMissingFrom(joined, now); err != nil {
 				return err

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -44,7 +44,7 @@ func (a *App) refreshGroups(ctx context.Context) error {
 		}
 		joined[g.JID.String()] = true
 		_ = a.db.UpsertGroupWithHierarchy(g.JID.String(), g.GroupName.Name, g.OwnerJID.String(), g.GroupCreated, g.IsParent, g.LinkedParentJID.String())
-		_ = a.db.UpsertChat(g.JID.String(), "group", g.GroupName.Name, now)
+		_ = a.db.UpsertChatMetadata(g.JID.String(), "group", g.GroupName.Name)
 	}
 	return a.db.MarkGroupsMissingFrom(joined, now)
 }

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -70,6 +70,40 @@ func TestRefreshGroupsStoresGroupsAndChats(t *testing.T) {
 	}
 }
 
+func TestRefreshGroupsPreservesChatLastMessageTimestamp(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	gid := types.JID{User: "12345", Server: types.GroupServer}
+	messageTS := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	refreshTS := messageTS.Add(24 * time.Hour)
+	if err := a.db.UpsertChat(gid.String(), "group", "Old Name", messageTS); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	f.groups[gid] = &types.GroupInfo{
+		JID:       gid,
+		GroupName: types.GroupName{Name: "New Name"},
+	}
+	previousNowUTC := nowUTC
+	nowUTC = func() time.Time { return refreshTS }
+	t.Cleanup(func() { nowUTC = previousNowUTC })
+
+	if err := a.refreshGroups(context.Background()); err != nil {
+		t.Fatalf("refreshGroups: %v", err)
+	}
+	c, err := a.db.GetChat(gid.String())
+	if err != nil {
+		t.Fatalf("GetChat: %v", err)
+	}
+	if c.Name != "New Name" {
+		t.Fatalf("expected refreshed chat name, got %q", c.Name)
+	}
+	if !c.LastMessageTS.Equal(messageTS) {
+		t.Fatalf("expected LastMessageTS=%s, got %s", messageTS, c.LastMessageTS)
+	}
+}
+
 func TestRefreshNewslettersStoresChats(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/store/chats.go
+++ b/internal/store/chats.go
@@ -30,6 +30,17 @@ func (d *DB) UpsertChat(jid, kind, name string, lastTS time.Time) error {
 	})
 }
 
+func (d *DB) UpsertChatMetadata(jid, kind, name string) error {
+	if strings.TrimSpace(kind) == "" {
+		kind = "unknown"
+	}
+	return d.q.UpsertChatMetadata(storeCtx(), storedb.UpsertChatMetadataParams{
+		Jid:  jid,
+		Kind: kind,
+		Name: nullString(name),
+	})
+}
+
 func (d *DB) ListChats(query string, limit int) ([]Chat, error) {
 	return d.ListChatsFiltered(ChatListFilter{Query: query, Limit: limit})
 }

--- a/internal/store/chats_test.go
+++ b/internal/store/chats_test.go
@@ -42,6 +42,39 @@ func TestUpsertChatNameAndLastMessageTS(t *testing.T) {
 	}
 }
 
+func TestUpsertChatMetadataPreservesLastMessageTimestamp(t *testing.T) {
+	db := openTestDB(t)
+
+	messageTS := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := db.UpsertChat("existing@g.us", "group", "Old Name", messageTS); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := db.UpsertChatMetadata("existing@g.us", "group", "New Name"); err != nil {
+		t.Fatalf("UpsertChatMetadata existing: %v", err)
+	}
+	existing, err := db.GetChat("existing@g.us")
+	if err != nil {
+		t.Fatalf("GetChat existing: %v", err)
+	}
+	if existing.Name != "New Name" {
+		t.Fatalf("expected refreshed name, got %q", existing.Name)
+	}
+	if !existing.LastMessageTS.Equal(messageTS) {
+		t.Fatalf("expected LastMessageTS=%s, got %s", messageTS, existing.LastMessageTS)
+	}
+
+	if err := db.UpsertChatMetadata("new@g.us", "group", "New Group"); err != nil {
+		t.Fatalf("UpsertChatMetadata new: %v", err)
+	}
+	created, err := db.GetChat("new@g.us")
+	if err != nil {
+		t.Fatalf("GetChat new: %v", err)
+	}
+	if !created.LastMessageTS.IsZero() {
+		t.Fatalf("expected new metadata-only chat to have unknown activity, got %s", created.LastMessageTS)
+	}
+}
+
 func TestChatStateColumnsAndFilters(t *testing.T) {
 	db := openTestDB(t)
 	now := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -6,6 +6,13 @@ ON CONFLICT(jid) DO UPDATE SET
     name=CASE WHEN excluded.name IS NOT NULL AND excluded.name != '' THEN excluded.name ELSE chats.name END,
     last_message_ts=CASE WHEN excluded.last_message_ts > COALESCE(chats.last_message_ts, 0) THEN excluded.last_message_ts ELSE chats.last_message_ts END;
 
+-- name: UpsertChatMetadata :exec
+INSERT INTO chats(jid, kind, name)
+VALUES(?, ?, ?)
+ON CONFLICT(jid) DO UPDATE SET
+    kind=excluded.kind,
+    name=CASE WHEN excluded.name IS NOT NULL AND excluded.name != '' THEN excluded.name ELSE chats.name END;
+
 -- name: GetChat :one
 SELECT jid, kind, COALESCE(name,''), COALESCE(last_message_ts,0), COALESCE(archived,0), COALESCE(pinned,0), COALESCE(muted_until,0), COALESCE(unread,0), COALESCE(unread_count,0)
 FROM chats

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -1639,6 +1639,25 @@ func (q *Queries) UpsertChat(ctx context.Context, arg UpsertChatParams) error {
 	return err
 }
 
+const upsertChatMetadata = `-- name: UpsertChatMetadata :exec
+INSERT INTO chats(jid, kind, name)
+VALUES(?, ?, ?)
+ON CONFLICT(jid) DO UPDATE SET
+    kind=excluded.kind,
+    name=CASE WHEN excluded.name IS NOT NULL AND excluded.name != '' THEN excluded.name ELSE chats.name END
+`
+
+type UpsertChatMetadataParams struct {
+	Jid  string
+	Kind string
+	Name sql.NullString
+}
+
+func (q *Queries) UpsertChatMetadata(ctx context.Context, arg UpsertChatMetadataParams) error {
+	_, err := q.db.ExecContext(ctx, upsertChatMetadata, arg.Jid, arg.Kind, arg.Name)
+	return err
+}
+
 const upsertContact = `-- name: UpsertContact :exec
 INSERT INTO contacts(jid, phone, push_name, full_name, first_name, business_name, updated_at)
 VALUES (?, ?, ?, ?, ?, ?, ?)


### PR DESCRIPTION
## What changed

- add a metadata-only chat upsert that updates group identity fields without changing message activity
- use it from both the CLI and internal group refresh paths
- cover existing and newly discovered groups at the store layer and preserve ordering through the refresh path

## Why

`groups refresh` supplied its wall-clock run time to the generic chat upsert for every group. Because chat lists sort by `last_message_ts`, a metadata refresh could make every group look recently active and push genuinely recent chats out of limited results.

The new upsert leaves an existing `last_message_ts` unchanged. A newly discovered metadata-only group starts with unknown activity until message sync provides a real timestamp.

Closes #339.

## Behavior proof

The focused regression failed on current `main` before the fix:

```text
go test ./internal/app -run TestRefreshGroupsPreservesChatLastMessageTimestamp -count=1 -v
expected LastMessageTS=2024-01-01 00:00:00 +0000 UTC, got 2024-01-02 00:00:00 +0000 UTC
```

After the fix, the refresh-layer regression and the store regression both pass. The store test also verifies that a metadata-only insert does not invent message activity. No live WhatsApp provider proof was used or claimed; the corrupted value originates and is asserted entirely in the local refresh and SQLite paths.

## Validation

```text
go test ./internal/app ./internal/store -run 'TestRefreshGroupsPreservesChatLastMessageTimestamp|TestUpsertChatMetadataPreservesLastMessageTimestamp' -count=1
go test ./...
go test -tags sqlite_fts5 ./...
go vet ./...
CGO_ENABLED=1 go build -tags sqlite_fts5 ./cmd/wacli
GOOS=windows GOARCH=amd64 go test -c ./internal/lock
node --test scripts/*.test.mjs
node scripts/govulncheck-stdlib.mjs source
go run golang.org/x/tools/cmd/deadcode@v0.47.0 -test -tags sqlite_fts5 ./...
test -z "$(gofmt -l .)"
git diff --check
```

The source vulnerability gate passed. It retained the repository's existing non-stdlib notice for the unmaintained `golang.org/x/crypto/openpgp` package; this change does not alter that dependency.

## Limitations

This does not infer activity for a group that has only been discovered through metadata refresh. Its timestamp remains unknown until a real message is synchronized, which avoids fabricating ordering data.

Disclosure: AI was used to understand the codebase and review the fix.
