### PR TITLE
sync: name the payload when a message is stored without content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Sync: identify unhandled payload types when content extraction produces a placeholder, with bounded diagnostics during history replay. (#344 - thanks @dvainrub)
+
 ## 0.16.0 - 2026-08-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Sync: warn when a message is stored without content, naming the payload field that went unextracted, so the resulting `(message)` placeholder can be diagnosed instead of silently losing the body. (#343)
+
 ## 0.16.0 - 2026-08-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Added
-
-- Sync: warn when a message is stored without content, naming the payload field that went unextracted, so the resulting `(message)` placeholder can be diagnosed instead of silently losing the body. (#343)
-
 ## 0.16.0 - 2026-08-02
 
 ### Added

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -399,6 +399,7 @@ func chatKind(chat types.JID) string {
 
 func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error {
 	pm.Chat = a.canonicalStoreJID(ctx, pm.Chat)
+	a.warnUnhandledPayload(pm)
 	chatJID := canonicalJIDString(pm.Chat)
 	chatName := a.wa.ResolveChatName(ctx, pm.Chat, pm.PushName)
 	if pm.Chat != types.StatusBroadcastJID {
@@ -712,6 +713,28 @@ func (a *App) buildDisplayText(ctx context.Context, pm wa.ParsedMessage) string 
 		base = "(message)"
 	}
 	return base
+}
+
+// warnUnhandledPayload surfaces messages whose payload produced no content, so
+// the resulting "(message)" placeholder is diagnosable. Without it the row is
+// indistinguishable from a message that genuinely carried nothing, and any
+// consumer reading local history silently sees a gap it cannot account for.
+func (a *App) warnUnhandledPayload(pm wa.ParsedMessage) {
+	if pm.UnhandledPayload == "" {
+		return
+	}
+	a.emitWarning(
+		"unhandled_message_payload",
+		fmt.Sprintf(
+			"stored message %s in %s without content: unhandled payload %s",
+			pm.ID, canonicalJIDString(pm.Chat), pm.UnhandledPayload,
+		),
+		map[string]any{
+			"chat_jid": canonicalJIDString(pm.Chat),
+			"msg_id":   pm.ID,
+			"payload":  pm.UnhandledPayload,
+		},
+	)
 }
 
 func baseDisplayText(pm wa.ParsedMessage) string {

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -399,7 +399,6 @@ func chatKind(chat types.JID) string {
 
 func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error {
 	pm.Chat = a.canonicalStoreJID(ctx, pm.Chat)
-	a.warnUnhandledPayload(pm)
 	chatJID := canonicalJIDString(pm.Chat)
 	chatName := a.wa.ResolveChatName(ctx, pm.Chat, pm.PushName)
 	if pm.Chat != types.StatusBroadcastJID {
@@ -543,6 +542,7 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 	}); err != nil {
 		return err
 	}
+	a.warnUnhandledPayload(pm)
 	if pm.Location != nil {
 		if err := a.db.UpsertMessageLocation(store.MessageLocation{
 			ChatJID:   chatJID,
@@ -719,6 +719,10 @@ func (a *App) buildDisplayText(ctx context.Context, pm wa.ParsedMessage) string 
 // the resulting "(message)" placeholder is diagnosable. Without it the row is
 // indistinguishable from a message that genuinely carried nothing, and any
 // consumer reading local history silently sees a gap it cannot account for.
+//
+// Called only after the message upsert succeeds: the warning states that the
+// row was stored, so emitting it earlier would report a write that may still
+// fail.
 func (a *App) warnUnhandledPayload(pm wa.ParsedMessage) {
 	if pm.UnhandledPayload == "" {
 		return

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -580,7 +580,55 @@ func historySyncNotificationFromMessage(v *events.Message) *waE2E.HistorySyncNot
 	return v.Message.GetProtocolMessage().GetHistorySyncNotification()
 }
 
+const maxHistoryUnhandledPayloadWarnings = 10
+
+type historyUnhandledPayloadWarnings struct {
+	seen       map[string]struct{}
+	reported   int
+	suppressed int
+}
+
+func (w *historyUnhandledPayloadWarnings) observe(a *App, pm wa.ParsedMessage) {
+	payload := strings.TrimSpace(pm.UnhandledPayload)
+	if payload == "" {
+		return
+	}
+	if w.seen == nil {
+		w.seen = make(map[string]struct{})
+	}
+	if _, ok := w.seen[payload]; ok {
+		w.suppressed++
+		return
+	}
+	w.seen[payload] = struct{}{}
+	if w.reported >= maxHistoryUnhandledPayloadWarnings {
+		w.suppressed++
+		return
+	}
+	w.reported++
+	a.warnUnhandledPayload(pm)
+}
+
+func (w *historyUnhandledPayloadWarnings) flush(a *App) {
+	if w.suppressed == 0 {
+		return
+	}
+	a.emitWarning(
+		"unhandled_message_payloads_suppressed",
+		fmt.Sprintf(
+			"history sync suppressed %d additional unhandled-payload warnings across %d payload shapes",
+			w.suppressed, len(w.seen),
+		),
+		map[string]any{
+			"suppressed_messages": w.suppressed,
+			"unique_payloads":     len(w.seen),
+		},
+	)
+}
+
 func (a *App) handleHistorySync(ctx context.Context, opts SyncOptions, v *events.HistorySync, messagesStored, lastEvent *atomic.Int64, enqueueMedia func(string, string), limits ...*syncStorageLimits) {
+	var unhandledWarnings historyUnhandledPayloadWarnings
+	defer unhandledWarnings.flush(a)
 	a.emitOrPrint("history_sync", map[string]any{"conversations": len(v.Data.Conversations)}, "\nProcessing history sync (%d conversations)...\n", len(v.Data.Conversations))
 	a.storeHistoryCallLogRecords(ctx, v, lastEvent)
 	for _, conv := range v.Data.Conversations {
@@ -617,7 +665,10 @@ func (a *App) handleHistorySync(ctx context.Context, opts SyncOptions, v *events
 					a.decryptEncryptedReaction(ctx, &pm, evt)
 				}
 			}
-			if err := a.storeParsedMessageForSync(ctx, pm, limits...); err == nil {
+			storedPM := pm
+			storedPM.UnhandledPayload = ""
+			if err := a.storeParsedMessageForSync(ctx, storedPM, limits...); err == nil {
+				unhandledWarnings.observe(a, pm)
 				a.emitSyncProgress(messagesStored.Add(1))
 				if pm.Poll != nil || pm.PollAdd != nil || pm.PollVote != nil {
 					pendingPolls = append(pendingPolls, historyPollSideEffect{pm: pm, evt: pollEvt, hist: m.Message})

--- a/internal/app/unhandled_payload_warning_test.go
+++ b/internal/app/unhandled_payload_warning_test.go
@@ -1,0 +1,112 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openclaw/wacli/internal/out"
+	"github.com/openclaw/wacli/internal/wa"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/proto/waCommon"
+	"go.mau.fi/whatsmeow/proto/waHistorySync"
+	"go.mau.fi/whatsmeow/proto/waWeb"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestHistorySyncBoundsUnhandledPayloadWarnings(t *testing.T) {
+	a := newTestApp(t)
+	a.wa = newFakeWA()
+
+	var eventsOut bytes.Buffer
+	a.opts.Events = out.NewEventWriter(&eventsOut, true)
+	chat := types.JID{User: "123", Server: types.DefaultUserServer}
+	const messageCount = 25
+	messages := make([]*waHistorySync.HistorySyncMsg, 0, messageCount)
+	for i := range messageCount {
+		messages = append(messages, &waHistorySync.HistorySyncMsg{
+			Message: &waWeb.WebMessageInfo{
+				Key: &waCommon.MessageKey{
+					RemoteJID: proto.String(chat.String()),
+					ID:        proto.String(fmt.Sprintf("opaque-%d", i)),
+				},
+				MessageTimestamp: proto.Uint64(uint64(time.Unix(int64(i+1), 0).Unix())),
+				Message: &waProto.Message{StickerSyncRmrMessage: &waProto.StickerSyncRMRMessage{
+					Filehash: []string{"abc"},
+				}},
+			},
+		})
+	}
+	history := &events.HistorySync{Data: &waHistorySync.HistorySync{
+		SyncType: waHistorySync.HistorySync_FULL.Enum(),
+		Conversations: []*waHistorySync.Conversation{{
+			ID:       proto.String(chat.String()),
+			Messages: messages,
+		}},
+	}}
+
+	var stored atomic.Int64
+	var lastEvent atomic.Int64
+	a.handleHistorySync(
+		context.Background(), SyncOptions{}, history, &stored, &lastEvent,
+		func(string, string) {},
+	)
+
+	if got := stored.Load(); got != messageCount {
+		t.Fatalf("stored messages = %d, want %d", got, messageCount)
+	}
+	var detailed, summaries int
+	for _, line := range strings.Split(strings.TrimSpace(eventsOut.String()), "\n") {
+		var event struct {
+			Event string         `json:"event"`
+			Data  map[string]any `json:"data"`
+		}
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("decode event %q: %v", line, err)
+		}
+		if event.Event != "warning" {
+			continue
+		}
+		switch event.Data["code"] {
+		case "unhandled_message_payload":
+			detailed++
+		case "unhandled_message_payloads_suppressed":
+			summaries++
+			if got := event.Data["suppressed_messages"]; got != float64(messageCount-1) {
+				t.Fatalf("suppressed_messages = %#v, want %d", got, messageCount-1)
+			}
+		}
+	}
+	if detailed != 1 || summaries != 1 {
+		t.Fatalf("warning events: detailed=%d summaries=%d, want 1 each\n%s", detailed, summaries, eventsOut.String())
+	}
+}
+
+func TestHistoryUnhandledPayloadWarningsCapsDistinctShapes(t *testing.T) {
+	a := newTestApp(t)
+	var eventsOut bytes.Buffer
+	a.opts.Events = out.NewEventWriter(&eventsOut, true)
+
+	var warnings historyUnhandledPayloadWarnings
+	for i := range maxHistoryUnhandledPayloadWarnings + 5 {
+		warnings.observe(a, wa.ParsedMessage{
+			ID:               fmt.Sprintf("opaque-%d", i),
+			UnhandledPayload: fmt.Sprintf("payload-%d", i),
+		})
+	}
+	warnings.flush(a)
+
+	if got := strings.Count(eventsOut.String(), `"code":"unhandled_message_payload"`); got != maxHistoryUnhandledPayloadWarnings {
+		t.Fatalf("detailed warnings = %d, want %d", got, maxHistoryUnhandledPayloadWarnings)
+	}
+	if !strings.Contains(eventsOut.String(), `"suppressed_messages":5`) {
+		t.Fatalf("missing suppression summary:\n%s", eventsOut.String())
+	}
+}

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -116,8 +116,7 @@ func ParseLiveMessage(evt *events.Message) ParsedMessage {
 		applyDeviceSentDestination(evt.Info.DeviceSentMeta.DestinationJID, &msg)
 	}
 
-	extractWAProto(evt.Message, &msg)
-	markUnhandledPayload(evt.Message, &msg)
+	markUnhandledPayload(extractWAProto(evt.Message, &msg), &msg)
 	return msg
 }
 
@@ -148,8 +147,7 @@ func ParseHistoryMessage(chatJID string, hist *waProto.WebMessageInfo) ParsedMes
 	pm.SenderJID = sender
 
 	if hist.GetMessage() != nil {
-		extractWAProto(hist.GetMessage(), &pm)
-		markUnhandledPayload(hist.GetMessage(), &pm)
+		markUnhandledPayload(extractWAProto(hist.GetMessage(), &pm), &pm)
 	}
 	return pm
 }
@@ -195,29 +193,32 @@ func markUnhandledPayload(m *waProto.Message, pm *ParsedMessage) {
 	pm.UnhandledPayload = strings.Join(names, ",")
 }
 
-func extractWAProto(m *waProto.Message, pm *ParsedMessage) {
+// extractWAProto returns the leaf message it ultimately extracted from, after
+// unwrapping any device-sent, edited or protocol-edit wrappers. Callers use it
+// to describe an unhandled payload: naming the wrapper instead of the leaf
+// would report `protocolMessage` for every unhandled edit, which is exactly the
+// case the diagnostic exists for.
+func extractWAProto(m *waProto.Message, pm *ParsedMessage) *waProto.Message {
 	if m == nil || pm == nil {
-		return
+		return nil
 	}
 
 	if deviceSent := m.GetDeviceSentMessage(); deviceSent.GetMessage() != nil {
 		applyDeviceSentDestination(deviceSent.GetDestinationJID(), pm)
-		extractWAProto(deviceSent.GetMessage(), pm)
-		return
+		return extractWAProto(deviceSent.GetMessage(), pm)
 	}
 	if edited := m.GetEditedMessage().GetMessage(); edited != nil {
 		if edited.MessageContextInfo == nil && m.MessageContextInfo != nil {
 			edited.MessageContextInfo = m.MessageContextInfo
 		}
 		pm.Edited = true
-		extractWAProto(edited, pm)
-		return
+		return extractWAProto(edited, pm)
 	}
 	if replacement, handled := extractProtocolMutation(m, pm); handled {
 		if replacement != nil {
-			extractWAProto(replacement, pm)
+			return extractWAProto(replacement, pm)
 		}
-		return
+		return m
 	}
 	extractReaction(m, pm)
 	extractPlainText(m, pm)
@@ -243,6 +244,7 @@ func extractWAProto(m *waProto.Message, pm *ParsedMessage) {
 		pm.ForwardingScore = ctx.GetForwardingScore()
 		pm.IsForwarded = ctx.GetIsForwarded() || pm.ForwardingScore > 0
 	}
+	return m
 }
 
 func applyDeviceSentDestination(destination string, pm *ParsedMessage) {

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -1,6 +1,7 @@
 package wa
 
 import (
+	"sort"
 	"strings"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 type Media struct {
@@ -94,6 +96,9 @@ type ParsedMessage struct {
 	Edited           bool
 	Revoked          bool
 	Call             *ParsedCallEvent
+	// UnhandledPayload names the populated waE2E.Message field when parsing
+	// extracted no content at all. Empty when the message was understood.
+	UnhandledPayload string
 }
 
 func ParseLiveMessage(evt *events.Message) ParsedMessage {
@@ -112,6 +117,7 @@ func ParseLiveMessage(evt *events.Message) ParsedMessage {
 	}
 
 	extractWAProto(evt.Message, &msg)
+	markUnhandledPayload(evt.Message, &msg)
 	return msg
 }
 
@@ -143,8 +149,50 @@ func ParseHistoryMessage(chatJID string, hist *waProto.WebMessageInfo) ParsedMes
 
 	if hist.GetMessage() != nil {
 		extractWAProto(hist.GetMessage(), &pm)
+		markUnhandledPayload(hist.GetMessage(), &pm)
 	}
 	return pm
+}
+
+// hasContent reports whether parsing produced anything storable. A message with
+// no content is persisted with a "(message)" placeholder, which is
+// indistinguishable from a message that genuinely carried nothing.
+func (pm ParsedMessage) hasContent() bool {
+	return strings.TrimSpace(pm.Text) != "" ||
+		pm.Media != nil ||
+		pm.Poll != nil ||
+		pm.PollVote != nil ||
+		pm.PollAdd != nil ||
+		pm.Call != nil ||
+		pm.Location != nil ||
+		pm.Revoked ||
+		len(pm.Buttons) > 0 ||
+		strings.TrimSpace(pm.ReactionToID) != "" ||
+		strings.TrimSpace(pm.ReactionEmoji) != ""
+}
+
+// markUnhandledPayload records which payload field was present when extraction
+// yielded nothing, so the placeholder row can be diagnosed instead of silently
+// discarding content. Field names come from the protobuf descriptor, so new
+// WhatsApp message types are reported without needing a code change here.
+func markUnhandledPayload(m *waProto.Message, pm *ParsedMessage) {
+	if m == nil || pm == nil || pm.hasContent() {
+		return
+	}
+	var names []string
+	m.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, _ protoreflect.Value) bool {
+		switch fd.Name() {
+		case "messageContextInfo":
+			return true
+		}
+		names = append(names, string(fd.Name()))
+		return true
+	})
+	if len(names) == 0 {
+		return
+	}
+	sort.Strings(names)
+	pm.UnhandledPayload = strings.Join(names, ",")
 }
 
 func extractWAProto(m *waProto.Message, pm *ParsedMessage) {

--- a/internal/wa/unhandled_payload_test.go
+++ b/internal/wa/unhandled_payload_test.go
@@ -1,0 +1,109 @@
+package wa
+
+import (
+	"testing"
+	"time"
+
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+)
+
+func liveEvent(msg *waProto.Message) *events.Message {
+	chat, _ := types.ParseJID("123@s.whatsapp.net")
+	return &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat},
+			ID:            "MSGID",
+			Timestamp:     time.Unix(1, 0),
+		},
+		Message: msg,
+	}
+}
+
+// A payload the parser understands must not be flagged, otherwise the warning
+// becomes noise and gets ignored.
+func TestParseLiveMessageLeavesUnhandledPayloadEmptyForText(t *testing.T) {
+	pm := ParseLiveMessage(liveEvent(&waProto.Message{
+		Conversation: proto.String("hello"),
+	}))
+	if pm.Text != "hello" {
+		t.Fatalf("expected text to be extracted, got %q", pm.Text)
+	}
+	if pm.UnhandledPayload != "" {
+		t.Fatalf("expected no unhandled payload, got %q", pm.UnhandledPayload)
+	}
+}
+
+// A payload the parser extracts nothing from is stored as "(message)". Naming
+// the field is what makes that row diagnosable after the fact.
+func TestParseLiveMessageNamesUnextractedPayload(t *testing.T) {
+	pm := ParseLiveMessage(liveEvent(&waProto.Message{
+		StickerSyncRmrMessage: &waProto.StickerSyncRMRMessage{
+			Filehash: []string{"abc"},
+		},
+	}))
+	if pm.Text != "" || pm.Media != nil {
+		t.Fatalf("expected no content, got text=%q media=%v", pm.Text, pm.Media)
+	}
+	if pm.UnhandledPayload != "stickerSyncRmrMessage" {
+		t.Fatalf("expected stickerSyncRmrMessage, got %q", pm.UnhandledPayload)
+	}
+}
+
+// messageContextInfo travels alongside real payloads and carries no content of
+// its own, so reporting it would point at the wrong field.
+func TestMarkUnhandledPayloadIgnoresMessageContextInfo(t *testing.T) {
+	pm := ParseLiveMessage(liveEvent(&waProto.Message{
+		MessageContextInfo: &waProto.MessageContextInfo{
+			MessageSecret: []byte{1, 2, 3},
+		},
+	}))
+	if pm.UnhandledPayload != "" {
+		t.Fatalf("expected context-info-only message to be ignored, got %q", pm.UnhandledPayload)
+	}
+}
+
+// An empty message has nothing to report; flagging it would fire on every
+// keep-alive-shaped payload.
+func TestMarkUnhandledPayloadIgnoresEmptyMessage(t *testing.T) {
+	pm := ParseLiveMessage(liveEvent(&waProto.Message{}))
+	if pm.UnhandledPayload != "" {
+		t.Fatalf("expected empty message to be ignored, got %q", pm.UnhandledPayload)
+	}
+}
+
+// History messages reach the same placeholder path, so they need the same
+// diagnostic.
+func TestParseHistoryMessageNamesUnextractedPayload(t *testing.T) {
+	pm := ParseHistoryMessage("123@s.whatsapp.net", &waProto.WebMessageInfo{
+		Key:              &waProto.MessageKey{ID: proto.String("HIST")},
+		MessageTimestamp: proto.Uint64(1),
+		Message: &waProto.Message{
+			StickerSyncRmrMessage: &waProto.StickerSyncRMRMessage{
+				Filehash: []string{"abc"},
+			},
+		},
+	})
+	if pm.UnhandledPayload != "stickerSyncRmrMessage" {
+		t.Fatalf("expected stickerSyncRmrMessage, got %q", pm.UnhandledPayload)
+	}
+}
+
+// A revoke produces no text by design; treating it as unhandled would flag
+// every deletion.
+func TestMarkUnhandledPayloadIgnoresRevoke(t *testing.T) {
+	pm := ParseLiveMessage(liveEvent(&waProto.Message{
+		ProtocolMessage: &waProto.ProtocolMessage{
+			Type: waProto.ProtocolMessage_REVOKE.Enum(),
+			Key:  &waProto.MessageKey{ID: proto.String("ORIGINAL")},
+		},
+	}))
+	if !pm.Revoked {
+		t.Fatal("expected message to be marked revoked")
+	}
+	if pm.UnhandledPayload != "" {
+		t.Fatalf("expected revoke to be handled, got %q", pm.UnhandledPayload)
+	}
+}

--- a/internal/wa/unhandled_payload_test.go
+++ b/internal/wa/unhandled_payload_test.go
@@ -107,3 +107,78 @@ func TestMarkUnhandledPayloadIgnoresRevoke(t *testing.T) {
 		t.Fatalf("expected revoke to be handled, got %q", pm.UnhandledPayload)
 	}
 }
+
+// A payload wrapped in deviceSentMessage must be named by its leaf. Reporting
+// the wrapper would send an operator looking at the envelope instead of the
+// content that went missing.
+func TestMarkUnhandledPayloadNamesLeafInsideDeviceSent(t *testing.T) {
+	pm := ParseLiveMessage(liveEvent(&waProto.Message{
+		DeviceSentMessage: &waProto.DeviceSentMessage{
+			DestinationJID: proto.String("456@s.whatsapp.net"),
+			Message: &waProto.Message{
+				StickerSyncRmrMessage: &waProto.StickerSyncRMRMessage{
+					Filehash: []string{"abc"},
+				},
+			},
+		},
+	}))
+	if pm.UnhandledPayload != "stickerSyncRmrMessage" {
+		t.Fatalf("expected the leaf payload, got %q", pm.UnhandledPayload)
+	}
+}
+
+// The edit case is the reason this diagnostic exists: naming protocolMessage
+// here would report every unhandled edit as the same generic wrapper.
+func TestMarkUnhandledPayloadNamesLeafInsideProtocolEdit(t *testing.T) {
+	pm := ParseLiveMessage(liveEvent(&waProto.Message{
+		ProtocolMessage: &waProto.ProtocolMessage{
+			Type: waProto.ProtocolMessage_MESSAGE_EDIT.Enum(),
+			Key:  &waProto.MessageKey{ID: proto.String("ORIGINAL")},
+			EditedMessage: &waProto.Message{
+				StickerSyncRmrMessage: &waProto.StickerSyncRMRMessage{
+					Filehash: []string{"abc"},
+				},
+			},
+		},
+	}))
+	if pm.ID != "ORIGINAL" {
+		t.Fatalf("expected the edit to adopt the original id, got %q", pm.ID)
+	}
+	if pm.UnhandledPayload != "stickerSyncRmrMessage" {
+		t.Fatalf("expected the leaf payload, got %q", pm.UnhandledPayload)
+	}
+}
+
+// editedMessage is the other wrapper shape the parser unwraps.
+func TestMarkUnhandledPayloadNamesLeafInsideEditedMessage(t *testing.T) {
+	pm := ParseLiveMessage(liveEvent(&waProto.Message{
+		EditedMessage: &waProto.FutureProofMessage{
+			Message: &waProto.Message{
+				StickerSyncRmrMessage: &waProto.StickerSyncRMRMessage{
+					Filehash: []string{"abc"},
+				},
+			},
+		},
+	}))
+	if !pm.Edited {
+		t.Fatal("expected the message to be marked edited")
+	}
+	if pm.UnhandledPayload != "stickerSyncRmrMessage" {
+		t.Fatalf("expected the leaf payload, got %q", pm.UnhandledPayload)
+	}
+}
+
+// A wrapper around content the parser understands stays unflagged.
+func TestMarkUnhandledPayloadIgnoresWrappedText(t *testing.T) {
+	pm := ParseLiveMessage(liveEvent(&waProto.Message{
+		DeviceSentMessage: &waProto.DeviceSentMessage{
+			Message: &waProto.Message{Conversation: proto.String("hello")},
+		},
+	}))
+	if pm.Text != "hello" {
+		t.Fatalf("expected wrapped text to be extracted, got %q", pm.Text)
+	}
+	if pm.UnhandledPayload != "" {
+		t.Fatalf("expected no unhandled payload, got %q", pm.UnhandledPayload)
+	}
+}


### PR DESCRIPTION
Makes content-less message rows diagnosable. Opening as a PR because #343 was closed automatically and I could not reopen it; the full context lives below so it does not depend on that thread.

## The gap

When parsing extracts nothing from a message, it is stored with a `(message)` placeholder. That row is indistinguishable from a message that genuinely carried no content, so there is no signal that anything was dropped and no way to tell what it was.

On one account: **6,403 of 64,349 stored messages (10%)**, and **3.11% over the last 14 days**. None of them join to `polls` or `call_events`, so the known content-less types do not account for them.

## Why it is worse than a gap

At least some of these are unhandled message edits. When an edit is not unwrapped, the original row keeps its **pre-edit text**, which reads as perfectly valid. A missing message is noticeable; a superseded one is not.

Concretely, an automated summariser over this database reported that a contact "wants to integrate Lightspeed", quoting the stored text verbatim. The contact had edited that message to say **Instagram** seconds after sending it. Nothing in the output flagged a discrepancy.

## The behaviour this came from (context from #343)

Reproduced on **v0.15.2** with `sync --follow` connected: an incoming 1:1 text (`Hola` at `04:30:04Z`), edited at `04:30:10Z`, produced a second row with its own `msg_id`, `text = NULL`, `display_text = "(message)"`, `edited = 0`, while the original kept `Hola`.

Two details from that investigation, in case they help:

- **It was the live path, not history.** The daemon connected at `04:20:31Z` and `sync.err` ends at `Connected.` with no `Synced N messages...` line after it, so no catch-up batch ran between connection and the message ten minutes later.
- **The handling code is present and unchanged.** `extractProtocolMutation` has handled `MESSAGE_EDIT` since 72db4db (May), and it is byte-for-byte identical between `v0.15.2` and current `main` — the only change to `extractWAProto` in between is the added `extractLocation(m, pm)` line from #338. So the code exists; something upstream of it is not reaching it. **This PR does not attempt to fix that**, because I have not identified the cause and would rather not guess at it.

`edited = 1` rows are also worth a look: 186/month in April and May 2026, 47 in June, 1 in July, 0 in August, while placeholder rows keep being produced throughout.

## What this PR does

Records which `waE2E.Message` field was populated when extraction produced nothing, and emits a warning at store time with the chat, message id and field name. **Nothing about what gets stored changes.**

Field names come from the protobuf descriptor, so a new WhatsApp message type is reported without needing a code change here.

Deliberately **not** flagged, to keep the warning from becoming noise that gets tuned out:

- messages carrying only `messageContextInfo`
- empty messages
- revokes, which are content-less by design

## Tests

Six cases in `internal/wa/unhandled_payload_test.go`: both parse entry points (live and history), a handled payload staying unflagged, and one per exclusion above.

## Gate

`gofmt -l` clean · `go vet ./...` · `go test ./...` · `go test -tags sqlite_fts5 ./...` · `go build -tags sqlite_fts5 ./cmd/wacli` · `git diff --check` — all pass on this branch.

## Unrelated, but blocking verification for tap users

`openclaw/homebrew-tap` is still pinned to `wacli 0.15.2`: the `update-formula` workflow has no run after 2026-08-03, so it never fired for v0.16.0 despite that release being complete and public. Filed as openclaw/homebrew-tap#13. It means anyone on the tap cannot install v0.16.0 to check the behaviour above.
