### PR TITLE
fix(sync): normalize webhook LID identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Sync: normalize resolvable LIDs in message, receipt, and chat-presence webhook payloads to match stored identities. (#352 - thanks @hchittanuru3)
+
 ## v0.17.0 - 2026-08-13
 
 **Highlight:** group identities are finally stable — resolvable LIDs are

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -26,7 +26,7 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-t
 - `--refresh-channels` fetches subscribed WhatsApp Channels live and updates local chat rows.
 - `--webhook URL` posts successfully stored live message events as JSON on a bounded background worker. The payload includes `ChatName` when a locally resolved chat name is available.
 - `--webhook-secret SECRET` signs webhook payloads with `X-Wacli-Signature: sha256=<hmac>`.
-- `--webhook-events LIST` selects which event types are posted, as a comma-separated list of `message`, `receipt`, and `chat_presence`. The default is `message`, which posts exactly what earlier versions posted. A list that omits `message` stops message posts, so `--webhook-events receipt` posts receipts only. `chat_presence` needs `--presence-mode normal` (the default): WhatsApp only sends typing notifications to devices that mark themselves available. See [Webhook payloads](#webhook-payloads).
+- `--webhook-events LIST` selects which event types are posted, as a comma-separated list of `message`, `receipt`, and `chat_presence`. The default is `message`, which preserves the earlier message event shape. A list that omits `message` stops message posts, so `--webhook-events receipt` posts receipts only. `chat_presence` needs `--presence-mode normal` (the default): WhatsApp only sends typing notifications to devices that mark themselves available. See [Webhook payloads](#webhook-payloads).
 - Webhook delivery is best-effort: failures, request timeouts, and full-queue drops are logged as warnings and do not stop sync. Retries/backoff are intentionally out of scope for this flag.
 - If neither storage cap is configured, sync prints one warning because WhatsApp history can grow the local database substantially.
 - `WACLI_SYNC_MAX_MESSAGES` and `WACLI_SYNC_MAX_DB_SIZE` apply the same caps to `auth` bootstrap sync and `sync`.
@@ -48,10 +48,11 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-t
 
 Webhook payloads remain flat JSON objects. Receipt and chat-presence payloads carry
 an `EventType` discriminator. Message payloads deliberately omit it so existing
-consumers receive the same signed body as before; a missing `EventType` means
-`message`.
+consumers retain the established object shape; a missing `EventType` means
+`message`. Every JID field uses the same identity namespace as the local store:
+known LIDs are resolved to phone JIDs, while unknown LIDs remain unchanged.
 
-Messages use the stored live message payload documented above, unchanged:
+Messages use the stored live message payload documented above:
 
 ```json
 {"Chat":"15551234567@s.whatsapp.net","ID":"3EB0…","SenderJID":"15551234567@s.whatsapp.net","Timestamp":"2026-07-25T10:00:00Z","FromMe":false,"Text":"hi","ChatName":"Alice"}

--- a/internal/app/webhook.go
+++ b/internal/app/webhook.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/openclaw/wacli/internal/linkpreview"
 	"github.com/openclaw/wacli/internal/wa"
+	"go.mau.fi/whatsmeow/types"
 )
 
 var syncWebhookPrivateHTTPClient = &http.Client{
@@ -180,20 +181,24 @@ func (a *App) postSyncWebhookEvent(ctx context.Context, opts SyncOptions, evt sy
 func (a *App) newSyncWebhookEventPayload(ctx context.Context, evt syncWebhookEvent) any {
 	switch evt.Kind {
 	case SyncWebhookEventReceipt:
-		return syncWebhookReceiptPayload{EventType: SyncWebhookEventReceipt, syncWebhookReceipt: evt.Receipt}
+		receipt := evt.Receipt
+		receipt.Chat = a.canonicalWebhookJID(ctx, receipt.Chat)
+		receipt.Sender = a.canonicalWebhookJID(ctx, receipt.Sender)
+		return syncWebhookReceiptPayload{EventType: SyncWebhookEventReceipt, syncWebhookReceipt: receipt}
 	case SyncWebhookEventChatPresence:
-		return syncWebhookChatPresencePayload{EventType: SyncWebhookEventChatPresence, syncWebhookChatPresence: evt.Presence}
+		presence := evt.Presence
+		presence.Chat = a.canonicalWebhookJID(ctx, presence.Chat)
+		presence.Sender = a.canonicalWebhookJID(ctx, presence.Sender)
+		return syncWebhookChatPresencePayload{EventType: SyncWebhookEventChatPresence, syncWebhookChatPresence: presence}
 	default:
 		return a.newSyncWebhookPayload(ctx, evt.Message)
 	}
 }
 
 func (a *App) newSyncWebhookPayload(ctx context.Context, pm wa.ParsedMessage) syncWebhookPayload {
+	pm = a.canonicalWebhookMessage(ctx, pm)
 	payload := syncWebhookPayload{ParsedMessage: pm}
 	chatJID := canonicalJIDString(pm.Chat)
-	if a.wa != nil {
-		chatJID = canonicalJIDString(a.canonicalStoreJID(ctx, pm.Chat))
-	}
 	if chatJID != "" && a.db != nil {
 		chat, err := a.db.GetChat(chatJID)
 		if err != nil {
@@ -202,6 +207,55 @@ func (a *App) newSyncWebhookPayload(ctx context.Context, pm wa.ParsedMessage) sy
 		payload.ChatName = chat.Name
 	}
 	return payload
+}
+
+func (a *App) canonicalWebhookMessage(ctx context.Context, pm wa.ParsedMessage) wa.ParsedMessage {
+	pm.Chat = a.canonicalWebhookJID(ctx, pm.Chat)
+	pm.SenderJID = a.canonicalWebhookJIDString(ctx, pm.SenderJID)
+	pm.ReplyToSenderJID = a.canonicalWebhookJIDString(ctx, pm.ReplyToSenderJID)
+
+	if pm.PollVote != nil {
+		pollVote := *pm.PollVote
+		pollVote.PollChatJID = a.canonicalWebhookJIDString(ctx, pollVote.PollChatJID)
+		pollVote.PollSenderJID = a.canonicalWebhookJIDString(ctx, pollVote.PollSenderJID)
+		pm.PollVote = &pollVote
+	}
+	if pm.PollAdd != nil {
+		pollAdd := *pm.PollAdd
+		pollAdd.PollChatJID = a.canonicalWebhookJIDString(ctx, pollAdd.PollChatJID)
+		pollAdd.PollSenderJID = a.canonicalWebhookJIDString(ctx, pollAdd.PollSenderJID)
+		pm.PollAdd = &pollAdd
+	}
+	if pm.Call != nil {
+		call := *pm.Call
+		call.Chat = pm.Chat
+		if call.SenderJID == "" {
+			call.SenderJID = pm.SenderJID
+		} else {
+			call.SenderJID = a.canonicalWebhookJIDString(ctx, call.SenderJID)
+		}
+		call.Participants = append([]wa.ParsedCallParticipant(nil), call.Participants...)
+		for i := range call.Participants {
+			call.Participants[i].JID = a.canonicalWebhookJIDString(ctx, call.Participants[i].JID)
+		}
+		pm.Call = &call
+	}
+	return pm
+}
+
+func (a *App) canonicalWebhookJID(ctx context.Context, jid types.JID) types.JID {
+	if a.wa == nil {
+		return canonicalJID(jid)
+	}
+	return a.canonicalStoreJID(ctx, jid)
+}
+
+func (a *App) canonicalWebhookJIDString(ctx context.Context, raw string) string {
+	jid, err := types.ParseJID(raw)
+	if err != nil {
+		return raw
+	}
+	return a.canonicalWebhookJID(ctx, jid).String()
 }
 
 func newSyncWebhookRequest(ctx context.Context, webhookURL, secret, version string, payload []byte) (*http.Request, error) {

--- a/internal/app/webhook_events.go
+++ b/internal/app/webhook_events.go
@@ -12,7 +12,7 @@ import (
 
 // SyncWebhookEventKind identifies the selected webhook event kind. New event
 // payloads carry it as "EventType"; message payloads deliberately omit it to
-// preserve the established webhook body byte-for-byte.
+// preserve the established webhook shape.
 type SyncWebhookEventKind string
 
 const (

--- a/internal/app/webhook_events_test.go
+++ b/internal/app/webhook_events_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -227,6 +229,115 @@ func TestMessageWebhookPayloadMatchesLegacyBody(t *testing.T) {
 	}
 	if !bytes.Equal(got, legacy) {
 		t.Fatalf("message payload changed\ngot:  %s\nwant: %s", got, legacy)
+	}
+}
+
+func TestSyncWebhookPayloadNormalizesResolvableLIDs(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	lid := types.JID{User: "999123456789", Server: types.HiddenUserServer}
+	pn := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+	f.lids[lid] = pn
+	ctx := context.Background()
+
+	message := wa.ParsedMessage{
+		Chat:             lid,
+		ID:               "m-lid",
+		SenderJID:        lid.String(),
+		ReplyToSenderJID: lid.String(),
+		PollVote: &wa.PollVoteRef{
+			PollChatJID:   lid.String(),
+			PollSenderJID: lid.String(),
+		},
+		PollAdd: &wa.PollAddOptionRef{
+			PollChatJID:   lid.String(),
+			PollSenderJID: lid.String(),
+		},
+		Call: &wa.ParsedCallEvent{
+			Chat:      lid,
+			SenderJID: lid.String(),
+			Participants: []wa.ParsedCallParticipant{{
+				JID: lid.String(),
+			}},
+		},
+	}
+	assertSyncWebhookPayloadJIDs(t, a.newSyncWebhookEventPayload(ctx, syncWebhookEvent{
+		Kind:    SyncWebhookEventMessage,
+		Message: message,
+	}), pn.String(), []string{
+		"Chat", "SenderJID", "ReplyToSenderJID",
+		"PollVote.PollChatJID", "PollVote.PollSenderJID",
+		"PollAdd.PollChatJID", "PollAdd.PollSenderJID",
+		"Call.Chat", "Call.SenderJID", "Call.Participants.0.JID",
+	})
+
+	assertSyncWebhookPayloadJIDs(t, a.newSyncWebhookEventPayload(ctx, syncWebhookEvent{
+		Kind: SyncWebhookEventReceipt,
+		Receipt: syncWebhookReceipt{
+			Chat:       lid,
+			Sender:     lid,
+			MessageIDs: []string{"m-lid"},
+			Type:       "read",
+		},
+	}), pn.String(), []string{"Chat", "Sender"})
+
+	assertSyncWebhookPayloadJIDs(t, a.newSyncWebhookEventPayload(ctx, syncWebhookEvent{
+		Kind: SyncWebhookEventChatPresence,
+		Presence: syncWebhookChatPresence{
+			Chat:   lid,
+			Sender: lid,
+			State:  "composing",
+		},
+	}), pn.String(), []string{"Chat", "Sender"})
+}
+
+func TestSyncWebhookPayloadPreservesUnresolvedLIDs(t *testing.T) {
+	a := newTestApp(t)
+	a.wa = newFakeWA()
+	lid := types.JID{User: "999123456789", Server: types.HiddenUserServer}
+
+	assertSyncWebhookPayloadJIDs(t, a.newSyncWebhookEventPayload(context.Background(), syncWebhookEvent{
+		Kind: SyncWebhookEventReceipt,
+		Receipt: syncWebhookReceipt{
+			Chat:       lid,
+			Sender:     lid,
+			MessageIDs: []string{"m-lid"},
+			Type:       "read",
+		},
+	}), lid.String(), []string{"Chat", "Sender"})
+}
+
+func assertSyncWebhookPayloadJIDs(t *testing.T, payload any, want string, paths []string) {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal webhook payload: %v", err)
+	}
+	var decoded any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("unmarshal webhook payload: %v", err)
+	}
+	for _, path := range paths {
+		value := decoded
+		for _, part := range strings.Split(path, ".") {
+			switch current := value.(type) {
+			case map[string]any:
+				value = current[part]
+			case []any:
+				index, err := strconv.Atoi(part)
+				if err != nil || index >= len(current) {
+					t.Fatalf("payload path %s is invalid in %s", path, body)
+				}
+				value = current[index]
+			default:
+				t.Fatalf("payload path %s is invalid in %s", path, body)
+			}
+		}
+		if value != want {
+			t.Fatalf("payload %s = %v, want %q: %s", path, value, want, body)
+		}
 	}
 }
 
@@ -454,6 +565,39 @@ func TestWebhookEventsOptInDeliversAllThreeKinds(t *testing.T) {
 	for _, want := range []string{"message", "receipt", "chat_presence"} {
 		if !seen[want] {
 			t.Fatalf("missing %s event, saw %v", want, seen)
+		}
+	}
+}
+
+func TestWebhookEventsNormalizeResolvableLIDsBeforeDelivery(t *testing.T) {
+	lid := types.JID{User: "999123456789", Server: types.HiddenUserServer}
+	pn := types.JID{User: "15551234567", Server: types.DefaultUserServer}
+	rec := emitWebhookEvents(t, "message,receipt,chat_presence", func(f *fakeWA) {
+		f.lids[lid] = pn
+
+		message := testLiveMessageEvent()
+		message.Info.Chat = lid
+		message.Info.Sender = lid
+		f.emit(message)
+
+		receipt := testReceiptEvent()
+		receipt.Chat = lid
+		receipt.Sender = lid
+		f.emit(receipt)
+
+		presence := testChatPresenceEvent()
+		presence.Chat = lid
+		presence.Sender = lid
+		f.emit(presence)
+	})
+
+	for range 3 {
+		body := rec.next(t)
+		if bytes.Contains(body, []byte(types.HiddenUserServer)) {
+			t.Fatalf("webhook payload retained a raw LID: %s", body)
+		}
+		if !bytes.Contains(body, []byte(pn.String())) {
+			t.Fatalf("webhook payload missing resolved phone JID %q: %s", pn, body)
 		}
 	}
 }


### PR DESCRIPTION
Closes #352.

## What changed

- Normalize every webhook JID at the payload serialization boundary, using the same known-LID-to-phone-JID resolution as stored messages.
- Cover message, receipt, and chat-presence events, including quoted senders plus nested poll and call identities.
- Preserve unresolved LIDs unchanged.
- Document the webhook identity contract and compatibility impact.

Thanks @hchittanuru3 for tracing the mismatch after the #348 identity work and reporting the affected receipt and presence paths too.

## Proof

- Focused webhook tests pass, including a real local HTTP server receiving all three event kinds.
- Mapped LIDs arrive as phone JIDs; an unmapped LID remains unchanged.
- The full repository gate passes: docs site, formatting, vet, normal and FTS suites, Windows lock cross-compile, CGO guard, docs tests, build, and diff checks.
- Structured autoreview completed cleanly with no accepted or actionable findings.

No live WhatsApp account was connected or mutated for this change.
