### PR TITLE
store: expose edited state in message output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Sync: identify unhandled payload types when content extraction produces a placeholder, with bounded diagnostics during history replay. (#344 - thanks @dvainrub)
+- Messages: expose persisted edited state consistently in list, search, show, and context JSON output. (#347 - thanks @dvainrub)
 
 ### Chore
 

--- a/internal/store/edited_output_test.go
+++ b/internal/store/edited_output_test.go
@@ -1,0 +1,111 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// The edited columns were written on ingestion but never read back, so callers
+// had to open the SQLite file to tell an edited message from an untouched one.
+func TestListMessagesReportsEdited(t *testing.T) {
+	db := openTestDB(t)
+
+	chat := "123@s.whatsapp.net"
+	if err := db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+
+	ts := time.Date(2024, 2, 1, 12, 0, 0, 0, time.UTC)
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:   chat,
+		MsgID:     "edited",
+		Timestamp: ts,
+		Text:      "final text",
+		Edited:    true,
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	msgs, err := db.ListMessages(ListMessagesParams{ChatJID: chat, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if !msgs[0].Edited {
+		t.Fatal("expected Edited to be true")
+	}
+	if msgs[0].EditedAt == nil {
+		t.Fatal("expected EditedAt to be set")
+	}
+	if !msgs[0].EditedAt.Equal(ts) {
+		t.Fatalf("expected EditedAt %v, got %v", ts, *msgs[0].EditedAt)
+	}
+}
+
+// An untouched message must not carry an edit timestamp, otherwise every row
+// looks edited and the field is useless for filtering.
+func TestListMessagesLeavesEditedUnsetForPlainMessage(t *testing.T) {
+	db := openTestDB(t)
+
+	chat := "123@s.whatsapp.net"
+	if err := db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:   chat,
+		MsgID:     "plain",
+		Timestamp: time.Date(2024, 2, 1, 12, 0, 0, 0, time.UTC),
+		Text:      "hello",
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	msgs, err := db.ListMessages(ListMessagesParams{ChatJID: chat, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].Edited {
+		t.Fatal("expected Edited to be false")
+	}
+	if msgs[0].EditedAt != nil {
+		t.Fatalf("expected no EditedAt, got %v", *msgs[0].EditedAt)
+	}
+}
+
+// Search shares the same column list and scanner, so it must report the flag
+// too; a message found by search should not look different from the same
+// message found by listing it.
+func TestSearchMessagesReportsEdited(t *testing.T) {
+	db := openTestDB(t)
+
+	chat := "123@s.whatsapp.net"
+	if err := db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:   chat,
+		MsgID:     "edited",
+		Timestamp: time.Date(2024, 2, 1, 12, 0, 0, 0, time.UTC),
+		Text:      "distinctivetoken",
+		Edited:    true,
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	msgs, err := db.SearchMessages(SearchMessagesParams{Query: "distinctivetoken", Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchMessages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if !msgs[0].Edited {
+		t.Fatal("expected Edited to be true from search results")
+	}
+}

--- a/internal/store/edited_output_test.go
+++ b/internal/store/edited_output_test.go
@@ -36,16 +36,9 @@ func TestListMessagesReportsEdited(t *testing.T) {
 	if !msgs[0].Edited {
 		t.Fatal("expected Edited to be true")
 	}
-	if msgs[0].EditedAt == nil {
-		t.Fatal("expected EditedAt to be set")
-	}
-	if !msgs[0].EditedAt.Equal(ts) {
-		t.Fatalf("expected EditedAt %v, got %v", ts, *msgs[0].EditedAt)
-	}
 }
 
-// An untouched message must not carry an edit timestamp, otherwise every row
-// looks edited and the field is useless for filtering.
+// An untouched message must keep the edit flag false so callers can filter it.
 func TestListMessagesLeavesEditedUnsetForPlainMessage(t *testing.T) {
 	db := openTestDB(t)
 
@@ -72,9 +65,6 @@ func TestListMessagesLeavesEditedUnsetForPlainMessage(t *testing.T) {
 	}
 	if msgs[0].Edited {
 		t.Fatal("expected Edited to be false")
-	}
-	if msgs[0].EditedAt != nil {
-		t.Fatalf("expected no EditedAt, got %v", *msgs[0].EditedAt)
 	}
 }
 
@@ -107,5 +97,65 @@ func TestSearchMessagesReportsEdited(t *testing.T) {
 	}
 	if !msgs[0].Edited {
 		t.Fatal("expected Edited to be true from search results")
+	}
+}
+
+func TestGetMessageReportsEdited(t *testing.T) {
+	db := openTestDB(t)
+
+	chat := "123@s.whatsapp.net"
+	if err := db.UpsertChat(chat, "dm", "Alice", time.Now()); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID:   chat,
+		MsgID:     "edited",
+		Timestamp: time.Date(2024, 2, 1, 12, 0, 0, 0, time.UTC),
+		Text:      "final text",
+		Edited:    true,
+	}); err != nil {
+		t.Fatalf("UpsertMessage: %v", err)
+	}
+
+	msg, err := db.GetMessage(chat, "edited")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if !msg.Edited {
+		t.Fatal("expected Edited to be true")
+	}
+}
+
+func TestMessageContextReportsEdited(t *testing.T) {
+	db := openTestDB(t)
+
+	chat := "123@s.whatsapp.net"
+	base := time.Date(2024, 2, 1, 12, 0, 0, 0, time.UTC)
+	if err := db.UpsertChat(chat, "dm", "Alice", base); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	for i, id := range []string{"before", "target", "after"} {
+		if err := db.UpsertMessage(UpsertMessageParams{
+			ChatJID:   chat,
+			MsgID:     id,
+			Timestamp: base.Add(time.Duration(i) * time.Minute),
+			Text:      id,
+			Edited:    true,
+		}); err != nil {
+			t.Fatalf("UpsertMessage %s: %v", id, err)
+		}
+	}
+
+	msgs, err := db.MessageContext(chat, "target", 1, 1)
+	if err != nil {
+		t.Fatalf("MessageContext: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(msgs))
+	}
+	for _, msg := range msgs {
+		if !msg.Edited {
+			t.Fatalf("expected %s to report Edited", msg.MsgID)
+		}
 	}
 }

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -47,7 +47,7 @@ type UpsertMessageParams struct {
 }
 
 func messageSelectColumns(snippet string) string {
-	return fmt.Sprintf(`m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), COALESCE(m.buttons,''), %s`, snippetSQL(snippet))
+	return fmt.Sprintf(`m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), COALESCE(m.buttons,''), m.edited, COALESCE(m.edited_ts,0), %s`, snippetSQL(snippet))
 }
 
 func snippetSQL(snippet string) string {
@@ -556,7 +556,9 @@ func (d *DB) scanMessages(query string, args ...interface{}) ([]Message, error) 
 		var deletionReason string
 		var payloadPurgedAt int64
 		var buttonsJSON string
-		if err := rows.Scan(&m.rowID, &m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &m.SenderName, &ts, &fromMe, &m.Text, &m.DisplayText, &m.QuotedMsgID, &m.QuotedSenderJID, &forwarded, &forwardingScore, &m.ReactionToID, &m.ReactionEmoji, &m.MediaType, &m.MediaCaption, &m.Filename, &m.MimeType, &m.DirectPath, &m.LocalPath, &downloadedAt, &starred, &starredAt, &revoked, &deletedForMe, &deletedAt, &deletionReason, &payloadPurgedAt, &buttonsJSON, &m.Snippet); err != nil {
+		var edited int
+		var editedTs int64
+		if err := rows.Scan(&m.rowID, &m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &m.SenderName, &ts, &fromMe, &m.Text, &m.DisplayText, &m.QuotedMsgID, &m.QuotedSenderJID, &forwarded, &forwardingScore, &m.ReactionToID, &m.ReactionEmoji, &m.MediaType, &m.MediaCaption, &m.Filename, &m.MimeType, &m.DirectPath, &m.LocalPath, &downloadedAt, &starred, &starredAt, &revoked, &deletedForMe, &deletedAt, &deletionReason, &payloadPurgedAt, &buttonsJSON, &edited, &editedTs, &m.Snippet); err != nil {
 			return nil, err
 		}
 		m.Timestamp = fromUnix(ts)
@@ -571,6 +573,8 @@ func (d *DB) scanMessages(query string, args ...interface{}) ([]Message, error) 
 		m.DeletedAt = timePointerFromUnix(deletedAt)
 		m.DeletionReason = deletionReason
 		m.PayloadPurgedAt = timePointerFromUnix(payloadPurgedAt)
+		m.Edited = edited != 0
+		m.EditedAt = timePointerFromUnix(editedTs)
 		if buttonsJSON != "" {
 			_ = json.Unmarshal([]byte(buttonsJSON), &m.Buttons)
 		}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -47,7 +47,7 @@ type UpsertMessageParams struct {
 }
 
 func messageSelectColumns(snippet string) string {
-	return fmt.Sprintf(`m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), COALESCE(m.buttons,''), m.edited, COALESCE(m.edited_ts,0), %s`, snippetSQL(snippet))
+	return fmt.Sprintf(`m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), m.edited, COALESCE(m.buttons,''), %s`, snippetSQL(snippet))
 }
 
 func snippetSQL(snippet string) string {
@@ -557,8 +557,7 @@ func (d *DB) scanMessages(query string, args ...interface{}) ([]Message, error) 
 		var payloadPurgedAt int64
 		var buttonsJSON string
 		var edited int
-		var editedTs int64
-		if err := rows.Scan(&m.rowID, &m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &m.SenderName, &ts, &fromMe, &m.Text, &m.DisplayText, &m.QuotedMsgID, &m.QuotedSenderJID, &forwarded, &forwardingScore, &m.ReactionToID, &m.ReactionEmoji, &m.MediaType, &m.MediaCaption, &m.Filename, &m.MimeType, &m.DirectPath, &m.LocalPath, &downloadedAt, &starred, &starredAt, &revoked, &deletedForMe, &deletedAt, &deletionReason, &payloadPurgedAt, &buttonsJSON, &edited, &editedTs, &m.Snippet); err != nil {
+		if err := rows.Scan(&m.rowID, &m.ChatJID, &m.ChatName, &m.MsgID, &m.SenderJID, &m.SenderName, &ts, &fromMe, &m.Text, &m.DisplayText, &m.QuotedMsgID, &m.QuotedSenderJID, &forwarded, &forwardingScore, &m.ReactionToID, &m.ReactionEmoji, &m.MediaType, &m.MediaCaption, &m.Filename, &m.MimeType, &m.DirectPath, &m.LocalPath, &downloadedAt, &starred, &starredAt, &revoked, &deletedForMe, &deletedAt, &deletionReason, &payloadPurgedAt, &edited, &buttonsJSON, &m.Snippet); err != nil {
 			return nil, err
 		}
 		m.Timestamp = fromUnix(ts)
@@ -574,7 +573,6 @@ func (d *DB) scanMessages(query string, args ...interface{}) ([]Message, error) 
 		m.DeletionReason = deletionReason
 		m.PayloadPurgedAt = timePointerFromUnix(payloadPurgedAt)
 		m.Edited = edited != 0
-		m.EditedAt = timePointerFromUnix(editedTs)
 		if buttonsJSON != "" {
 			_ = json.Unmarshal([]byte(buttonsJSON), &m.Buttons)
 		}
@@ -590,7 +588,7 @@ func messageFromGetRow(row storedb.GetMessageRow) Message {
 		row.ForwardingScore, row.ReactionToID, row.ReactionEmoji, row.MediaType,
 		row.MediaCaption, row.Filename, row.MimeType, row.DirectPath, row.LocalPath,
 		row.DownloadedAt, row.Column24, row.StarredAt, row.Revoked, row.DeletedForMe,
-		row.DeletedAt, row.DeletionReason, row.PayloadPurgedAt, row.Buttons, row.Column32,
+		row.DeletedAt, row.DeletionReason, row.PayloadPurgedAt, row.Edited, row.Buttons, row.Column33,
 	)
 }
 
@@ -601,7 +599,7 @@ func messageFromBeforeRow(row storedb.MessageContextBeforeRow) Message {
 		row.ForwardingScore, row.ReactionToID, row.ReactionEmoji, row.MediaType,
 		row.MediaCaption, row.Filename, row.MimeType, row.DirectPath, row.LocalPath,
 		row.DownloadedAt, row.Column24, row.StarredAt, row.Revoked, row.DeletedForMe,
-		row.DeletedAt, row.DeletionReason, row.PayloadPurgedAt, row.Buttons, row.Column32,
+		row.DeletedAt, row.DeletionReason, row.PayloadPurgedAt, row.Edited, row.Buttons, row.Column33,
 	)
 }
 
@@ -612,11 +610,11 @@ func messageFromAfterRow(row storedb.MessageContextAfterRow) Message {
 		row.ForwardingScore, row.ReactionToID, row.ReactionEmoji, row.MediaType,
 		row.MediaCaption, row.Filename, row.MimeType, row.DirectPath, row.LocalPath,
 		row.DownloadedAt, row.Column24, row.StarredAt, row.Revoked, row.DeletedForMe,
-		row.DeletedAt, row.DeletionReason, row.PayloadPurgedAt, row.Buttons, row.Column32,
+		row.DeletedAt, row.DeletionReason, row.PayloadPurgedAt, row.Edited, row.Buttons, row.Column33,
 	)
 }
 
-func messageFromScalars(rowID int64, chatJID, chatName, msgID, senderJID, senderName string, ts, fromMe int64, text, displayText, quotedMsgID, quotedSenderJID string, forwarded, forwardingScore int64, reactionToID, reactionEmoji, mediaType, mediaCaption, filename, mimeType, directPath, localPath string, downloadedAt, starred, starredAt, revoked, deletedForMe, deletedAt int64, deletionReason string, payloadPurgedAt int64, buttonsJSON, snippet string) Message {
+func messageFromScalars(rowID int64, chatJID, chatName, msgID, senderJID, senderName string, ts, fromMe int64, text, displayText, quotedMsgID, quotedSenderJID string, forwarded, forwardingScore int64, reactionToID, reactionEmoji, mediaType, mediaCaption, filename, mimeType, directPath, localPath string, downloadedAt, starred, starredAt, revoked, deletedForMe, deletedAt int64, deletionReason string, payloadPurgedAt, edited int64, buttonsJSON, snippet string) Message {
 	m := Message{
 		rowID:           rowID,
 		ChatJID:         chatJID,
@@ -648,6 +646,7 @@ func messageFromScalars(rowID int64, chatJID, chatName, msgID, senderJID, sender
 		DeletedAt:       timePointerFromUnix(deletedAt),
 		DeletionReason:  deletionReason,
 		PayloadPurgedAt: timePointerFromUnix(payloadPurgedAt),
+		Edited:          edited != 0,
 		Snippet:         snippet,
 	}
 	if buttonsJSON != "" {

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -275,7 +275,7 @@ SET text = ?,
 WHERE chat_jid = ? AND msg_id = ? AND deleted_at IS NULL;
 
 -- name: GetMessage :one
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), m.edited, COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
@@ -299,7 +299,7 @@ ORDER BY m.ts DESC, m.rowid DESC
 LIMIT 1;
 
 -- name: MessageContextBefore :many
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), m.edited, COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
@@ -308,7 +308,7 @@ ORDER BY m.ts DESC, m.rowid DESC
 LIMIT ?;
 
 -- name: MessageContextAfter :many
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), m.edited, COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -474,7 +474,7 @@ func (q *Queries) GetMediaDownloadInfo(ctx context.Context, arg GetMediaDownload
 }
 
 const getMessage = `-- name: GetMessage :one
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), m.edited, COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
@@ -517,8 +517,9 @@ type GetMessageRow struct {
 	DeletedAt       int64
 	DeletionReason  string
 	PayloadPurgedAt int64
+	Edited          int64
 	Buttons         string
-	Column32        string
+	Column33        string
 }
 
 func (q *Queries) GetMessage(ctx context.Context, arg GetMessageParams) (GetMessageRow, error) {
@@ -555,8 +556,9 @@ func (q *Queries) GetMessage(ctx context.Context, arg GetMessageParams) (GetMess
 		&i.DeletedAt,
 		&i.DeletionReason,
 		&i.PayloadPurgedAt,
+		&i.Edited,
 		&i.Buttons,
-		&i.Column32,
+		&i.Column33,
 	)
 	return i, err
 }
@@ -1192,7 +1194,7 @@ func (q *Queries) MarkMessageRevoked(ctx context.Context, arg MarkMessageRevoked
 }
 
 const messageContextAfter = `-- name: MessageContextAfter :many
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), m.edited, COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
@@ -1240,8 +1242,9 @@ type MessageContextAfterRow struct {
 	DeletedAt       int64
 	DeletionReason  string
 	PayloadPurgedAt int64
+	Edited          int64
 	Buttons         string
-	Column32        string
+	Column33        string
 }
 
 func (q *Queries) MessageContextAfter(ctx context.Context, arg MessageContextAfterParams) ([]MessageContextAfterRow, error) {
@@ -1290,8 +1293,9 @@ func (q *Queries) MessageContextAfter(ctx context.Context, arg MessageContextAft
 			&i.DeletedAt,
 			&i.DeletionReason,
 			&i.PayloadPurgedAt,
+			&i.Edited,
 			&i.Buttons,
-			&i.Column32,
+			&i.Column33,
 		); err != nil {
 			return nil, err
 		}
@@ -1307,7 +1311,7 @@ func (q *Queries) MessageContextAfter(ctx context.Context, arg MessageContextAft
 }
 
 const messageContextBefore = `-- name: MessageContextBefore :many
-SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), COALESCE(m.buttons,''), ''
+SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), m.edited, COALESCE(m.buttons,''), ''
 FROM messages m
 LEFT JOIN chats c ON c.jid = m.chat_jid
 LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
@@ -1355,8 +1359,9 @@ type MessageContextBeforeRow struct {
 	DeletedAt       int64
 	DeletionReason  string
 	PayloadPurgedAt int64
+	Edited          int64
 	Buttons         string
-	Column32        string
+	Column33        string
 }
 
 func (q *Queries) MessageContextBefore(ctx context.Context, arg MessageContextBeforeParams) ([]MessageContextBeforeRow, error) {
@@ -1405,8 +1410,9 @@ func (q *Queries) MessageContextBefore(ctx context.Context, arg MessageContextBe
 			&i.DeletedAt,
 			&i.DeletionReason,
 			&i.PayloadPurgedAt,
+			&i.Edited,
 			&i.Buttons,
-			&i.Column32,
+			&i.Column33,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -95,6 +95,8 @@ type Message struct {
 	DownloadedAt    time.Time
 	Starred         bool
 	StarredAt       time.Time
+	Edited          bool
+	EditedAt        *time.Time `json:"edited_at,omitempty"`
 	Revoked         bool
 	DeletedForMe    bool
 	DeletedAt       *time.Time `json:"deleted_at,omitempty"`

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -96,7 +96,6 @@ type Message struct {
 	Starred         bool
 	StarredAt       time.Time
 	Edited          bool
-	EditedAt        *time.Time `json:"edited_at,omitempty"`
 	Revoked         bool
 	DeletedForMe    bool
 	DeletedAt       *time.Time `json:"deleted_at,omitempty"`


### PR DESCRIPTION
Follow-up to #343, where exposing persisted edit state was identified as a separate output enhancement.

## The gap

The store has written the `messages.edited` flag since migration 16, but message read paths did not return it. Consumers therefore had to inspect SQLite directly to distinguish edited messages from untouched ones.

## What this does

- Adds `Edited` to the message output type.
- Hydrates it through list and search's shared scanner.
- Hydrates it through the independent sqlc-backed show and context queries.
- Covers list, search, show, and both sides of context with store-level regression fixtures.

The branch deliberately does not expose `edited_ts`. Existing writers give that column two meanings: synced edits record the message timestamp, while local CLI edits record the edit wall-clock time. Publishing it as `edited_at` would create an unreliable public contract.

## Proof

The full local gate passes:

```text
pnpm format:check
pnpm lint
pnpm test
pnpm build
git diff --check
```

A freshly built `dist/wacli` was also exercised with `--read-only` against a synthetic SQLite store containing edited rows. `messages list`, `messages search`, `messages show`, and `messages context` all returned `Edited:true` for the same fixture messages. No WhatsApp authentication, network calls, or sends were used.
