### PR TITLE
chore(release): prepare 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.16.0 - Unreleased
+## 0.16.0 - 2026-08-02
 
 ### Added
 

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const sourceVersion = "0.15.2"
+const sourceVersion = "0.16.0"
 
 var version string
 


### PR DESCRIPTION
## Summary

- close the 0.16.0 changelog section with the authorized release date
- update source builds to report 0.16.0
- satisfy the documented reusable release-workflow preconditions

## Validation

- full normal and FTS Go test suites, Windows cross-compile, docs tests/site, and SQLC e2e
- source and binary vulnerability gates plus dead-code scan
- both GoReleaser configuration checks
- native build and Docker build/smoke both report `wacli 0.16.0`
- autoreview clean with no actionable findings
