### PR TITLE
build: move Go floor to 1.26.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: pnpm -s lint
 
       - name: Verify exact Go security floor
-        run: test "$(go env GOVERSION)" = "go1.26.5"
+        run: test "$(go env GOVERSION)" = "go1.26.6"
 
       - name: govulncheck source
         run: pnpm -s govulncheck:source

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build
+FROM golang:1.26.6-alpine@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df AS build
 RUN apk add --no-cache build-base ca-certificates git
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/wacli
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.49


### PR DESCRIPTION
Bumps go.mod and the CI version pin from 1.26.5 to 1.26.6, clearing the four reachable stdlib advisories (GO-2026-5026, GO-2026-5972, GO-2026-6090, GO-2026-6218) that currently fail govulncheck on main and block #353.