### PR TITLE
fix(sync): normalize stored group identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Sync: identify unhandled payload types when content extraction produces a placeholder, with bounded diagnostics during history replay. (#344 - thanks @dvainrub)
 
+### Fixed
+
+- Sync: normalize resolvable LIDs in group owners, participants, and quoted senders, including historical store repair. (#348 - thanks @hchittanuru3)
+
 ### Chore
 
 - Dependencies: update `whatsmeow` for current socket headers, LID history tokens, status queries, and group creation behavior.

--- a/cmd/wacli/groups_admin.go
+++ b/cmd/wacli/groups_admin.go
@@ -75,7 +75,7 @@ func newGroupsCreateCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			if info != nil {
-				_ = persistGroupInfo(a.DB(), info)
+				_ = persistGroupInfo(ctx, a.DB(), a.WA(), info)
 			}
 
 			if flags.asJSON {
@@ -135,7 +135,7 @@ func newGroupsTopicCmd(flags *rootFlags, use string) *cobra.Command {
 				return err
 			}
 			if info, err := a.WA().GetGroupInfo(ctx, gjid); err == nil && info != nil {
-				_ = persistGroupInfo(a.DB(), info)
+				_ = persistGroupInfo(ctx, a.DB(), a.WA(), info)
 			}
 			if flags.asJSON {
 				return out.WriteJSON(os.Stdout, map[string]any{"jid": gjid.String(), "topic": text})
@@ -202,7 +202,7 @@ func newGroupsToggleCmd(flags *rootFlags, use, short string, apply func(context.
 				return err
 			}
 			if info, err := a.WA().GetGroupInfo(ctx, gjid); err == nil && info != nil {
-				_ = persistGroupInfo(a.DB(), info)
+				_ = persistGroupInfo(ctx, a.DB(), a.WA(), info)
 			}
 			if flags.asJSON {
 				return out.WriteJSON(os.Stdout, map[string]any{"jid": gjid.String(), jsonKey: enabled})
@@ -343,7 +343,7 @@ func newGroupsRequestsActionCmd(flags *rootFlags, action string) *cobra.Command 
 				return err
 			}
 			if info, err := a.WA().GetGroupInfo(ctx, gjid); err == nil && info != nil {
-				_ = persistGroupInfo(a.DB(), info)
+				_ = persistGroupInfo(ctx, a.DB(), a.WA(), info)
 			}
 
 			if flags.asJSON {

--- a/cmd/wacli/groups_info_rename.go
+++ b/cmd/wacli/groups_info_rename.go
@@ -52,7 +52,7 @@ func newGroupsInfoCmd(flags *rootFlags) *cobra.Command {
 				return fmt.Errorf("group info not found for %s", gjid.String())
 			}
 			if info != nil {
-				_ = persistGroupInfo(a.DB(), info)
+				_ = persistGroupInfo(ctx, a.DB(), a.WA(), info)
 			}
 
 			if flags.asJSON {
@@ -116,7 +116,7 @@ func newGroupsRenameCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			if info, err := a.WA().GetGroupInfo(ctx, gjid); err == nil && info != nil {
-				_ = persistGroupInfo(a.DB(), info)
+				_ = persistGroupInfo(ctx, a.DB(), a.WA(), info)
 			}
 			if flags.asJSON {
 				return out.WriteJSON(os.Stdout, map[string]any{"jid": gjid.String(), "name": name})

--- a/cmd/wacli/groups_invite_join.go
+++ b/cmd/wacli/groups_invite_join.go
@@ -151,7 +151,7 @@ func newGroupsJoinCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			if info, err := a.WA().GetGroupInfo(ctx, jid); err == nil && info != nil {
-				_ = persistGroupInfo(a.DB(), info)
+				_ = persistGroupInfo(ctx, a.DB(), a.WA(), info)
 			}
 			if flags.asJSON {
 				return out.WriteJSON(os.Stdout, map[string]any{"jid": jid.String(), "joined": true})

--- a/cmd/wacli/groups_participants.go
+++ b/cmd/wacli/groups_participants.go
@@ -71,7 +71,7 @@ func newGroupsParticipantsActionCmd(flags *rootFlags, action string) *cobra.Comm
 				return err
 			}
 			if info, err := a.WA().GetGroupInfo(ctx, gjid); err == nil && info != nil {
-				_ = persistGroupInfo(a.DB(), info)
+				_ = persistGroupInfo(ctx, a.DB(), a.WA(), info)
 			}
 
 			if flags.asJSON {

--- a/cmd/wacli/groups_persist.go
+++ b/cmd/wacli/groups_persist.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+
 	"github.com/openclaw/wacli/internal/store"
 	"go.mau.fi/whatsmeow/types"
 )
@@ -12,14 +14,19 @@ func canonicalCLIJID(jid types.JID) types.JID {
 	return jid
 }
 
-func persistGroupInfo(db *store.DB, info *types.GroupInfo) error {
+type groupJIDResolver interface {
+	ResolveLIDToPN(context.Context, types.JID) types.JID
+}
+
+func persistGroupInfo(ctx context.Context, db *store.DB, resolver groupJIDResolver, info *types.GroupInfo) error {
 	if info == nil {
 		return nil
 	}
+	ownerJID := canonicalCLIJID(resolver.ResolveLIDToPN(ctx, info.OwnerJID)).String()
 	if err := db.UpsertGroupWithHierarchy(
 		info.JID.String(),
 		info.GroupName.Name,
-		info.OwnerJID.String(),
+		ownerJID,
 		info.GroupCreated,
 		info.IsParent,
 		info.LinkedParentJID.String(),
@@ -36,7 +43,7 @@ func persistGroupInfo(db *store.DB, info *types.GroupInfo) error {
 		}
 		ps = append(ps, store.GroupParticipant{
 			GroupJID: info.JID.String(),
-			UserJID:  canonicalCLIJID(p.JID).String(),
+			UserJID:  canonicalCLIJID(resolver.ResolveLIDToPN(ctx, p.JID)).String(),
 			Role:     role,
 		})
 	}

--- a/cmd/wacli/groups_persist_test.go
+++ b/cmd/wacli/groups_persist_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openclaw/wacli/internal/store"
+	"go.mau.fi/whatsmeow/types"
+)
+
+type groupPersistResolver map[types.JID]types.JID
+
+func (r groupPersistResolver) ResolveLIDToPN(_ context.Context, jid types.JID) types.JID {
+	if resolved, ok := r[jid.ToNonAD()]; ok {
+		return resolved
+	}
+	return jid
+}
+
+func TestPersistGroupInfoResolvesKnownLIDs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wacli.db")
+	db, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	group := types.JID{User: "120363000000", Server: types.GroupServer}
+	knownLID := types.JID{User: "999123456789", Server: types.HiddenUserServer}
+	knownPN := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+	unknownLID := types.JID{User: "888123456789", Server: types.HiddenUserServer}
+	info := &types.GroupInfo{
+		JID:       group,
+		OwnerJID:  knownLID,
+		GroupName: types.GroupName{Name: "Project"},
+		Participants: []types.GroupParticipant{
+			{JID: knownLID, IsAdmin: true},
+			{JID: unknownLID},
+		},
+		GroupCreated: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	resolver := groupPersistResolver{knownLID: knownPN}
+	if err := persistGroupInfo(context.Background(), db, resolver, info); err != nil {
+		t.Fatalf("persistGroupInfo: %v", err)
+	}
+
+	groups, err := db.ListGroups("Project", 1)
+	if err != nil {
+		t.Fatalf("ListGroups: %v", err)
+	}
+	if len(groups) != 1 || groups[0].OwnerJID != knownPN.String() {
+		t.Fatalf("groups = %+v, want owner %q", groups, knownPN.String())
+	}
+
+	raw, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer raw.Close()
+	rows, err := raw.Query(`SELECT user_jid, role FROM group_participants WHERE group_jid = ?`, group.String())
+	if err != nil {
+		t.Fatalf("query participants: %v", err)
+	}
+	defer rows.Close()
+	got := map[string]string{}
+	for rows.Next() {
+		var jid, role string
+		if err := rows.Scan(&jid, &role); err != nil {
+			t.Fatalf("scan participant: %v", err)
+		}
+		got[jid] = role
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("participants rows: %v", err)
+	}
+	if got[knownPN.String()] != "admin" || got[unknownLID.String()] != "member" || len(got) != 2 {
+		t.Fatalf("participants = %#v", got)
+	}
+}

--- a/cmd/wacli/groups_refresh_list.go
+++ b/cmd/wacli/groups_refresh_list.go
@@ -45,7 +45,7 @@ func newGroupsRefreshCmd(flags *rootFlags) *cobra.Command {
 					continue
 				}
 				joined[g.JID.String()] = true
-				_ = persistGroupInfo(a.DB(), g)
+				_ = persistGroupInfo(ctx, a.DB(), a.WA(), g)
 				_ = a.DB().UpsertChatMetadata(g.JID.String(), "group", g.GroupName.Name)
 			}
 			if err := a.DB().MarkGroupsMissingFrom(joined, now); err != nil {

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -43,7 +43,8 @@ func (a *App) refreshGroups(ctx context.Context) error {
 			continue
 		}
 		joined[g.JID.String()] = true
-		_ = a.db.UpsertGroupWithHierarchy(g.JID.String(), g.GroupName.Name, g.OwnerJID.String(), g.GroupCreated, g.IsParent, g.LinkedParentJID.String())
+		ownerJID := a.canonicalStoreJID(ctx, g.OwnerJID).String()
+		_ = a.db.UpsertGroupWithHierarchy(g.JID.String(), g.GroupName.Name, ownerJID, g.GroupCreated, g.IsParent, g.LinkedParentJID.String())
 		_ = a.db.UpsertChatMetadata(g.JID.String(), "group", g.GroupName.Name)
 	}
 	return a.db.MarkGroupsMissingFrom(joined, now)

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -39,10 +39,13 @@ func TestRefreshGroupsStoresGroupsAndChats(t *testing.T) {
 	a.wa = f
 
 	gid := types.JID{User: "12345", Server: types.GroupServer}
+	ownerLID := types.JID{User: "999123456789", Server: types.HiddenUserServer}
+	ownerPN := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+	f.lids[ownerLID] = ownerPN
 	created := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	f.groups[gid] = &types.GroupInfo{
 		JID:               gid,
-		OwnerJID:          types.JID{User: "999", Server: types.DefaultUserServer},
+		OwnerJID:          ownerLID,
 		GroupName:         types.GroupName{Name: "MyGroup"},
 		GroupCreated:      created,
 		GroupLinkedParent: types.GroupLinkedParent{LinkedParentJID: types.JID{User: "parent", Server: types.GroupServer}},
@@ -60,6 +63,9 @@ func TestRefreshGroupsStoresGroupsAndChats(t *testing.T) {
 	}
 	if gs[0].LinkedParentJID != "parent@g.us" {
 		t.Fatalf("expected linked parent to be stored, got %+v", gs[0])
+	}
+	if gs[0].OwnerJID != ownerPN.String() {
+		t.Fatalf("OwnerJID = %q, want %q", gs[0].OwnerJID, ownerPN.String())
 	}
 	c, err := a.db.GetChat(gid.String())
 	if err != nil {

--- a/internal/app/jid.go
+++ b/internal/app/jid.go
@@ -20,3 +20,11 @@ func canonicalJIDString(jid types.JID) string {
 func (a *App) canonicalStoreJID(ctx context.Context, jid types.JID) types.JID {
 	return canonicalJID(a.wa.ResolveLIDToPN(ctx, jid))
 }
+
+func (a *App) canonicalStoreJIDString(ctx context.Context, raw string) string {
+	jid, err := types.ParseJID(raw)
+	if err != nil {
+		return raw
+	}
+	return a.canonicalStoreJID(ctx, jid).String()
+}

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -452,7 +452,8 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 	// Best-effort: store group metadata (and participants) when available.
 	if pm.Chat.Server == types.GroupServer {
 		if gi, err := a.wa.GetGroupInfo(ctx, pm.Chat); err == nil && gi != nil {
-			_ = a.db.UpsertGroupWithHierarchy(gi.JID.String(), gi.GroupName.Name, gi.OwnerJID.String(), gi.GroupCreated, gi.IsParent, gi.LinkedParentJID.String())
+			ownerJID := a.canonicalStoreJID(ctx, gi.OwnerJID).String()
+			_ = a.db.UpsertGroupWithHierarchy(gi.JID.String(), gi.GroupName.Name, ownerJID, gi.GroupCreated, gi.IsParent, gi.LinkedParentJID.String())
 			var ps []store.GroupParticipant
 			for _, p := range gi.Participants {
 				role := "member"
@@ -463,7 +464,7 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 				}
 				ps = append(ps, store.GroupParticipant{
 					GroupJID: pm.Chat.String(),
-					UserJID:  canonicalJIDString(p.JID),
+					UserJID:  a.canonicalStoreJID(ctx, p.JID).String(),
 					Role:     role,
 				})
 			}
@@ -522,7 +523,7 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 		Text:            pm.Text,
 		DisplayText:     displayText,
 		QuotedMsgID:     pm.ReplyToID,
-		QuotedSenderJID: pm.ReplyToSenderJID,
+		QuotedSenderJID: a.canonicalStoreJIDString(ctx, pm.ReplyToSenderJID),
 		Buttons:         waButtonsToStore(pm.Buttons),
 		IsForwarded:     pm.IsForwarded,
 		ForwardingScore: pm.ForwardingScore,

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -2991,6 +2991,67 @@ func TestStoreParsedMessageResolvesLIDChatAndSender(t *testing.T) {
 	}
 }
 
+func TestStoreParsedMessageResolvesGroupIdentityLIDs(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	group := types.JID{User: "120363000000", Server: types.GroupServer}
+	lid := types.JID{User: "999123456789", Server: types.HiddenUserServer}
+	pn := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+	f.lids[lid] = pn
+	f.groups[group] = &types.GroupInfo{
+		JID:       group,
+		OwnerJID:  lid,
+		GroupName: types.GroupName{Name: "Project"},
+		Participants: []types.GroupParticipant{{
+			JID:     lid,
+			IsAdmin: true,
+		}},
+	}
+
+	err := a.storeParsedMessage(context.Background(), wa.ParsedMessage{
+		Chat:             group,
+		ID:               "m-group-lid",
+		SenderJID:        lid.String(),
+		ReplyToID:        "quoted",
+		ReplyToSenderJID: lid.String(),
+		Timestamp:        time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		Text:             "hello",
+	})
+	if err != nil {
+		t.Fatalf("storeParsedMessage: %v", err)
+	}
+
+	msg, err := a.db.GetMessage(group.String(), "m-group-lid")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if msg.SenderJID != pn.String() || msg.QuotedSenderJID != pn.String() {
+		t.Fatalf("message identities = sender %q quoted %q, want %q", msg.SenderJID, msg.QuotedSenderJID, pn.String())
+	}
+	groups, err := a.db.ListGroups("Project", 1)
+	if err != nil {
+		t.Fatalf("ListGroups: %v", err)
+	}
+	if len(groups) != 1 || groups[0].OwnerJID != pn.String() {
+		t.Fatalf("stored group = %+v, want owner %q", groups, pn.String())
+	}
+
+	raw, err := sql.Open("sqlite3", filepath.Join(a.opts.StoreDir, "wacli.db"))
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer raw.Close()
+	var participantJID string
+	if err := raw.QueryRow(`SELECT user_jid FROM group_participants WHERE group_jid = ?`, group.String()).Scan(&participantJID); err != nil {
+		t.Fatalf("query participant: %v", err)
+	}
+	if participantJID != pn.String() {
+		t.Fatalf("participant JID = %q, want %q", participantJID, pn.String())
+	}
+}
+
 func TestStoreParsedMessageStoresForwardedMetadata(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()

--- a/internal/store/lid_migration.go
+++ b/internal/store/lid_migration.go
@@ -16,8 +16,8 @@ type MessageLocalMedia struct {
 	LocalPath string
 }
 
-// HistoricalLIDJIDs returns distinct hidden-user JIDs stored in chat and
-// message/poll identity columns. The app layer resolves these through whatsmeow.
+// HistoricalLIDJIDs returns distinct hidden-user JIDs stored in chat, group,
+// message, and poll identity columns. The app layer resolves these through whatsmeow.
 func (d *DB) HistoricalLIDJIDs() ([]string, error) {
 	rows, err := d.sql.Query(`
 		SELECT jid FROM chats WHERE jid GLOB '*@lid'
@@ -27,6 +27,10 @@ func (d *DB) HistoricalLIDJIDs() ([]string, error) {
 		SELECT sender_jid FROM messages WHERE sender_jid GLOB '*@lid'
 		UNION
 		SELECT quoted_sender_jid FROM messages WHERE quoted_sender_jid GLOB '*@lid'
+		UNION
+		SELECT owner_jid FROM groups WHERE owner_jid GLOB '*@lid'
+		UNION
+		SELECT user_jid FROM group_participants WHERE user_jid GLOB '*@lid'
 		UNION
 		SELECT chat_jid FROM polls WHERE chat_jid GLOB '*@lid'
 		UNION
@@ -96,6 +100,9 @@ func (d *DB) MigrateLIDToPN(lidJID, pnJID string) error {
 		return err
 	}
 	if err := migrateLIDSenderToPN(tx, lidJID, pnJID); err != nil {
+		return err
+	}
+	if err := migrateLIDGroupIdentitiesToPN(tx, lidJID, pnJID); err != nil {
 		return err
 	}
 	if err := migrateLIDMessageLocationsToPN(tx, lidJID, pnJID); err != nil {
@@ -431,6 +438,30 @@ func migrateLIDSenderToPN(tx *sql.Tx, lidJID, pnJID string) error {
 	}
 	if _, err := tx.Exec(`UPDATE messages SET quoted_sender_jid = ? WHERE quoted_sender_jid = ?`, pnJID, lidJID); err != nil {
 		return fmt.Errorf("rewrite lid quoted message senders: %w", err)
+	}
+	return nil
+}
+
+func migrateLIDGroupIdentitiesToPN(tx *sql.Tx, lidJID, pnJID string) error {
+	if _, err := tx.Exec(`UPDATE groups SET owner_jid = ? WHERE owner_jid = ?`, pnJID, lidJID); err != nil {
+		return fmt.Errorf("rewrite lid group owners: %w", err)
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO group_participants(group_jid, user_jid, role, updated_at)
+		SELECT group_jid, ?, role, updated_at
+		FROM group_participants
+		WHERE user_jid = ?
+		ON CONFLICT(group_jid, user_jid) DO UPDATE SET
+			role = CASE
+				WHEN excluded.updated_at >= group_participants.updated_at THEN excluded.role
+				ELSE group_participants.role
+			END,
+			updated_at = max(group_participants.updated_at, excluded.updated_at)
+	`, pnJID, lidJID); err != nil {
+		return fmt.Errorf("merge lid group participants: %w", err)
+	}
+	if _, err := tx.Exec(`DELETE FROM group_participants WHERE user_jid = ?`, lidJID); err != nil {
+		return fmt.Errorf("delete lid group participants: %w", err)
 	}
 	return nil
 }

--- a/internal/store/lid_migration_test.go
+++ b/internal/store/lid_migration_test.go
@@ -70,6 +70,30 @@ func TestHistoricalLIDJIDsFindsChatAndMessageColumns(t *testing.T) {
 	}
 }
 
+func TestHistoricalLIDJIDsFindsGroupIdentities(t *testing.T) {
+	db := openTestDB(t)
+	lid := "999123456789@lid"
+	group := "120363000000@g.us"
+	if err := db.UpsertGroup(group, "Project", lid, time.Time{}); err != nil {
+		t.Fatalf("UpsertGroup: %v", err)
+	}
+	if err := db.ReplaceGroupParticipants(group, []GroupParticipant{{
+		GroupJID: group,
+		UserJID:  lid,
+		Role:     "admin",
+	}}); err != nil {
+		t.Fatalf("ReplaceGroupParticipants: %v", err)
+	}
+
+	got, err := db.HistoricalLIDJIDs()
+	if err != nil {
+		t.Fatalf("HistoricalLIDJIDs: %v", err)
+	}
+	if want := []string{lid}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("HistoricalLIDJIDs = %#v, want %#v", got, want)
+	}
+}
+
 func TestHistoricalLIDJIDsFindsPurgeLedgerOnlyIdentity(t *testing.T) {
 	db := openTestDB(t)
 	lid := "888123456789@lid"
@@ -314,6 +338,52 @@ func TestMigrateLIDToPNMergesChatsAndMessages(t *testing.T) {
 	}
 	if len(lids) != 0 {
 		t.Fatalf("HistoricalLIDJIDs after migrate = %#v, want none", lids)
+	}
+}
+
+func TestMigrateLIDToPNMergesGroupIdentities(t *testing.T) {
+	db := openTestDB(t)
+	lid := "999123456789@lid"
+	pn := "15551234567@s.whatsapp.net"
+	group := "120363000000@g.us"
+	if err := db.UpsertGroup(group, "Project", lid, time.Time{}); err != nil {
+		t.Fatalf("UpsertGroup: %v", err)
+	}
+	if _, err := db.sql.Exec(`
+		INSERT INTO group_participants(group_jid, user_jid, role, updated_at)
+		VALUES (?, ?, 'member', 1), (?, ?, 'admin', 2)
+	`, group, pn, group, lid); err != nil {
+		t.Fatalf("insert participants: %v", err)
+	}
+
+	if err := db.MigrateLIDToPN(lid, pn); err != nil {
+		t.Fatalf("MigrateLIDToPN: %v", err)
+	}
+	if err := db.MigrateLIDToPN(lid, pn); err != nil {
+		t.Fatalf("MigrateLIDToPN idempotent: %v", err)
+	}
+
+	groups, err := db.ListGroups("Project", 1)
+	if err != nil {
+		t.Fatalf("ListGroups: %v", err)
+	}
+	if len(groups) != 1 || groups[0].OwnerJID != pn {
+		t.Fatalf("groups = %+v, want owner %q", groups, pn)
+	}
+	if got := countRows(t, db.sql, "SELECT COUNT(*) FROM group_participants WHERE group_jid = ?", group); got != 1 {
+		t.Fatalf("participant rows = %d, want 1", got)
+	}
+	var userJID, role string
+	var updatedAt int64
+	if err := db.sql.QueryRow(`
+		SELECT user_jid, role, updated_at
+		FROM group_participants
+		WHERE group_jid = ?
+	`, group).Scan(&userJID, &role, &updatedAt); err != nil {
+		t.Fatalf("query participant: %v", err)
+	}
+	if userJID != pn || role != "admin" || updatedAt != 2 {
+		t.Fatalf("participant = (%q, %q, %d), want (%q, admin, 2)", userJID, role, updatedAt, pn)
 	}
 }
 


### PR DESCRIPTION
Fixes #348.

## What changed

- Resolve known LIDs to canonical phone JIDs before storing quoted senders, group owners, and group participants during sync.
- Apply the same normalization during group bootstrap refresh and every CLI group operation that persists returned group info.
- Preserve unresolved LIDs unchanged instead of dropping rows.
- Extend the existing historical LID migration to discover group owner/participant identities and repair them transactionally.
- Merge participant primary-key collisions by keeping the newest role and update timestamp, then remove the obsolete LID row.

This keeps roster, message sender, quoted sender, and group owner identities in the same namespace without making consumers read whatsmeow's private session database.

## Proof

The full repository gate passes:

```text
pnpm format:check
pnpm lint
pnpm test
pnpm build
git diff --check
```

Regression coverage includes sync-time owner/participant/quoted-sender normalization, bootstrap owner normalization, all shared CLI group persistence, historical discovery, migration idempotency, and participant collision merging.

A freshly built `dist/wacli` was also exercised with `--read-only` against a synthetic group/message store. `groups list --json` returned the phone JID owner, and a roster-to-message join matched `group_participants.user_jid`, `messages.sender_jid`, and `messages.quoted_sender_jid` on the same phone JID. Per the maintainer constraint, no live WhatsApp authentication, network connection, or send was used.
