### PR TITLE
fix: fail closed on unsupported passkey auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Auth: stop with an actionable error when WhatsApp requires unsupported passkey pairing instead of silently rotating unusable QR codes. (#355 - thanks @Avg8888)
 - Sync: normalize resolvable LIDs in message, receipt, and chat-presence webhook payloads to match stored identities. (#352 - thanks @hchittanuru3)
 
 ## v0.17.0 - 2026-08-13

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -19,6 +19,7 @@ wacli --account work auth status
 - `--qr-format text` prints the raw QR payload for external renderers.
 - `--phone PHONE` uses WhatsApp phone-number pairing instead of QR pairing.
 - Transient websocket drops before pairing completes are retried with a fresh QR/code.
+- Passkey-gated pairing is not yet supported. If WhatsApp requests passkey verification or confirmation, auth stops with an actionable error instead of continuing to rotate unusable QR codes.
 - After pairing, auth runs bootstrap sync until idle unless `--follow` is set.
 - Bootstrap sync honors `WACLI_SYNC_MAX_MESSAGES` and `WACLI_SYNC_MAX_DB_SIZE` to cap local history growth.
 - `--events` emits NDJSON lifecycle events on stderr, including raw QR and phone-pairing codes for external renderers.

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -247,13 +247,17 @@ func qrChannelEventError(evt whatsmeow.QRChannelItem) error {
 		return fmt.Errorf("QR scanned, but multi-device is not enabled on the phone")
 	case evt == whatsmeow.QRChannelErrUnexpectedEvent:
 		return fmt.Errorf("unexpected QR pairing state; run `wacli auth` again")
+	case evt.Event == whatsmeow.QRChannelEventPasskeyRequest:
+		return fmt.Errorf("WhatsApp requires passkey verification, which wacli cannot safely complete yet; preserve any existing authenticated store and check for an updated wacli release")
+	case evt.Event == whatsmeow.QRChannelEventPasskeyResponse:
+		return fmt.Errorf("WhatsApp requires passkey confirmation, which wacli cannot safely complete yet; preserve any existing authenticated store and check for an updated wacli release")
 	case evt.Event == whatsmeow.QRChannelEventError:
 		if evt.Error != nil {
 			return fmt.Errorf("QR pairing failed: %w", evt.Error)
 		}
 		return fmt.Errorf("QR pairing failed")
 	default:
-		return nil
+		return fmt.Errorf("unsupported QR pairing state %q; update wacli and try again", evt.Event)
 	}
 }
 

--- a/internal/wa/client_test.go
+++ b/internal/wa/client_test.go
@@ -286,6 +286,9 @@ func TestQRChannelEventError(t *testing.T) {
 		{name: "multidevice disabled", evt: whatsmeow.QRChannelScannedWithoutMultidevice, want: "multi-device is not enabled"},
 		{name: "unexpected state", evt: whatsmeow.QRChannelErrUnexpectedEvent, want: "unexpected QR pairing state"},
 		{name: "pair error", evt: whatsmeow.QRChannelItem{Event: whatsmeow.QRChannelEventError, Error: errors.New("bad code")}, want: "bad code"},
+		{name: "passkey request", evt: whatsmeow.QRChannelItem{Event: whatsmeow.QRChannelEventPasskeyRequest}, want: "requires passkey verification"},
+		{name: "passkey confirmation", evt: whatsmeow.QRChannelItem{Event: whatsmeow.QRChannelEventPasskeyResponse}, want: "requires passkey confirmation"},
+		{name: "unknown event", evt: whatsmeow.QRChannelItem{Event: "future-pairing-step"}, want: "unsupported QR pairing state"},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Summary

- recognize whatsmeow passkey-request and passkey-confirmation QR-channel events
- stop immediately with an actionable unsupported-flow error instead of rotating unusable QR codes
- fail closed on future unknown QR pairing states, with regression coverage and auth documentation

# Security boundary

This intentionally does not attempt a WebAuthn ceremony. A complete passkey implementation needs an approved genuine web.whatsapp.com origin handoff and live validation with a passkey-gated account. The patch does not inspect, log, or persist passkey payloads.

This fixes the silent-ignore failure mode reported in #355, but does not close the issue because passkey-gated accounts still cannot complete new authentication.

# Verification

- `go test ./internal/wa -run TestQRChannelEventError -count=1`
- `pnpm docs:site && pnpm format:check && pnpm lint && pnpm test && pnpm build && git diff --check`
- built-binary read-only auth-status probe against a fresh isolated store: valid unauthenticated JSON and no files created
- source-aware autoreview: clean
- black-box validation: fresh-store and invalid-input clauses pass; live passkey clause blocked by unavailable passkey-gated WhatsApp fixture
